### PR TITLE
frontend: Fix register AKS cluster heading

### DIFF
--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
@@ -182,10 +182,12 @@ export default function RegisterAKSClusterDialog({
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>
+      <DialogTitle component="h1">
         <Box display="flex" alignItems="center" gap={1}>
           <Icon icon="logos:microsoft-azure" style={{ fontSize: '24px' }} />
-          <Typography variant="h6">Register AKS Cluster</Typography>
+          <Typography variant="h6" component="span">
+            Register AKS Cluster
+          </Typography>
         </Box>
       </DialogTitle>
 


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "Register AKS cluster" modal.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Code refactoring

## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/193
Related to https://github.com/Azure/aks-desktop/issues/219

## Changes Made

- Reformatted header component to have the HTML match the visual styling

## How to test:

- Click on your username on the side bar in AKS
- Continue beyond the login modal
- View the "Register AKS Cluster" modal
- Use inspect tools and open Lighthouse
- Scan at this view
- Notice full checklist is valid

## Images

<img width="1830" height="808" alt="image" src="https://github.com/user-attachments/assets/a6d5d517-c83a-475a-abfa-ec5f497507ff" />

