### PR TITLE
refactor: extract runCommandAsync to shared module

### DIFF
--- a/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
@@ -35,7 +35,13 @@ export default function AzureProfilePage() {
     try {
       // Import dynamically to avoid circular dependencies
       const { runCommandAsync } = await import('../../utils/azure/az-cli');
-      await runCommandAsync('az', ['logout']);
+      const result = await runCommandAsync('az', ['logout']);
+
+      if (result.stderr && result.stderr.includes('ERROR:')) {
+        console.error('Azure CLI logout error:', result.stderr);
+        setLoggingOut(false);
+        return;
+      }
 
       // Trigger update event for sidebar label
       window.dispatchEvent(new CustomEvent('azure-auth-update'));

--- a/plugins/aks-desktop/src/utils/shared/runCommandAsync.test.ts
+++ b/plugins/aks-desktop/src/utils/shared/runCommandAsync.test.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Store event handlers registered by runCommandAsync so tests can trigger them.
+type EventCallback = (...args: any[]) => void;
+
+interface MockCmd {
+  stdout: { on: ReturnType<typeof vi.fn> };
+  stderr: { on: ReturnType<typeof vi.fn> };
+  on: ReturnType<typeof vi.fn>;
+}
+
+function createMockCmd(): { cmd: MockCmd; handlers: Record<string, EventCallback> } {
+  const handlers: Record<string, EventCallback> = {};
+
+  const cmd: MockCmd = {
+    stdout: {
+      on: vi.fn((event: string, cb: EventCallback) => {
+        handlers[`stdout:${event}`] = cb;
+      }),
+    },
+    stderr: {
+      on: vi.fn((event: string, cb: EventCallback) => {
+        handlers[`stderr:${event}`] = cb;
+      }),
+    },
+    on: vi.fn((event: string, cb: EventCallback) => {
+      handlers[event] = cb;
+    }),
+  };
+
+  return { cmd, handlers };
+}
+
+// We need to control the global `pluginRunCommand` that runCommandAsync.ts declares.
+// Since it reads the global at call-time (typeof check), we assign/delete on globalThis.
+const mockPluginRunCommand = vi.fn();
+
+beforeEach(() => {
+  (globalThis as any).pluginRunCommand = mockPluginRunCommand;
+});
+
+afterEach(() => {
+  delete (globalThis as any).pluginRunCommand;
+  vi.restoreAllMocks();
+});
+
+const { runCommandAsync } = await import('./runCommandAsync');
+
+describe('runCommandAsync', () => {
+  test('resolves with stdout and empty stderr on successful exit', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('echo', ['hello']);
+
+    // Simulate stdout data and successful exit.
+    handlers['stdout:data']('hello world');
+    handlers['exit'](0);
+
+    const result = await promise;
+    expect(result).toEqual({ stdout: 'hello world', stderr: '' });
+  });
+
+  test('resolves with stderr when command writes to stderr', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('az', ['login']);
+
+    handlers['stderr:data']('some warning');
+    handlers['exit'](0);
+
+    const result = await promise;
+    expect(result).toEqual({ stdout: '', stderr: 'some warning' });
+  });
+
+  test('populates stderr when exit code is non-zero and stderr is empty', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('false', []);
+
+    handlers['exit'](1);
+
+    const result = await promise;
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('Command exited with code 1');
+  });
+
+  test('preserves stderr when exit code is non-zero and stderr already has content', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('az', ['bad-command']);
+
+    handlers['stderr:data']('ERROR: bad-command is not a valid command');
+    handlers['exit'](2);
+
+    const result = await promise;
+    expect(result.stderr).toBe('ERROR: bad-command is not a valid command');
+  });
+
+  test('resolves with error message when error event fires', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('nonexistent', []);
+
+    handlers['error'](new Error('spawn nonexistent ENOENT'));
+
+    const result = await promise;
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'Command execution error: spawn nonexistent ENOENT',
+    });
+  });
+
+  test('resolves with error message when error event fires with a code number', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('cmd', []);
+
+    handlers['error'](127);
+
+    const result = await promise;
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'Command execution error: 127',
+    });
+  });
+
+  test('resolves with error when pluginRunCommand is not available', async () => {
+    delete (globalThis as any).pluginRunCommand;
+
+    const result = await runCommandAsync('az', ['version']);
+
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'pluginRunCommand is not available.',
+    });
+  });
+
+  test('resolves with error when pluginRunCommand throws synchronously', async () => {
+    mockPluginRunCommand.mockImplementation(() => {
+      throw new Error('bridge not ready');
+    });
+
+    const result = await runCommandAsync('az', ['version']);
+
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'Failed to execute command: bridge not ready',
+    });
+  });
+
+  test('resolves only once when both error and exit fire', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('bad', []);
+
+    // Node child_process can emit both 'error' and 'exit' for the same process.
+    handlers['error'](new Error('spawn bad ENOENT'));
+    handlers['exit'](1);
+
+    const result = await promise;
+    // The first event (error) wins.
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'Command execution error: spawn bad ENOENT',
+    });
+  });
+
+  test('concatenates multiple stdout chunks', async () => {
+    const { cmd, handlers } = createMockCmd();
+    mockPluginRunCommand.mockReturnValue(cmd);
+
+    const promise = runCommandAsync('az', ['account', 'list']);
+
+    handlers['stdout:data']('chunk1');
+    handlers['stdout:data']('chunk2');
+    handlers['exit'](0);
+
+    const result = await promise;
+    expect(result.stdout).toBe('chunk1chunk2');
+  });
+});

