### PR TITLE
frontend: DeployWizard: Fix Deploy Application YAML header

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.tsx
@@ -20,7 +20,7 @@ export default function ConfigureYAML({
 }: ConfigureYAMLProps) {
   return (
     <>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="h6" component="h2" gutterBottom>
         Kubernetes YAML
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "Kubernetes YAML" section.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/215
Related to #219 

## Changes Made

- Fixes Lighthouse scan flagged as the following:

"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."

How to test:

- Navigate to projects tab
- Navigate into a project
- Click the "Deploy application" button
- View the "Deploy application" modal
- Choose "Kubernetes YAML"
- View the "Configure" section
- Use inspect tools and open Lighthouse
- Scan at this view