### PR TITLE
aksd: fix: Override productName for Linux builds

### DIFF
--- a/app/electron-builder.config.js
+++ b/app/electron-builder.config.js
@@ -64,6 +64,15 @@ if (config.deb) {
   };
 }
 
+// Override productName for Linux builds to avoid spaces in installation path
+if (
+  process.argv.includes('--linux') &&
+  !process.argv.includes('--win') &&
+  !process.argv.includes('--mac')
+) {
+  config.productName = 'AKS-Desktop';
+}
+
 // On non-Mac platforms, ensure dmg-license is truly optional by not including Mac targets during --dir builds
 // This prevents electron-builder from trying to validate Mac-specific dependencies on Linux/Windows
 if (process.env.npm_lifecycle_event === 'build' && process.platform !== 'darwin') {


### PR DESCRIPTION
## Description

Overrode productName for Linux builds to resolve error where builds couldn't be executed on some linux environments.


The `productName` "AKS desktop" caused electron-builder to install the app to `/opt/AKS desktop/`. In some environments,  Chromium's zygote process, which manages sandboxed child processes on Linux, did not properly handle spaces in the executable path — it splits `/opt/AKS desktop/aks-desktop` into `/opt/AKS` and `desktop/aks-desktop`, causing the launch to fail.

This issue does not appear to affect Windows or macOS, which use different process spawning mechanisms that handle the spaces correctly.

## Changes Made

Override `productName` to `AKS-Desktop` (hyphenated) in `electron-builder.config.js` when building exclusively for Linux. This
changes the install path to `/opt/AKS-Desktop/`, avoiding the space.

The override is guarded so it only applies when `--linux` is passed without `--win` or `--mac`, ensuring Windows and macOS builds retain the original "AKS desktop" branding.

## Related Issues

- https://github.com/Azure/aks-desktop/issues/29
Closes #[29]

## Testing

1. Built the deb package with and without the fix
2. Reproduced the original crash on a native Ubuntu 24.04 VM with multipass
3. Verified the fixed build installs to `/opt/AKS-Desktop/` and launched successfully