### PR TITLE
plugins/aks-desktop: Refactor ScalingCard and add tests

### DIFF
--- a/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.test.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.test.ts
@@ -1,0 +1,526 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearChartDataCaches, useChartData } from './useChartData';
+
+// Mock the external dependencies
+vi.mock('../../../utils/azure/az-cli', () => ({
+  getClusterResourceIdAndGroup: vi.fn(),
+}));
+
+vi.mock('../../MetricsTab/getPrometheusEndpoint', () => ({
+  getPrometheusEndpoint: vi.fn(),
+}));
+
+vi.mock('../../MetricsTab/queryPrometheus', () => ({
+  queryPrometheus: vi.fn(),
+}));
+
+import { getClusterResourceIdAndGroup } from '../../../utils/azure/az-cli';
+import { getPrometheusEndpoint } from '../../MetricsTab/getPrometheusEndpoint';
+import { queryPrometheus } from '../../MetricsTab/queryPrometheus';
+
+const mockGetClusterResourceIdAndGroup = vi.mocked(getClusterResourceIdAndGroup);
+const mockGetPrometheusEndpoint = vi.mocked(getPrometheusEndpoint);
+const mockQueryPrometheus = vi.mocked(queryPrometheus);
+
+describe('useChartData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearChartDataCaches();
+    mockGetClusterResourceIdAndGroup.mockResolvedValue({
+      resourceId:
+        '/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster',
+      resourceGroup: 'test-rg',
+    });
+    mockGetPrometheusEndpoint.mockResolvedValue('https://prometheus.test.azure.com');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('returns empty data and no loading when deployment is not selected', async () => {
+    const { result } = renderHook(() =>
+      useChartData('', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('returns empty data when namespace is missing', async () => {
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', '', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('returns empty data when subscription is missing', async () => {
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', undefined, 'test-rg')
+    );
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('fetches and merges Prometheus data correctly', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const mockReplicaResults = [
+      {
+        values: [
+          [now - 120, '3'],
+          [now - 60, '3'],
+          [now, '4'],
+        ],
+      },
+    ];
+    const mockCpuResults = [
+      {
+        values: [
+          [now - 120, '45.5'],
+          [now - 60, '52.3'],
+          [now, '67.8'],
+        ],
+      },
+    ];
+
+    mockQueryPrometheus
+      .mockResolvedValueOnce(mockReplicaResults)
+      .mockResolvedValueOnce(mockCpuResults);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    // Initially loading
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(3);
+    expect(result.current.error).toBeNull();
+
+    // Verify data structure
+    result.current.chartData.forEach(point => {
+      expect(point).toHaveProperty('time');
+      expect(point).toHaveProperty('Replicas');
+      expect(point).toHaveProperty('CPU');
+      expect(typeof point.Replicas).toBe('number');
+      expect(typeof point.CPU).toBe('number');
+    });
+
+    // Verify the last point has correct values
+    const lastPoint = result.current.chartData[2];
+    expect(lastPoint.Replicas).toBe(4);
+    expect(lastPoint.CPU).toBe(68); // Rounded from 67.8
+  });
+
+  test('handles Prometheus query error gracefully', async () => {
+    mockGetPrometheusEndpoint.mockRejectedValue(new Error('Failed to get Prometheus endpoint'));
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.error).toBe('Failed to get Prometheus endpoint');
+  });
+
+  test('handles missing resource group by fetching it', async () => {
+    mockQueryPrometheus.mockResolvedValue([{ values: [] }]);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', undefined)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetClusterResourceIdAndGroup).toHaveBeenCalledWith('test-cluster', 'test-sub');
+    expect(mockGetPrometheusEndpoint).toHaveBeenCalledWith('test-rg', 'test-cluster', 'test-sub');
+  });
+
+  test('handles empty Prometheus results', async () => {
+    mockQueryPrometheus.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('refetches data when deployment changes', async () => {
+    mockQueryPrometheus.mockResolvedValue([{ values: [] }]);
+
+    const { result, rerender } = renderHook(
+      ({ deployment }) =>
+        useChartData(deployment, 'test-namespace', 'test-cluster', 'test-sub', 'test-rg'),
+      { initialProps: { deployment: 'deployment-1' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockQueryPrometheus).toHaveBeenCalledTimes(2); // replica + cpu queries
+
+    // Change deployment
+    rerender({ deployment: 'deployment-2' });
+
+    await waitFor(() => {
+      expect(mockQueryPrometheus).toHaveBeenCalledTimes(4); // 2 more queries
+    });
+  });
+
+  test('returns empty data when cluster is missing', async () => {
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', '', 'test-sub', 'test-rg')
+    );
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('handles non-Error thrown exceptions', async () => {
+    mockGetPrometheusEndpoint.mockRejectedValue('string error');
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(0);
+    expect(result.current.error).toBe('Failed to fetch chart data');
+  });
+
+  test('handles null result from getClusterResourceIdAndGroup', async () => {
+    mockGetClusterResourceIdAndGroup.mockResolvedValue(null as any);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', undefined)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Could not find resource group for cluster');
+  });
+
+  test('handles CPU data without matching replica timestamps', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const mockReplicaResults = [
+      {
+        values: [
+          [now - 60, '3'],
+          [now, '4'],
+        ],
+      },
+    ];
+    // CPU data has different timestamps
+    const mockCpuResults = [
+      {
+        values: [
+          [now - 120, '50'],
+          [now - 30, '60'],
+        ],
+      },
+    ];
+
+    mockQueryPrometheus
+      .mockResolvedValueOnce(mockReplicaResults)
+      .mockResolvedValueOnce(mockCpuResults);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Should have 2 data points (from replica data)
+    expect(result.current.chartData).toHaveLength(2);
+    // CPU should be 0 for non-matching timestamps
+    expect(result.current.chartData[0].CPU).toBe(0);
+    expect(result.current.chartData[1].CPU).toBe(0);
+  });
+
+  test('sanitizes non-finite Prometheus values to 0', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const mockReplicaResults = [
+      {
+        values: [[now, 'NaN']],
+      },
+    ];
+    const mockCpuResults = [
+      {
+        values: [[now, '+Inf']],
+      },
+    ];
+
+    mockQueryPrometheus
+      .mockResolvedValueOnce(mockReplicaResults)
+      .mockResolvedValueOnce(mockCpuResults);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(1);
+    expect(result.current.chartData[0].Replicas).toBe(0);
+    expect(result.current.chartData[0].CPU).toBe(0);
+  });
+
+  test('uses resourceGroupLabel when provided', async () => {
+    mockQueryPrometheus.mockResolvedValue([{ values: [] }]);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'provided-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Should NOT call getClusterResourceIdAndGroup when resourceGroupLabel is provided
+    expect(mockGetClusterResourceIdAndGroup).not.toHaveBeenCalled();
+    // Should use the provided resource group
+    expect(mockGetPrometheusEndpoint).toHaveBeenCalledWith(
+      'provided-rg',
+      'test-cluster',
+      'test-sub'
+    );
+  });
+
+  test('passes correct query parameters to queryPrometheus', async () => {
+    mockQueryPrometheus.mockResolvedValue([{ values: [] }]);
+
+    renderHook(() => useChartData('my-app', 'my-namespace', 'my-cluster', 'my-sub', 'my-rg'));
+
+    await waitFor(() => {
+      expect(mockQueryPrometheus).toHaveBeenCalled();
+    });
+
+    // Check replica query
+    expect(mockQueryPrometheus).toHaveBeenCalledWith(
+      'https://prometheus.test.azure.com',
+      expect.stringContaining(
+        'kube_deployment_spec_replicas{deployment="my-app",namespace="my-namespace"}'
+      ),
+      expect.any(Number),
+      expect.any(Number),
+      7200,
+      'my-sub'
+    );
+
+    // Check CPU query
+    expect(mockQueryPrometheus).toHaveBeenCalledWith(
+      'https://prometheus.test.azure.com',
+      expect.stringContaining('my-namespace'),
+      expect.any(Number),
+      expect.any(Number),
+      7200,
+      'my-sub'
+    );
+  });
+
+  test('returns cached data without re-fetching within TTL', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const mockResults = [{ values: [[now, '2']] }];
+    mockQueryPrometheus
+      .mockResolvedValueOnce(mockResults) // replica
+      .mockResolvedValueOnce([{ values: [[now, '30']] }]); // cpu
+
+    const { result, unmount } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(1);
+    expect(mockQueryPrometheus).toHaveBeenCalledTimes(2);
+
+    // Unmount and re-mount — should use cached data, no new queries
+    unmount();
+
+    const { result: result2 } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result2.current.chartData).toHaveLength(1);
+    });
+
+    // Still only 2 calls — cache was used
+    expect(mockQueryPrometheus).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not reuse cached chart data across different resource groups', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockQueryPrometheus
+      .mockResolvedValueOnce([{ values: [[now, '2']] }]) // rg-a replica
+      .mockResolvedValueOnce([{ values: [[now, '30']] }]) // rg-a cpu
+      .mockResolvedValueOnce([{ values: [[now, '5']] }]) // rg-b replica
+      .mockResolvedValueOnce([{ values: [[now, '60']] }]); // rg-b cpu
+
+    const { result, unmount } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'rg-a')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chartData).toHaveLength(1);
+    expect(result.current.chartData[0].Replicas).toBe(2);
+    expect(result.current.chartData[0].CPU).toBe(30);
+    expect(mockQueryPrometheus).toHaveBeenCalledTimes(2);
+
+    unmount();
+
+    const { result: result2 } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'rg-b')
+    );
+
+    await waitFor(() => {
+      expect(result2.current.loading).toBe(false);
+    });
+
+    expect(result2.current.chartData).toHaveLength(1);
+    expect(result2.current.chartData[0].Replicas).toBe(5);
+    expect(result2.current.chartData[0].CPU).toBe(60);
+    expect(mockQueryPrometheus).toHaveBeenCalledTimes(4);
+  });
+
+  test('caches Prometheus endpoint and reuses it across deployments', async () => {
+    mockQueryPrometheus.mockResolvedValue([{ values: [] }]);
+
+    const { result, rerender } = renderHook(
+      ({ deployment }) =>
+        useChartData(deployment, 'test-namespace', 'test-cluster', 'test-sub', 'test-rg'),
+      { initialProps: { deployment: 'deploy-a' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetPrometheusEndpoint).toHaveBeenCalledTimes(1);
+
+    // Switch deployment — same cluster, endpoint should be cached
+    rerender({ deployment: 'deploy-b' });
+
+    await waitFor(() => {
+      expect(mockQueryPrometheus).toHaveBeenCalledTimes(4); // 2 per deployment
+    });
+
+    // Endpoint was only fetched once
+    expect(mockGetPrometheusEndpoint).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes day name in time labels', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const mockResults = [{ values: [[now, '3']] }];
+    mockQueryPrometheus
+      .mockResolvedValueOnce(mockResults)
+      .mockResolvedValueOnce([{ values: [[now, '50']] }]);
+
+    const { result } = renderHook(() =>
+      useChartData('test-deployment', 'test-namespace', 'test-cluster', 'test-sub', 'test-rg')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Time label should include a date/day part, a comma, and a time segment (e.g., "Wed, 14:00" or "Mi., 02:00 PM")
+    const timeLabel = result.current.chartData[0].time;
+    expect(timeLabel).toContain(', ');
+    expect(timeLabel).toMatch(/\d{2}:\d{2}/);
+  });
+
+  test('ignores stale in-flight responses after deployment changes', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    let resolveOldReplica: ((value: any[]) => void) | undefined;
+    let resolveOldCpu: ((value: any[]) => void) | undefined;
+
+    const oldReplicaPromise = new Promise<any[]>(resolve => {
+      resolveOldReplica = resolve;
+    });
+    const oldCpuPromise = new Promise<any[]>(resolve => {
+      resolveOldCpu = resolve;
+    });
+
+    mockQueryPrometheus.mockImplementation((_endpoint, query) => {
+      if (query.includes('deployment="deployment-1"')) {
+        return oldReplicaPromise;
+      }
+      if (query.includes('pod=~"deployment-1-.*"')) {
+        return oldCpuPromise;
+      }
+      if (query.includes('deployment="deployment-2"')) {
+        return Promise.resolve([{ values: [[now, '7']] }]);
+      }
+      if (query.includes('pod=~"deployment-2-.*"')) {
+        return Promise.resolve([{ values: [[now, '80']] }]);
+      }
+      return Promise.resolve([{ values: [] }]);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ deployment }) =>
+        useChartData(deployment, 'test-namespace', 'test-cluster', 'test-sub', 'test-rg'),
+      { initialProps: { deployment: 'deployment-1' } }
+    );
+
+    rerender({ deployment: 'deployment-2' });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.chartData).toHaveLength(1);
+      expect(result.current.chartData[0].Replicas).toBe(7);
+      expect(result.current.chartData[0].CPU).toBe(80);
+    });
+
+    await act(async () => {
+      resolveOldReplica?.([{ values: [[now, '1']] }]);
+      resolveOldCpu?.([{ values: [[now, '10']] }]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.chartData).toHaveLength(1);
+      expect(result.current.chartData[0].Replicas).toBe(7);
+      expect(result.current.chartData[0].CPU).toBe(80);
+    });
+  });
+});

