### PR TITLE
CODEOWNERS: Add initial usernames to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@yolossn @ashu8912 @illume @tejhan @sniok @skoeva @Tatsinnit


### PR DESCRIPTION
Later if needed we can add more specific CODEOWNERS for different folders if required.

This will be used for branch protection so reviews require a CODEOWNERS.

Fixes #74