### PR TITLE
frontend: Fix a11y issue feature flag required heading

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -191,7 +191,9 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
           type="error"
           message={
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              <Typography variant="h6">Feature Flag Required</Typography>
+              <Typography variant="h6" component="div">
+                Feature Flag Required
+              </Typography>
               <Typography variant="body2">
                 The ManagedNamespacePreview feature must be registered to create managed namespaces.
               </Typography>


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "Feature Flag Required" section.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Related Issues 

Closes https://github.com/Azure/aks-desktop/issues/201
Related to #219 

## Changes Made

- Fixes Lighthouse scan flagged as the following:

"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."

How to test: 

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Click "AKS Managed Project" option
- Use inspect tools and open Lighthouse
- Scan at this view