--- a/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.ts
@@ -1,95 +1,205 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { useMemo } from 'react';
-import type { DeploymentInfo } from './useDeployments';
-import type { HPAInfo } from './useHPAInfo';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getClusterResourceIdAndGroup } from '../../../utils/azure/az-cli';
+import { getPrometheusEndpoint } from '../../MetricsTab/getPrometheusEndpoint';
+import { queryPrometheus } from '../../MetricsTab/queryPrometheus';
 
+/**
+ * A single data point for the scaling chart.
+ */
 export interface ChartDataPoint {
+  /** Formatted time string including day name (e.g., "Wed, 14:00"). */
   time: string;
+  /** Number of replicas at this time. */
   Replicas: number;
+  /** CPU utilization percentage at this time. */
   CPU: number;
 }
 
 /**
- * Custom hook to generate chart data for scaling metrics visualization
- * Generates historical data based on current deployment and HPA information
+ * Result of the useChartData hook including loading and error states.
+ */
+export interface UseChartDataResult {
+  /** Array of chart data points in chronological order. */
+  chartData: ChartDataPoint[];
+  /** Whether the chart data is currently loading. */
+  loading: boolean;
+  /** Error message if data fetching failed, null otherwise. */
+  error: string | null;
+}
+
+// Module-level caches persist across component remounts to avoid refetching
+// the same chart data and endpoint repeatedly in the same session.
+let chartDataCache: { key: string; data: ChartDataPoint[]; timestamp: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// Cache for Prometheus endpoint (keyed by resourceGroup:cluster:subscription)
+const promEndpointCache = new Map<string, string>();
+
+/** Clears all module-level caches. Exported for testing only. */
+export function clearChartDataCaches(): void {
+  chartDataCache = null;
+  promEndpointCache.clear();
+}
+
+function getCachedChartData(cacheKey: string): ChartDataPoint[] | null {
+  if (!chartDataCache || chartDataCache.key !== cacheKey) {
+    return null;
+  }
+
+  return Date.now() - chartDataCache.timestamp < CACHE_TTL_MS ? chartDataCache.data : null;
+}
+
+/**
+ * Fetches real chart data from Prometheus for scaling metrics visualization.
+ *
+ * Queries Prometheus for replica count and CPU usage history over the last 24 hours.
+ *
+ * @param selectedDeployment - Name of the currently selected deployment.
+ * @param namespace - The Kubernetes namespace.
+ * @param cluster - The cluster name.
+ * @param subscription - The Azure subscription ID.
+ * @param resourceGroupLabel - The resource group from namespace labels (optional).
+ * @returns Object containing chartData array, loading state, and error state.
  */
 export const useChartData = (
   selectedDeployment: string,
-  deployments: DeploymentInfo[],
-  hpaInfo: HPAInfo | null
-): ChartDataPoint[] => {
-  return useMemo(() => {
-    const data: ChartDataPoint[] = [];
-    const now = new Date();
+  namespace: string,
+  cluster: string,
+  subscription: string | undefined,
+  resourceGroupLabel: string | undefined
+): UseChartDataResult => {
+  const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const latestRequestIdRef = useRef(0);
 
-    // Get current deployment info
-    const currentDeployment = deployments.find(d => d.name === selectedDeployment);
+  const fetchChartData = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current;
+    const isLatestRequest = () => latestRequestIdRef.current === requestId;
+    const applyIfLatest = (callback: () => void) => {
+      if (isLatestRequest()) {
+        callback();
+      }
+    };
 
-    // Use actual data - no fake fallbacks
-    const currentReplicas = hpaInfo?.currentReplicas ?? currentDeployment?.readyReplicas ?? 0;
-    const currentCPU = hpaInfo?.currentCPUUtilization || 0; // Keep 0 if no real data
+    if (!namespace || !selectedDeployment || !cluster || !subscription) {
+      applyIfLatest(() => {
+        setChartData([]);
+        setError(null);
+        setLoading(false);
+      });
+      return;
+    }
 
-    // Generate data for the last 24 hours (every 2 hours to avoid crowding)
-    for (let i = 23; i >= 0; i -= 2) {
-      const time = new Date(now.getTime() - i * 60 * 60 * 1000);
-      const timeString = `${time.getHours().toString().padStart(2, '0')}:00`;
+    try {
+      applyIfLatest(() => {
+        setLoading(true);
+        setError(null);
+      });
 
-      let replicas = currentReplicas;
-      let cpu = currentCPU;
+      // Extract resource group from label if available, otherwise fetch
+      let resourceGroup = resourceGroupLabel;
 
-      if (i === 0) {
-        // Current time - use actual values only
-        replicas = currentReplicas;
-        cpu = currentCPU;
-      } else {
-        // Historical data - only simulate if we have real current data
-        if (currentCPU > 0) {
-          // We have real CPU data, simulate historical variation
-          const timeVariation = Math.sin((i / 24) * Math.PI * 2) * 0.3;
-          const randomVariation = (Math.random() - 0.5) * 0.2;
-          const totalVariation = timeVariation + randomVariation;
+      if (!resourceGroup) {
+        const result = await getClusterResourceIdAndGroup(cluster, subscription);
+        resourceGroup = result?.resourceGroup;
 
-          cpu = Math.max(5, Math.min(95, Math.round(currentCPU * (1 + totalVariation))));
-
-          // Simulate scaling based on CPU if HPA exists
-          if (hpaInfo && hpaInfo.minReplicas !== undefined && hpaInfo.maxReplicas !== undefined) {
-            const targetCPU = hpaInfo.targetCPUUtilization || 50;
-            if (cpu > targetCPU * 1.2) {
-              replicas = Math.min(
-                hpaInfo.maxReplicas,
-                currentReplicas + Math.floor(Math.random() * 2)
-              );
-            } else if (cpu < targetCPU * 0.7) {
-              replicas = Math.max(
-                hpaInfo.minReplicas,
-                currentReplicas - Math.floor(Math.random() * 2)
-              );
-            } else {
-              replicas = Math.max(
-                hpaInfo.minReplicas,
-                Math.min(
-                  hpaInfo.maxReplicas,
-                  currentReplicas + Math.floor((Math.random() - 0.5) * 2)
-                )
-              );
-            }
-          }
-        } else {
-          // No real CPU data - keep CPU at 0 and replicas stable
-          cpu = 0;
-          replicas = currentReplicas;
+        if (!resourceGroup) {
+          throw new Error('Could not find resource group for cluster');
         }
       }
 
-      data.push({
-        time: timeString,
-        Replicas: replicas,
-        CPU: cpu,
-      });
-    }
+      // Return cached data if the same parameters were queried recently.
+      // Include resolved resource group to avoid cross-resource-group cache collisions.
+      const cacheKey = `${selectedDeployment}:${namespace}:${cluster}:${subscription}:${resourceGroup}`;
+      const cachedChartData = getCachedChartData(cacheKey);
+      if (cachedChartData) {
+        applyIfLatest(() => {
+          setChartData(cachedChartData);
+          setError(null);
+        });
+        return;
+      }
 
-    return data.reverse(); // Reverse to get chronological order
-  }, [selectedDeployment, deployments, hpaInfo]);
+      const endpointKey = `${resourceGroup}:${cluster}:${subscription}`;
+      let promEndpoint = promEndpointCache.get(endpointKey);
+      if (!promEndpoint) {
+        promEndpoint = await getPrometheusEndpoint(resourceGroup, cluster, subscription);
+        promEndpointCache.set(endpointKey, promEndpoint);
+      }
+
+      const end = Math.floor(Date.now() / 1000);
+      const start = end - 86400; // Last 24 hours
+      const step = 7200; // Data point every 2 hours
+
+      // Query replica count and CPU usage in parallel
+      const replicaQuery = `kube_deployment_spec_replicas{deployment="${selectedDeployment}",namespace="${namespace}"}`;
+      const cpuQuery = `100 * (sum by (namespace) (rate(container_cpu_usage_seconds_total{namespace="${namespace}", pod=~"${selectedDeployment}-.*", container!=""}[5m])) / sum by (namespace) (kube_pod_container_resource_limits{namespace="${namespace}", pod=~"${selectedDeployment}-.*", resource="cpu"}))`;
+
+      const [replicaResults, cpuResults] = await Promise.all([
+        queryPrometheus(promEndpoint, replicaQuery, start, end, step, subscription),
+        queryPrometheus(promEndpoint, cpuQuery, start, end, step, subscription),
+      ]);
+
+      // Merge replica and CPU data by timestamp
+      const mergedData: ChartDataPoint[] = [];
+      const replicaValues = replicaResults[0]?.values || [];
+      const cpuValues = cpuResults[0]?.values || [];
+      const dayFormatter = new Intl.DateTimeFormat([], { weekday: 'short' });
+      const timeFormatter = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' });
+
+      // Create a map of timestamps to CPU values for easier lookup
+      const cpuMap = new Map<number, number>();
+      cpuValues.forEach(([timestamp, value]: [number, string]) => {
+        const parsedCpu = parseFloat(value);
+        cpuMap.set(timestamp, Number.isFinite(parsedCpu) ? parsedCpu : 0);
+      });
+
+      // Iterate through replica values and match with CPU
+      replicaValues.forEach(([timestamp, replicaValue]: [number, string]) => {
+        const date = new Date(timestamp * 1000);
+        const day = dayFormatter.format(date);
+        const time = timeFormatter.format(date);
+        const timeString = `${day}, ${time}`;
+
+        const parsedReplicas = parseInt(replicaValue, 10);
+        const replicas = Number.isFinite(parsedReplicas) ? parsedReplicas : 0;
+        const cpu = cpuMap.get(timestamp) || 0;
+
+        mergedData.push({
+          time: timeString,
+          Replicas: replicas,
+          CPU: Math.round(cpu),
+        });
+      });
+
+      chartDataCache = { key: cacheKey, data: mergedData, timestamp: Date.now() };
+      applyIfLatest(() => setChartData(mergedData));
+    } catch (err) {
+      console.error('Failed to fetch chart data from Prometheus:', err);
+      applyIfLatest(() => {
+        const nextError = err instanceof Error ? err.message : 'Failed to fetch chart data';
+        setError(nextError);
+        setChartData([]);
+      });
+    } finally {
+      applyIfLatest(() => setLoading(false));
+    }
+  }, [namespace, selectedDeployment, cluster, subscription, resourceGroupLabel]);
+
+  useEffect(() => {
+    fetchChartData();
+  }, [fetchChartData]);
+
+  useEffect(() => {
+    return () => {
+      // Invalidate any in-flight async work for this hook instance.
+      latestRequestIdRef.current += 1;
+    };
+  }, []);
+
+  return { chartData, loading, error };
 };

--- a/plugins/aks-desktop/src/components/Scaling/hooks/useDeployments.test.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useDeployments.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the Headlamp K8s API — vi.hoisted ensures the variable is available when vi.mock is hoisted
+const mockApiList = vi.hoisted(() => vi.fn());
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    ResourceClasses: {
+      Deployment: {
+        apiList: mockApiList,
+      },
+    },
+  },
+}));
+
+import { useDeployments } from './useDeployments';
+
+/** Helper to create a mock Headlamp deployment object. */
+function createMockDeployment(
+  name: string,
+  namespace: string,
+  replicas = 3,
+  availableReplicas = 3,
+  readyReplicas = 3
+) {
+  return {
+    getName: () => name,
+    getNamespace: () => namespace,
+    spec: { replicas },
+    status: { availableReplicas, readyReplicas },
+  };
+}
+
+describe('useDeployments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb([]);
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('returns empty state when namespace is undefined', () => {
+    const { result } = renderHook(() => useDeployments(undefined, 'test-cluster'));
+
+    expect(result.current.deployments).toHaveLength(0);
+    expect(result.current.selectedDeployment).toBe('');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockApiList).not.toHaveBeenCalled();
+  });
+
+  test('fetches, maps, and auto-selects deployments correctly', () => {
+    const mockDeployments = [
+      createMockDeployment('app-1', 'test-namespace', 3, 3, 3),
+      createMockDeployment('app-2', 'test-namespace', 5, 4, 4),
+    ];
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb(mockDeployments);
+      };
+    });
+
+    const { result } = renderHook(() => useDeployments('test-namespace', 'test-cluster'));
+
+    expect(result.current.deployments).toHaveLength(2);
+    expect(result.current.deployments[0]).toEqual({
+      name: 'app-1',
+      namespace: 'test-namespace',
+      replicas: 3,
+      availableReplicas: 3,
+      readyReplicas: 3,
+    });
+    expect(result.current.deployments[1]).toEqual({
+      name: 'app-2',
+      namespace: 'test-namespace',
+      replicas: 5,
+      availableReplicas: 4,
+      readyReplicas: 4,
+    });
+    expect(result.current.selectedDeployment).toBe('app-1');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockApiList).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), {
+      namespace: 'test-namespace',
+      cluster: 'test-cluster',
+    });
+  });
+
+  test('filters deployments by namespace', () => {
+    const mockDeployments = [
+      createMockDeployment('app-in-ns', 'test-namespace'),
+      createMockDeployment('app-other-ns', 'other-namespace'),
+    ];
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb(mockDeployments);
+      };
+    });
+
+    const { result } = renderHook(() => useDeployments('test-namespace', 'test-cluster'));
+
+    expect(result.current.deployments).toHaveLength(1);
+    expect(result.current.deployments[0].name).toBe('app-in-ns');
+  });
+
+  test('handles error callback gracefully', () => {
+    mockApiList.mockImplementation((_successCb: Function, errorCb: Function) => {
+      return () => {
+        errorCb(new Error('API connection failed'));
+      };
+    });
+
+    const { result } = renderHook(() => useDeployments('test-namespace', 'test-cluster'));
+
+    expect(result.current.deployments).toHaveLength(0);
+    expect(result.current.error).toBe('Failed to fetch deployments');
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('handles deployments with missing status fields', () => {
+    const mockDeployments = [
+      {
+        getName: () => 'partial-deploy',
+        getNamespace: () => 'test-namespace',
+        spec: { replicas: 2 },
+        status: {},
+      },
+    ];
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb(mockDeployments);
+      };
+    });
+
+    const { result } = renderHook(() => useDeployments('test-namespace', 'test-cluster'));
+
+    expect(result.current.deployments[0]).toEqual({
+      name: 'partial-deploy',
+      namespace: 'test-namespace',
+      replicas: 2,
+      availableReplicas: 0,
+      readyReplicas: 0,
+    });
+  });
+});

