### PR TITLE
CreateAKSProject: Remove extra steps in Breadcrumb component

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.tsx
@@ -29,7 +29,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ steps, activeStep, onSte
       }}
     >
       {steps.map((label, index) => (
-        <React.Fragment key={label}>
+        <React.Fragment key={index}>
           <Box
             onClick={() => onStepClick(index)}
             sx={{


### PR DESCRIPTION
`t()` returns empty strings while i18n is initializing, causing all steps to get duplicated `key=""` on first render. When keys changed to actual strings on re-render, React left stale ghost DOM nodes. Using `key={index}` keeps keys stable across renders.

Fixes: #279
Related: #94 