### PR TITLE
frontend: Fix a11y header for Configure Container Deployment

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
@@ -45,7 +45,7 @@ function LabelWithInfo({ label, infoText }: { label: string; infoText: string })
 export default function ConfigureContainer({ containerConfig }: ConfigureContainerProps) {
   return (
     <>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6" component="h2" gutterBottom>
         Configure Container Deployment
       </Typography>
       <Stepper activeStep={containerConfig.config.containerStep} orientation="vertical">


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "Configure Container Deployment" section.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/205
Related to #219 

## Changes Made

- Fixes Lighthouse scan flagged as the following:

"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."


How to test:

- Navigate to projects tab
- Navigate into a project
- Click the "Deploy application" button
- View the "Deploy application" modal
- Choose "Container Image"
- View the "Basics" section
- Use inspect tools and open Lighthouse
- Scan at this view