### PR TITLE
frontend: Fix header order for Project Basics

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
@@ -30,7 +30,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({ formData, subscriptions,
         {/* Basics Section */}
         <Grid item xs={12}>
           <Card variant="outlined" sx={{ p: 2, mb: 2 }}>
-            <Typography variant="h6" gutterBottom sx={sectionTitleSx}>
+            <Typography variant="h6" component="h3" gutterBottom sx={sectionTitleSx}>
               <Icon icon="mdi:project" style={{ marginRight: 8, verticalAlign: 'middle' }} />
               Project Basics
             </Typography>


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "Project Basics" section for the New Project workflow Review tab.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.
## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/203
Related to #219 

## Changes Made

- Fixes Lighthouse scan flagged as the following:
"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."

How to test:

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Click "AKS Managed Project" option
- Continue progress into "Review" tab (click on review)
- Use inspect tools and open Lighthouse
- Scan at this view
