### PR TITLE
frontend: Fix CPU resources & Memory Resources headers

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ResourceCard.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ResourceCard.tsx
@@ -14,7 +14,7 @@ export const ResourceCard: React.FC<ResourceCardProps> = ({ title, icon, iconCol
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
         <Icon icon={icon} width={24} height={24} color={iconColor} style={{ marginRight: 12 }} />
-        <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+        <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>
           {title}
         </Typography>
       </Box>


### PR DESCRIPTION
## Description

This PR fixes _**a collection**_ of a11y issues identified by Lighthouse where headings were not in sequential order for the  Create AKS Project workflow "Compute Quota" tab.

The ResourceCard component is used for sub categories "CPU Resources" and "Memory Resource" on the "Compute Quota" tab of the Create AKS Project workflow. Both of the sub categories lack a proper semantic header order. This PR introduces a fix for both of these issues by adding a component prop to the titles.

# Related Issues

- Closes https://github.com/Azure/aks-desktop/issues/258
- Closes https://github.com/Azure/aks-desktop/issues/202

Related to #219 

## Changes Made

- Fixes Lighthouse scans flagged as the following:
"Heading elements are not in a sequentially-descending order"

"Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies."

How to test: 

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Click "AKS Managed Project" option
- Continue progress into "Compute Quota" tab
- Use inspect tools and open Lighthouse
- Scan at this view

## Images

<img width="1513" height="791" alt="image" src="https://github.com/user-attachments/assets/1264ba77-c00e-4817-8252-26527a1bc8fd" />

<img width="931" height="847" alt="image" src="https://github.com/user-attachments/assets/bc2f823d-26b5-495d-8c33-5dea23d647df" />


