### PR TITLE
Frontend: LabelWithInfo: Fix and improve a11y size and text

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
@@ -34,7 +34,7 @@ function LabelWithInfo({ label, infoText }: { label: string; infoText: string })
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
       <span>{label}</span>
       <Tooltip title={infoText} arrow>
-        <IconButton size="small" sx={{ p: 0, minWidth: 'auto', width: '20px', height: '20px' }}>
+        <IconButton aria-label={`Information about ${label}`}>
           <Icon icon="mdi:information-outline" width="16px" height="16px" />
         </IconButton>
       </Tooltip>
@@ -739,11 +739,8 @@ export default function ConfigureContainer({ containerConfig }: ConfigureContain
                     title="The minimum amount of CPU guaranteed to the container. Kubernetes will schedule the pod on a node with at least this much CPU available."
                     arrow
                   >
-                    <IconButton
-                      size="small"
-                      sx={{ p: 0, minWidth: 'auto', width: '16px', height: '16px' }}
-                    >
-                      <Icon icon="mdi:information-outline" width="14px" height="14px" />
+                    <IconButton aria-label="Information about CPU request">
+                      <Icon icon="mdi:information-outline" width="16px" height="16px" />
                     </IconButton>
                   </Tooltip>
                 </Box>
@@ -800,11 +797,8 @@ export default function ConfigureContainer({ containerConfig }: ConfigureContain
                     title="The maximum amount of CPU the container can use. If exceeded, the container will be throttled."
                     arrow
                   >
-                    <IconButton
-                      size="small"
-                      sx={{ p: 0, minWidth: 'auto', width: '16px', height: '16px' }}
-                    >
-                      <Icon icon="mdi:information-outline" width="14px" height="14px" />
+                    <IconButton aria-label="Information about CPU limit">
+                      <Icon icon="mdi:information-outline" width="16px" height="16px" />
                     </IconButton>
                   </Tooltip>
                 </Box>
@@ -861,11 +855,8 @@ export default function ConfigureContainer({ containerConfig }: ConfigureContain
                     title="The minimum amount of memory guaranteed to the container. Kubernetes will schedule the pod on a node with at least this much memory available."
                     arrow
                   >
-                    <IconButton
-                      size="small"
-                      sx={{ p: 0, minWidth: 'auto', width: '16px', height: '16px' }}
-                    >
-                      <Icon icon="mdi:information-outline" width="14px" height="14px" />
+                    <IconButton aria-label="Information about memory request">
+                      <Icon icon="mdi:information-outline" width="16px" height="16px" />
                     </IconButton>
                   </Tooltip>
                 </Box>
@@ -922,11 +913,8 @@ export default function ConfigureContainer({ containerConfig }: ConfigureContain
                     title="The maximum amount of memory the container can use. If exceeded, the container will be terminated (OOMKilled)."
                     arrow
                   >
-                    <IconButton
-                      size="small"
-                      sx={{ p: 0, minWidth: 'auto', width: '16px', height: '16px' }}
-                    >
-                      <Icon icon="mdi:information-outline" width="14px" height="14px" />
+                    <IconButton aria-label="Information about memory limit">
+                      <Icon icon="mdi:information-outline" width="16px" height="16px" />
                     </IconButton>
                   </Tooltip>
                 </Box>
@@ -1145,10 +1133,7 @@ export default function ConfigureContainer({ containerConfig }: ConfigureContain
                       title="The target average CPU utilization percentage across all pods. HPA will scale up when CPU usage exceeds this value and scale down when it's below."
                       arrow
                     >
-                      <IconButton
-                        size="small"
-                        sx={{ p: 0, minWidth: 'auto', width: '20px', height: '20px' }}
-                      >
+                      <IconButton aria-label="Information about target CPU utilization">
                         <Icon icon="mdi:information-outline" width="16px" height="16px" />
                       </IconButton>
                     </Tooltip>


### PR DESCRIPTION
## Description

This PR introduces improvements and fixes for a11y issues identified by Lighthouse where multiple tooltip buttons using LabelWithInfo component did not have sufficient size or spacing or accessible names.

Lighthouse's "Touch targets" audit requires interactive elements to be at least 48×48 CSS pixels so that users on touch devices can reliably tap them without accidentally hitting adjacent controls

This also introduces an accessible name for each use of the tooltip as this is an info button paired with a text name. This usage requires a context paired with the text name so that screen readers may function as needed and announce this option.


## Related Issues 

- Closes https://github.com/Azure/aks-desktop/issues/204
- Closes https://github.com/Azure/aks-desktop/issues/210

Related to #219 

## Changes Made

- Fixes Lighthouse scan flagged as the following:

"Touch targets do not have sufficient size or spacing"

"Touch targets with sufficient size and spacing help users who may have difficulty targeting small controls to active the targets"

How to test:

- Navigate to projects tab
- Navigate into a project
- Click the "Deploy application" button
- View the "Deploy application" modal
- Choose "Container Image"
- View the "Basics" section
- Use inspect tools and open Lighthouse
- Scan at this view



## Images


### Before

<img width="1355" height="819" alt="image" src="https://github.com/user-attachments/assets/9e355811-19d5-405e-bdd0-5d4f2e080c04" />

### After
<img width="1309" height="833" alt="image" src="https://github.com/user-attachments/assets/41c23394-9a5a-419a-886c-d04d564bd352" />

