### PR TITLE
github: Reduce excessive token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  checks: read
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
 
 jobs:
   label-issue:

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -10,8 +10,6 @@ on:
     # Daily
     - cron: '30 1 * * *'
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/update-headlamp-submodule.yml
+++ b/.github/workflows/update-headlamp-submodule.yml
@@ -11,13 +11,12 @@ on:
   # Allow manual trigger for testing
   workflow_dispatch:
 
-permissions:
-  contents: write  # Required to push commits
-
 jobs:
   update-submodule:
     name: Update submodule reference in main branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to push commits
 
     steps:
       - name: Checkout main repository with submodules


### PR DESCRIPTION
These changes reduce excessive token permissions in the workflows by either removing unnecessary permissions or reducing the scope from workflow-level to job-level.

Fixes: #72