### PR TITLE
frontend: HTML template: Fix title to show AKS desktop

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Headlamp</title>
+    <title>AKS desktop</title>
     <script>
         // handles both webpack and rspack build systems
         __baseUrl__ = '%BASE_URL%<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');


### PR DESCRIPTION
It would show Headlamp in the app title sometimes

How to test:

1. Open app
2. While loading it should show AKS desktop instead of headlamp