### PR TITLE
frontend: Fix DeployWizard accessible names dialog

### DIFF
--- a/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
+++ b/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
@@ -82,6 +82,7 @@ function DeployButton({ project }: DeployButtonProps) {
         onClose={handleClose}
         maxWidth="lg"
         fullWidth
+        aria-labelledby="deploy-wizard-dialog-title"
         PaperProps={{
           sx: {
             height: '90vh',

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
@@ -214,7 +214,12 @@ export default function DeployWizard({
   return (
     // Todo: noScroll could be done like this? <Container maxWidth="lg" sx={{ py: 3, overflow: 'hidden' }}>
     <Container maxWidth="lg" sx={{ py: 3 }}>
-      <Typography variant="h4" gutterBottom sx={{ fontWeight: 600, mb: 2 }}>
+      <Typography
+        id="deploy-wizard-dialog-title"
+        variant="h4"
+        gutterBottom
+        sx={{ fontWeight: 600, mb: 2 }}
+      >
         {t('Deploy Application')}
       </Typography>
       <Card>


### PR DESCRIPTION
## Description

This PR introduces improvements and fixes for a11y issues identified by Lighthouse where the DeployWizard component did not have accessible names.

Previously the modal itself was not linked to the dialog for screen readers to announce, these changes fix this.

## Related Issues 

- Closes https://github.com/Azure/aks-desktop/issues/195

Related to #219 

## Changes Made

- Updates DeployWizard aria label

How to test:

- Navigate to projects tab
- Navigate into a project
- Click the "Deploy application" button
- View the "Deploy application" modal
- Use inspect tools and open Lighthouse
- Scan at this view