--- a/plugins/aks-desktop/src/utils/shared/runCommandAsync.ts
+++ b/plugins/aks-desktop/src/utils/shared/runCommandAsync.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// Declared with `string` for the command parameter because the runtime global
+// accepts any command, while the library type restricts it to a string-literal union.
+declare const pluginRunCommand: (
+  command: string,
+  args: string[],
+  options: Record<string, unknown>
+) => ReturnType<typeof import('@kinvolk/headlamp-plugin/lib').runCommand>;
+
+/**
+ * Executes a shell command via Headlamp's pluginRunCommand bridge.
+ *
+ * **Important**: This function always resolves — it never rejects.
+ * Errors are reported in the `stderr` field of the resolved value.
+ * Callers should check `stderr` to detect failures rather than
+ * wrapping calls in try/catch.
+ *
+ * @param command - The executable to run (e.g. the resolved `az` path).
+ * @param args - Command-line arguments.
+ * @returns Always resolves with `{ stdout, stderr }`. On failure, `stdout`
+ *          is empty and `stderr` contains the error description.
+ */
+export function runCommandAsync(
+  command: string,
+  args: string[]
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    try {
+      if (typeof pluginRunCommand === 'undefined') {
+        resolve({
+          stdout: '',
+          stderr: 'pluginRunCommand is not available.',
+        });
+        return;
+      }
+
+      const cmd = pluginRunCommand(command, args, {});
+
+      let stdout = '';
+      let stderr = '';
+      let resolved = false;
+
+      const done = (result: { stdout: string; stderr: string }) => {
+        if (!resolved) {
+          resolved = true;
+          resolve(result);
+        }
+      };
+
+      cmd.stdout.on('data', (data: string) => (stdout += data));
+      cmd.stderr.on('data', (data: string) => (stderr += data));
+
+      cmd.on('exit', (code: number) => {
+        if (code !== 0 && !stderr) {
+          stderr = `Command exited with code ${code}`;
+        }
+        done({ stdout, stderr });
+      });
+      // Headlamp types the error callback param as `number`, but Node's
+      // child_process emits an Error object. Use `unknown` to handle both.
+      cmd.on('error', (errOrCode: unknown) => {
+        const msg = errOrCode instanceof Error ? errOrCode.message : String(errOrCode);
+        done({ stdout: '', stderr: `Command execution error: ${msg}` });
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      resolve({ stdout: '', stderr: `Failed to execute command: ${message}` });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Extract `runCommandAsync()` into `utils/shared/run-command.ts` — a promise-based wrapper around Headlamp's `pluginRunCommand` bridge, so it can be reused by other integrations
- Simplify `az-cli.ts` to delegate to the shared module (no signature changes — callers are unaffected)
- Fix stderr handling when logging out of Azure CLI

## Test plan
- [x] `run-command` unit tests pass (9 tests)
- [x] TypeScript type check passes
- [x] ESLint + Prettier pass
