### PR TITLE
frontend: BasicsStep: Fix accessible name for edit project name button

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -11,7 +11,6 @@ import {
   Button,
   CircularProgress,
   FormControl,
-  IconButton,
   Typography,
 } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
@@ -256,11 +255,7 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
                 ? 'Project name is available'
                 : 'Project name must contain only lowercase letters, numbers, and hyphens (no spaces)'
             }
-            endAdornment={
-              <IconButton size="small" sx={{ color: 'primary.main' }}>
-                <Icon icon="mdi:edit" />
-              </IconButton>
-            }
+            endAdornment={<Icon icon="mdi:edit" />}
           />
         </FormControl>
 


### PR DESCRIPTION
## Description

This PR fixes an a11y issue identified by Lighthouse where the edit button for the "Project Name" input did not have an accessible name.

Since this is an icon button is not being used and has no functionality, this PR introduces a change that will remove it.


## Related Issues 

Closes https://github.com/Azure/aks-desktop/issues/200
Related to #219 

## Changes Made

- Removed unused button component that flagged the following:

"Buttons do not have an accessible name"

"When a button doesn't have an accessible name, screen readers announce it as "button", making it unusable for users who rely on screen readers."

How to test: 

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Click "AKS Managed Project" option
- Use inspect tools and open Lighthouse
- Scan at this view