### PR TITLE
upstreamable: frontend: EmptyContent: Announce content of the component for screen readers

### DIFF
--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
@@ -30,14 +30,11 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
-            >
-              No data to be shown.
-            </p>
-          </div>
+            role="status"
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
@@ -20,7 +20,10 @@
             class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             />
             <div
               class="MuiBox-root css-p8ekiu"

--- a/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
@@ -20,7 +20,10 @@
             class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             />
             <div
               class="MuiBox-root css-p8ekiu"

--- a/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
@@ -20,7 +20,10 @@
             class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             />
             <div
               class="MuiBox-root css-p8ekiu"

--- a/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
@@ -20,7 +20,10 @@
             class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             />
             <div
               class="MuiBox-root css-p8ekiu"

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.CollapsedSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.CollapsedSidebar.stories.storyshot
@@ -13,7 +13,10 @@
           type="button"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           />
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.Disabled.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.Disabled.stories.storyshot
@@ -14,7 +14,10 @@
           type="button"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           />
         </button>
       </div>

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.ExpandedSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.ExpandedSidebar.stories.storyshot
@@ -13,7 +13,10 @@
           type="button"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           />
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -46,7 +46,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -69,7 +69,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -42,7 +42,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>
@@ -100,7 +103,10 @@
                 class="MuiBox-root css-1c5ij41"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -42,7 +42,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -42,7 +42,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -42,7 +42,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -42,7 +42,10 @@
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 />
               </h1>
             </div>

--- a/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
@@ -679,7 +679,10 @@
                   class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
                     class="MuiBox-root css-19midj6"
+                    role="status"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
@@ -679,7 +679,10 @@
                   class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
                     class="MuiBox-root css-19midj6"
+                    role="status"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
@@ -679,7 +679,10 @@
                   class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
                     class="MuiBox-root css-19midj6"
