### PR TITLE
plugins/aks-desktop: Extract DeployButton logic into hooks

### DIFF
--- a/plugins/aks-desktop/src/components/Deploy/hooks/useDeployUrlParams.test.ts
+++ b/plugins/aks-desktop/src/components/Deploy/hooks/useDeployUrlParams.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeployUrlParams } from './useDeployUrlParams';
+
+const mockReplace = vi.fn();
+
+let mockLocation = {
+  pathname: '/project/123',
+  search: '',
+};
+
+vi.mock('react-router-dom', () => ({
+  useHistory: () => ({ replace: mockReplace }),
+  useLocation: () => mockLocation,
+}));
+
+describe('useDeployUrlParams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation = { pathname: '/project/123', search: '' };
+  });
+
+  it.each([
+    { search: '', expectedOpen: false, expectedAppName: undefined },
+    { search: '?openDeploy=false', expectedOpen: false, expectedAppName: undefined },
+    { search: '?openDeploy=true', expectedOpen: true, expectedAppName: undefined },
+    {
+      search: '?openDeploy=true&applicationName=my-app',
+      expectedOpen: true,
+      expectedAppName: 'my-app',
+    },
+  ])(
+    'should parse URL "$search" -> shouldOpenDialog=$expectedOpen, appName=$expectedAppName',
+    async ({ search, expectedOpen, expectedAppName }) => {
+      mockLocation.search = search;
+      const { result } = renderHook(() => useDeployUrlParams());
+
+      await waitFor(() => {
+        expect(result.current.shouldOpenDialog).toBe(expectedOpen);
+        expect(result.current.initialApplicationName).toBe(expectedAppName);
+      });
+    }
+  );
+
+  it.each([
+    { search: '?openDeploy=true', expectedPath: '/project/123' },
+    { search: '?openDeploy=true&applicationName=app', expectedPath: '/project/123' },
+    { search: '?openDeploy=true&foo=bar', expectedPath: '/project/123?foo=bar' },
+  ])('should clean URL "$search" -> "$expectedPath"', async ({ search, expectedPath }) => {
+    mockLocation.search = search;
+    renderHook(() => useDeployUrlParams());
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(expectedPath);
+    });
+  });
+
+  it('should clear state when clearUrlTrigger is called', async () => {
+    mockLocation.search = '?openDeploy=true&applicationName=app';
+    const { result } = renderHook(() => useDeployUrlParams());
+
+    await waitFor(() => {
+      expect(result.current.shouldOpenDialog).toBe(true);
+    });
+
+    // Simulate URL being cleaned (as history.replace would do)
+    mockLocation.search = '';
+
+    act(() => {
+      result.current.clearUrlTrigger();
+    });
+
+    expect(result.current.shouldOpenDialog).toBe(false);
+    expect(result.current.initialApplicationName).toBeUndefined();
+  });
+});

--- a/plugins/aks-desktop/src/components/Deploy/hooks/useDeployUrlParams.ts
+++ b/plugins/aks-desktop/src/components/Deploy/hooks/useDeployUrlParams.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+/**
+ * Return type for the {@link useDeployUrlParams} hook.
+ */
+interface UseDeployUrlParamsResult {
+  /** Whether the URL contains `openDeploy=true`, indicating the dialog should open. */
+  shouldOpenDialog: boolean;
+  /** The value of the `applicationName` query parameter, if present. */
+  initialApplicationName: string | undefined;
+  /** Resets the trigger state after the dialog has been opened. */
+  clearUrlTrigger: () => void;
+}
+
+/**
+ * Reads and manages URL query parameters for deep-linking into the deploy wizard.
+ *
+ * Monitors the URL for `openDeploy=true` and an optional `applicationName` parameter.
+ * When detected, sets state to trigger dialog opening and automatically removes the
+ * parameters from the URL to prevent re-triggering on navigation.
+ *
+ * @returns An object containing the trigger state and a function to clear it.
+ */
+export const useDeployUrlParams = (): UseDeployUrlParamsResult => {
+  const location = useLocation();
+  const history = useHistory();
+  const [shouldOpenDialog, setShouldOpenDialog] = useState(false);
+  const [initialApplicationName, setInitialApplicationName] = useState<string | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const openDeploy = searchParams.get('openDeploy');
+    const applicationName = searchParams.get('applicationName');
+
+    if (openDeploy === 'true') {
+      setShouldOpenDialog(true);
+      setInitialApplicationName(applicationName ?? undefined);
+
+      // Clean up URL parameters using React Router
+      searchParams.delete('openDeploy');
+      searchParams.delete('applicationName');
+      const newSearch = searchParams.toString();
+      const newPath = newSearch ? `${location.pathname}?${newSearch}` : location.pathname;
+      history.replace(newPath);
+    }
+  }, [location.search, location.pathname, history]);
+
+  const clearUrlTrigger = useCallback(() => {
+    setShouldOpenDialog(false);
+    setInitialApplicationName(undefined);
+  }, []);
+
+  return {
+    shouldOpenDialog,
+    initialApplicationName,
+    clearUrlTrigger,
+  };
+};

--- a/plugins/aks-desktop/src/components/Deploy/hooks/useDialogState.test.ts
+++ b/plugins/aks-desktop/src/components/Deploy/hooks/useDialogState.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useDialogState } from './useDialogState';
+
+describe('useDialogState', () => {
+  it.each([
+    { appName: undefined, expectedAppName: undefined },
+    { appName: 'my-app', expectedAppName: 'my-app' },
+  ])('should open dialog with appName=$appName', ({ appName, expectedAppName }) => {
+    const { result } = renderHook(() => useDialogState());
+
+    expect(result.current.open).toBe(false);
+
+    act(() => {
+      result.current.openDialog(appName);
+    });
+
+    expect(result.current.open).toBe(true);
+    expect(result.current.initialApplicationName).toBe(expectedAppName);
+  });
+
+  it('should close dialog and clear app name', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openDialog('test-app');
+    });
+
+    act(() => {
+      result.current.closeDialog();
+    });
+
+    expect(result.current.open).toBe(false);
+    expect(result.current.initialApplicationName).toBeUndefined();
+  });
+});

--- a/plugins/aks-desktop/src/components/Deploy/hooks/useDialogState.ts
+++ b/plugins/aks-desktop/src/components/Deploy/hooks/useDialogState.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Return type for the {@link useDialogState} hook.
+ */
+interface UseDialogStateResult {
+  /** Whether the dialog is currently open. */
+  open: boolean;
+  /** The application name to pre-populate in the wizard, if any. */
+  initialApplicationName: string | undefined;
+  /** Opens the dialog, optionally with a pre-populated application name. */
+  openDialog: (appName?: string) => void;
+  /** Closes the dialog and resets the initial application name. */
+  closeDialog: () => void;
+}
+
+/**
+ * Manages open/close state and initial application name for the deploy wizard dialog.
+ *
+ * @returns An object containing dialog state and control functions.
+ */
+export const useDialogState = (): UseDialogStateResult => {
+  const [open, setOpen] = useState(false);
+  const [initialApplicationName, setInitialApplicationName] = useState<string | undefined>(
+    undefined
+  );
+
+  const openDialog = useCallback((appName?: string) => {
+    setOpen(true);
+    setInitialApplicationName(appName);
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    setOpen(false);
+    setInitialApplicationName(undefined);
+  }, []);
+
+  return {
+    open,
+    initialApplicationName,
+    openDialog,
+    closeDialog,
+  };
+};


### PR DESCRIPTION
This change separates presentation from logic in DeployButton by using custom hooks.

Fixes: #96 