### PR TITLE
Update: Linux pipeline to use custom pool

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -26,7 +26,7 @@ extends:
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: staging-pool-amd64-mariner-2
-      image: azcu-1es-agent-amd64-mariner-2-img
+      image: 1es-azlinux-3-amd64-custom-disk
       os: linux
       hostArchitecture: amd64
     sdl:
@@ -58,6 +58,13 @@ extends:
                 retryCountOnTaskFailure: 3
                 inputs:
                   version: ${{ parameters.goVersion }}
+              # FIX: Install .NET SDK early (required for ESRP Code Signing)
+              # Changed from "runtime" to "sdk" and added version specification
+              - task: UseDotNet@2
+                displayName: Install .NET SDK (required for ESRP signing)
+                inputs:
+                  packageType: "sdk"
+                  version: "6.x" # Use 6.x or 8.x depending on ESRP requirement
               # TODO: Remove debug logging after pipeline is stable
               - bash: |
                   echo "=== GO INSTALLATION DEBUG ==="


### PR DESCRIPTION
## Description

This PR take care of the pool which is no longer valid and with the new custom pool there is a need to use the dot net task so that the `esrpcli.exe: not found error` can be avoided. 

This is preemptive change and helps in updating the pipeline. There is more required for moving forward, like:

* Moving the `1es` out to the `../workflow/.azure/.pipeline` or whatever preferred space folks want to.
* Secondly, there is a need to co-rdinate the move-around changes in the 1es pipeline as well.

Thanks

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Changes Made

- List the specific changes made are as follows:
    - Poolname change.
    - Consecutive botnet task required because there will be esop not found error with custom image.