+                    role="status"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/EmptyContent.tsx
+++ b/frontend/src/components/common/EmptyContent.tsx
@@ -23,18 +23,27 @@ type EmptyProps = React.PropsWithChildren<{
 }>;
 
 export default function Empty({ color = 'textSecondary', children }: EmptyProps) {
+  // Render the live region container empty first, then inject children on the next frame.
+  // Screen readers only announce content that changes inside a live region, not content present on mount.
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    const id = requestAnimationFrame(() => setReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   return (
-    <Box padding={2}>
-      {React.Children.map(children, child => {
-        if (typeof child === 'string') {
-          return (
-            <Typography color={color} align="center">
-              {child}
-            </Typography>
-          );
-        }
-        return child;
-      })}
+    <Box padding={2} role="status" aria-live="polite" aria-atomic="true">
+      {ready &&
+        React.Children.map(children, child => {
+          if (typeof child === 'string') {
+            return (
+              <Typography color={color} align="center">
+                {child}
+              </Typography>
+            );
+          }
+          return child;
+        })}
     </Box>
   );
 }

--- a/frontend/src/components/common/Resource/__snapshots__/DocsViewer.ErrorDocumentation.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DocsViewer.ErrorDocumentation.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/common/Resource/__snapshots__/DocsViewer.NoDocumentation.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DocsViewer.NoDocumentation.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/Resource/__snapshots__/DocsViewer.NoMatchingDocumentation.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DocsViewer.NoMatchingDocumentation.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -216,7 +216,10 @@
               class="MuiBox-root css-u718rw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -252,7 +252,10 @@
               class="MuiBox-root css-u718rw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/EmptyContent.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EmptyContent.Default.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/EmptyContent.Empty.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EmptyContent.Empty.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/EmptyContent.WithCustomColor.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EmptyContent.WithCustomColor.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/EmptyContent.WithMultipleChildren.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EmptyContent.WithMultipleChildren.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
@@ -12,7 +12,10 @@
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
       >
         <div
+          aria-atomic="true"
+          aria-live="polite"
           class="MuiBox-root css-19midj6"
+          role="status"
         >
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
@@ -30,7 +30,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
@@ -30,7 +30,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
@@ -158,7 +158,10 @@
               style="grid-column: span 4;"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
@@ -216,7 +216,10 @@
               class="MuiBox-root css-1txv3mw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -264,7 +267,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
@@ -345,7 +345,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -458,7 +458,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -1290,7 +1293,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -30,7 +30,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCR.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCR.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCRD.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.ErrorGettingCRD.stories.storyshot
@@ -1,7 +1,10 @@
 <body>
   <div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       class="MuiBox-root css-19midj6"
+      role="status"
     >
       <p
         class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -241,7 +241,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -303,7 +303,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -352,7 +355,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -303,7 +303,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -352,7 +355,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -134,7 +134,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -134,7 +134,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -357,7 +357,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Error.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -471,7 +471,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
@@ -87,7 +87,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
@@ -305,7 +305,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
@@ -374,7 +374,10 @@ cookieName: session-id"
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -233,7 +233,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -282,7 +285,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -383,7 +383,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
@@ -234,7 +234,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -374,7 +377,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -423,7 +429,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -639,7 +639,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
@@ -224,7 +224,10 @@
               class="MuiBox-root css-1txv3mw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -272,7 +275,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -321,7 +327,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
@@ -305,7 +305,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -585,7 +585,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -233,7 +233,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
@@ -255,7 +255,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -382,7 +382,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -408,7 +408,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -278,7 +278,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -259,7 +259,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
@@ -336,7 +336,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -230,7 +230,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -291,7 +294,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -352,7 +358,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -408,7 +417,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
@@ -455,7 +455,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
@@ -339,7 +339,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
@@ -281,7 +281,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -134,7 +134,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -329,7 +329,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
@@ -233,7 +233,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
@@ -230,7 +230,10 @@
               class="MuiBox-root css-1txv3mw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
@@ -278,7 +281,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -443,7 +443,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -598,7 +598,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -380,7 +380,10 @@
               class="MuiBox-root css-1txv3mw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"
@@ -425,7 +428,10 @@
               class="MuiBox-root css-1txv3mw"
             >
               <div
+                aria-atomic="true"
+                aria-live="polite"
                 class="MuiBox-root css-19midj6"
+                role="status"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"
@@ -473,7 +479,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
@@ -393,7 +393,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
@@ -403,7 +403,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
@@ -393,7 +393,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
@@ -393,7 +393,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.EmptyList.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.EmptyList.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -131,7 +131,10 @@
           class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
         >
           <div
+            aria-atomic="true"
+            aria-live="polite"
             class="MuiBox-root css-19midj6"
+            role="status"
           >
             <p
               class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
@@ -292,7 +292,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -246,7 +246,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
@@ -290,7 +290,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -686,7 +686,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
@@ -74,7 +74,10 @@
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
           >
             <div
+              aria-atomic="true"
+              aria-live="polite"
               class="MuiBox-root css-19midj6"
+              role="status"
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -575,7 +575,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -572,7 +572,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -561,7 +561,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -558,7 +558,10 @@
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
               >
                 <div
+                  aria-atomic="true"
+                  aria-live="polite"
                   class="MuiBox-root css-19midj6"
+                  role="status"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -998,7 +998,10 @@
                   class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
                     class="MuiBox-root css-19midj6"
+                    role="status"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"


### PR DESCRIPTION
Fixes #307 a11y issue for empty results

Repro Steps:
Start Narrator/NVDA.
Launch AKS desktop application.
TAB to "Azure Account" button and press ENTER.
Azure Authentication login screen will open. Sign in with your v-id.
Afte login "Azure Account" dialog will open with "Tenant ID" and "Default subscription ID". TAB to "Add cluster from Azure" button and press enter.
"Register AKS Cluster" dialog will open. Verify all the elements of these dialogs are accessible and MAS compliant.
After adding the cluster home page will open.
TAB to "All Clusters" Tab and press ENTER. 
TAB to "More actions" button in grid and press ENTER.
Tab to "View" button and press enter.
TAB to "Namespaces" button and select any list item.
Observe that Narrator/NVDA does not announce “No data to be shown” status message when no search results are found in Events after adding namespaces