### PR TITLE
Project review step: Fix all project review headers

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
@@ -168,7 +168,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({ formData, subscriptions,
         {/* Access Section with Scroll */}
         <Grid item xs={12}>
           <Card variant="outlined" sx={{ p: 2, mb: 2 }}>
-            <Typography variant="h6" gutterBottom sx={sectionTitleSx}>
+            <Typography variant="h6" component="h3" gutterBottom sx={sectionTitleSx}>
               <Icon icon="mdi:account-group" style={{ marginRight: 8, verticalAlign: 'middle' }} />
               Access Control ({formData.userAssignments.length} assignee
               {formData.userAssignments.length !== 1 ? 's' : ''})


### PR DESCRIPTION
## Description

This PR fixes _**a collection**_ of a11y issues identified by Lighthouse where headings were not in sequential order for the  New Project workflow "Review" tab.

The title components are visually styled as an h6 header without following the current headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Related Issues

- Closes https://github.com/Azure/aks-desktop/issues/203
- Closes https://github.com/Azure/aks-desktop/issues/241
- Closes https://github.com/Azure/aks-desktop/issues/242
- Closes https://github.com/Azure/aks-desktop/issues/243

Related to #219 

## Changes Made

- Fixes Lighthouse scans flagged as the following:
"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."

How to test:

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Click "AKS Managed Project" option
- Continue progress into "Review" tab (click on review)
- Use inspect tools and open Lighthouse
- Scan at this view
- Notice perfect Accessibility Score 

## Images

<img width="1424" height="843" alt="image" src="https://github.com/user-attachments/assets/33a7451d-40b0-488e-9e61-ef0d74824d1b" />

<img width="944" height="409" alt="image" src="https://github.com/user-attachments/assets/defdc06d-2641-432e-8398-d3bcc1c7d07d" />