--- a/plugins/aks-desktop/src/components/Scaling/hooks/useHPAInfo.test.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useHPAInfo.test.ts
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the Headlamp K8s API — vi.hoisted ensures the variable is available when vi.mock is hoisted
+const mockApiList = vi.hoisted(() => vi.fn());
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    ResourceClasses: {
+      HorizontalPodAutoscaler: {
+        apiList: mockApiList,
+      },
+    },
+  },
+}));
+
+import { useHPAInfo } from './useHPAInfo';
+
+/** Helper to create a mock Headlamp HPA object. */
+function createMockHPA(
+  name: string,
+  namespace: string,
+  targetDeployment: string,
+  options: {
+    minReplicas?: number;
+    maxReplicas?: number;
+    targetCPU?: number;
+    currentCPU?: number;
+    currentReplicas?: number;
+    desiredReplicas?: number;
+  } = {}
+) {
+  const {
+    minReplicas = 2,
+    maxReplicas = 10,
+    targetCPU = 70,
+    currentCPU = 45,
+    currentReplicas = 3,
+    desiredReplicas = 3,
+  } = options;
+
+  return {
+    getName: () => name,
+    getNamespace: () => namespace,
+    spec: {
+      scaleTargetRef: { name: targetDeployment, kind: 'Deployment' },
+      minReplicas,
+      maxReplicas,
+    },
+    status: {
+      currentReplicas,
+      desiredReplicas,
+    },
+    jsonData: {
+      spec: {
+        metrics: [
+          {
+            type: 'Resource',
+            resource: {
+              name: 'cpu',
+              target: { type: 'Utilization', averageUtilization: targetCPU },
+            },
+          },
+        ],
+      },
+      status: {
+        currentMetrics: [
+          {
+            type: 'Resource',
+            resource: {
+              name: 'cpu',
+              current: { averageUtilization: currentCPU },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('useHPAInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb([]);
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('returns null and skips fetch when deployment or namespace is undefined', () => {
+    const { result: r1 } = renderHook(() =>
+      useHPAInfo(undefined, 'test-namespace', 'test-cluster')
+    );
+    expect(r1.current.hpaInfo).toBeNull();
+
+    const { result: r2 } = renderHook(() =>
+      useHPAInfo('test-deployment', undefined, 'test-cluster')
+    );
+    expect(r2.current.hpaInfo).toBeNull();
+
+    expect(mockApiList).not.toHaveBeenCalled();
+  });
+
+  test('finds correct HPA, parses CPU metrics, and passes options', () => {
+    const mockHPAs = [
+      createMockHPA('hpa-other', 'test-namespace', 'other-deployment'),
+      createMockHPA('hpa-target', 'test-namespace', 'my-deployment', {
+        minReplicas: 2,
+        maxReplicas: 8,
+        targetCPU: 75,
+        currentCPU: 50,
+        currentReplicas: 4,
+        desiredReplicas: 4,
+      }),
+    ];
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb(mockHPAs);
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useHPAInfo('my-deployment', 'test-namespace', 'test-cluster')
+    );
+
+    expect(result.current.hpaInfo).toEqual({
+      name: 'hpa-target',
+      namespace: 'test-namespace',
+      minReplicas: 2,
+      maxReplicas: 8,
+      targetCPUUtilization: 75,
+      currentCPUUtilization: 50,
+      currentReplicas: 4,
+      desiredReplicas: 4,
+    });
+    expect(mockApiList).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), {
+      namespace: 'test-namespace',
+      cluster: 'test-cluster',
+    });
+  });
+
+  test('returns null when no HPA matches deployment or namespace', () => {
+    const mockHPAs = [
+      createMockHPA('hpa-wrong-ns', 'other-namespace', 'my-deploy'),
+      createMockHPA('hpa-wrong-deploy', 'test-namespace', 'different-deploy'),
+    ];
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb(mockHPAs);
+      };
+    });
+
+    const { result } = renderHook(() => useHPAInfo('my-deploy', 'test-namespace', 'test-cluster'));
+
+    expect(result.current.hpaInfo).toBeNull();
+  });
+
+  test('handles HPA without CPU metrics in spec', () => {
+    const hpa = createMockHPA('hpa-no-cpu', 'test-namespace', 'my-deploy');
+    hpa.jsonData = {
+      spec: {
+        metrics: [
+          {
+            type: 'Resource',
+            resource: {
+              name: 'memory',
+              target: { type: 'Utilization', averageUtilization: 80 },
+            },
+          },
+        ],
+      },
+      status: {
+        currentMetrics: [],
+      },
+    };
+
+    mockApiList.mockImplementation((successCb: Function) => {
+      return () => {
+        successCb([hpa]);
+      };
+    });
+
+    const { result } = renderHook(() => useHPAInfo('my-deploy', 'test-namespace', 'test-cluster'));
+
+    expect(result.current.hpaInfo).not.toBeNull();
+    expect(result.current.hpaInfo?.targetCPUUtilization).toBeUndefined();
+    expect(result.current.hpaInfo?.currentCPUUtilization).toBeUndefined();
+  });
+
+  test('handles error callback gracefully', () => {
+    mockApiList.mockImplementation((_successCb: Function, errorCb: Function) => {
+      return () => {
+        errorCb(new Error('HPA fetch failed'));
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useHPAInfo('test-deployment', 'test-namespace', 'test-cluster')
+    );
+
+    expect(result.current.hpaInfo).toBeNull();
+  });
+});

--- a/plugins/aks-desktop/src/components/Scaling/hooks/useHPAInfo.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useHPAInfo.ts
@@ -4,23 +4,43 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { useEffect, useState } from 'react';
 
+/**
+ * Represents Horizontal Pod Autoscaler configuration and status.
+ */
 export interface HPAInfo {
+  /** Name of the HPA resource. */
   name: string;
+  /** Kubernetes namespace where the HPA is defined. */
   namespace: string;
+  /** Minimum number of replicas the HPA can scale down to. */
   minReplicas: number | undefined;
+  /** Maximum number of replicas the HPA can scale up to. */
   maxReplicas: number | undefined;
+  /** Target average CPU utilization percentage across pods. */
   targetCPUUtilization: number | undefined;
+  /** Current average CPU utilization percentage across pods. */
   currentCPUUtilization: number | undefined;
+  /** Current number of running replicas. */
   currentReplicas: number | undefined;
+  /** Desired number of replicas as determined by the HPA. */
   desiredReplicas: number | undefined;
 }
 
+/**
+ * Return type for the {@link useHPAInfo} hook.
+ */
 interface UseHPAInfoResult {
+  /** The HPA info for the deployment, or null if no HPA targets it. */
   hpaInfo: HPAInfo | null;
 }
 
 /**
- * Custom hook to fetch Horizontal Pod Autoscaler (HPA) information for a deployment
+ * Fetches HPA information for a given deployment.
+ *
+ * @param deploymentName - The name of the deployment to find an HPA for.
+ * @param namespace - The Kubernetes namespace to search in.
+ * @param cluster - The cluster identifier.
+ * @returns An object containing the HPA info, or null if none found.
  */
 export const useHPAInfo = (
   deploymentName: string | undefined,
@@ -29,63 +49,62 @@ export const useHPAInfo = (
 ): UseHPAInfoResult => {
   const [hpaInfo, setHpaInfo] = useState<HPAInfo | null>(null);
 
-  // @ts-ignore todo: fix this
   useEffect(() => {
-    if (!deploymentName || !namespace) return;
-
-    try {
-      // Find HPA that targets this deployment
-      const cancel = K8s.ResourceClasses.HorizontalPodAutoscaler.apiList(
-        hpaList => {
-          const hpa = hpaList.find(
-            hpa =>
-              hpa.getNamespace() === namespace && hpa.spec?.scaleTargetRef?.name === deploymentName
-          );
-          console.log('hpa is ', hpa);
-          if (hpa) {
-            // Parse HPA CPU metrics from spec.metrics[] and status.currentMetrics[] arrays
-            const hpaJson = (hpa as any).jsonData;
-            const targetMetric = hpaJson?.spec?.metrics?.find(
-              (m: any) => m.type === 'Resource' && m.resource?.name === 'cpu'
-            );
-            const targetCPU = targetMetric?.resource?.target?.averageUtilization;
-
-            const currentMetric = hpaJson?.status?.currentMetrics?.find(
-              (m: any) => m.type === 'Resource' && m.resource?.name === 'cpu'
-            );
-            const currentCPU = currentMetric?.resource?.current?.averageUtilization;
-            const hpaData: HPAInfo = {
-              name: hpa.getName(),
-              namespace: hpa.getNamespace(),
-              minReplicas: hpa.spec?.minReplicas,
-              maxReplicas: hpa.spec?.maxReplicas,
-              targetCPUUtilization: targetCPU,
-              currentCPUUtilization: currentCPU,
-              currentReplicas: hpa.status?.currentReplicas,
-              desiredReplicas: hpa.status?.desiredReplicas,
-            };
-            setHpaInfo(hpaData);
-          } else {
-            setHpaInfo(null);
-          }
-        },
-        (error: any) => {
-          console.error('Error fetching HPA info:', error);
-          setHpaInfo(null);
-        },
-        {
-          namespace,
-          cluster,
-        }
-      )();
-
-      // Return cleanup function
-      return cancel;
-    } catch (error) {
-      console.error('Error in fetchHPAInfo:', error);
-      setHpaInfo(null);
-      return undefined;
+    if (!deploymentName || !namespace) {
+      return;
     }
+
+    // Find HPA that targets this deployment
+    // @ts-expect-error Headlamp apiList returns a callable runner at runtime.
+    const runWatcher = K8s.ResourceClasses.HorizontalPodAutoscaler.apiList(
+      hpaList => {
+        const hpa = hpaList.find(
+          hpa =>
+            hpa.getNamespace() === namespace && hpa.spec?.scaleTargetRef?.name === deploymentName
+        );
+        if (hpa) {
+          // Parse HPA CPU metrics from spec.metrics[] and status.currentMetrics[] arrays
+          const hpaJson = (hpa as any).jsonData;
+          const targetMetric = hpaJson?.spec?.metrics?.find(
+            (m: any) => m.type === 'Resource' && m.resource?.name === 'cpu'
+          );
+          const targetCPU = targetMetric?.resource?.target?.averageUtilization;
+
+          const currentMetric = hpaJson?.status?.currentMetrics?.find(
+            (m: any) => m.type === 'Resource' && m.resource?.name === 'cpu'
+          );
+          const currentCPU = currentMetric?.resource?.current?.averageUtilization;
+          const hpaData: HPAInfo = {
+            name: hpa.getName(),
+            namespace: hpa.getNamespace(),
+            minReplicas: hpa.spec?.minReplicas,
+            maxReplicas: hpa.spec?.maxReplicas,
+            targetCPUUtilization: targetCPU,
+            currentCPUUtilization: currentCPU,
+            currentReplicas: hpa.status?.currentReplicas,
+            desiredReplicas: hpa.status?.desiredReplicas,
+          };
+          setHpaInfo(hpaData);
+        } else {
+          setHpaInfo(null);
+        }
+      },
+      (error: any) => {
+        console.error('Error fetching HPA info:', error);
+        setHpaInfo(null);
+      },
+      {
+        namespace,
+        cluster,
+      }
+    ) as () => void | (() => void);
+
+    const unsubscribe = runWatcher();
+    if (typeof unsubscribe === 'function') {
+      return unsubscribe;
+    }
+
+    return;
   }, [deploymentName, namespace, cluster]);
 
   return {


### PR DESCRIPTION
### Summary

- Replace simulated chart data with real Prometheus queries for replica count and CPU usage over the last 24 hours (2-hour intervals)
- Add module-level caching for chart data (5-min TTL) and Prometheus endpoint to avoid redundant fetches
- Parallelize Prometheus queries with `Promise.all` for faster loading
- Guard against stale async updates in `useChartData` so older in-flight requests cannot overwrite newer selection data
- Sanitize non-finite Prometheus sample values (`NaN`/`Inf`) before chart mapping
- Add watcher cleanup/unsubscribe handling in `useDeployments` and `useHPAInfo` to avoid leaked subscriptions
- Add loading spinner and error states to `ScalingChart`
- Add day name labels (e.g., `"Wed, 14:00"`) and angled tick renderer to improve chart readability
- Add TSDoc for interfaces, hooks, and components
- Add test suites for `useChartData`, `useDeployments`, and `useHPAInfo` hooks (30 tests, near 100% coverage)

Fixes: #136, #209 

### Testing
- [x] Run `cd plugins/aks-desktop && npm test` and ensure the tests pass

### Screenshot
<img width="643" height="692" alt="image" src="https://github.com/user-attachments/assets/fc23ca00-aa5d-4291-a28c-8d68e464298c" />