### PR TITLE
app: electron: Fix broken zoom menu items

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1075,7 +1075,7 @@ function getDefaultAppMenu(): AppMenu[] {
         {
           label: i18n.t('Zoom In'),
           id: 'original-zoom-in',
-          accelerator: 'CmdOrCtrl+Plus',
+          accelerator: 'CmdOrCtrl+=',
           click: () => adjustZoom(0.1),
         },
         {


### PR DESCRIPTION
This change fixes zoom in/out and reset zoom menu items that were not working due to click handlers being stripped during menu serialization. Also updates the Zoom in accelerator from `CmdOrCtrl+Plus` (requires Shift) to `CmdOrCtrl+=`.

Fixes: #285 

### Testing
- [x] Open AKS desktop and test the zoom options under the Navigate tab in the app window
- [x] Ensure that the zoom level changes
- [x] Verify Zoom In works with `Ctrl+=` (no Shift required)

### Screenshots
#### Zoomed in
<img width="2452" height="1428" alt="image" src="https://github.com/user-attachments/assets/f7d54770-409e-445a-bc10-ee8c5b10eb7d" />

#### Zoomed out
<img width="2464" height="1429" alt="image" src="https://github.com/user-attachments/assets/c74027b1-fd27-4b99-836a-bf89fe259151" />