### PR TITLE
aksd: fix: Respect KUBECONFIG env var when writing to kubeconfig

### DIFF
--- a/app/electron/aks-cluster.ts
+++ b/app/electron/aks-cluster.ts
@@ -332,7 +332,13 @@ export async function registerAKSCluster(
     }
 
     // Step 3: Merge into main kubeconfig
-    const kubeconfigPath = path.join(os.homedir(), '.kube', 'config');
+    // Use the first non-empty path from $KUBECONFIG if set,
+    // otherwise default to ~/.kube/config
+    const defaultKubeconfigPath = path.join(os.homedir(), '.kube', 'config');
+    const kubeconfigPath =
+      process.env.KUBECONFIG?.split(path.delimiter)
+        .map(p => p.trim())
+        .find(p => p) || defaultKubeconfigPath;
     const kubeconfigDir = path.dirname(kubeconfigPath);
 
     // Ensure .kube directory exists


### PR DESCRIPTION
## Description

When registering an AKS cluster or trying to merge one into the kubeconfig via the project creation screen, the kubeconfig path was hardcoded to `~/.kube/config`, ignoring the  `$KUBECONFIG` environment variable. Meaning that a user with $KUBECONFIG set would have their cluster config written to the default location instead. This would happen silently & it's propagation would result in inability to create project or properly merge clusters via AKSD.

This change reads `$KUBECONFIG` and if it's set, uses the first path in the list (matching kubectl behavior for colon/semicolon-separated paths), falling back to `~/.kube/config` only when the variable is unset. 


Fixes #294
- #294 

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] Code refactoring

## How to test: 

1. Set $KUBECONFIG to non-default location
2. Attempt to create a project where the target cluster is not merged as of yet
3. Merge the cluster when notified in the project creation screen. 

Results should be successful merge & next button is properly enabled. 

(If this were to fail, a successful merge message would still appear but the next button would still be disabled due to merge at wrong location.)