### PR TITLE
upstreamable: frontend: Table: Implement keyboard accessible column selector in ColumnVisibilityButton

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -189,6 +189,8 @@
                         />
                       </button>
                       <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
                         aria-label="Show/Hide columns"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -128,6 +128,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -133,6 +133,8 @@
                 />
               </button>
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -125,6 +125,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
+import { MRT_TableInstance } from 'material-react-table';
+import { useId, useState } from 'react';
+
+export function ColumnVisibilityButton<T extends Record<string, any>>({
+  table,
+}: {
+  table: MRT_TableInstance<T>;
+}) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuId = useId();
+  const isOpen = !!anchorEl;
+  const {
+    icons: { ViewColumnIcon },
+    localization,
+  } = table.options;
+
+  const columns = table
+    .getAllLeafColumns()
+    .filter(
+      col =>
+        col.columnDef.enableHiding !== false &&
+        col.columnDef.visibleInShowHideMenu !== false &&
+        col.columnDef.columnDefType !== 'display'
+    );
+
+  const handleToggleAll = (visible: boolean) => {
+    columns.filter(col => col.getCanHide()).forEach(col => col.toggleVisibility(visible));
+  };
+
+  return (
+    <>
+      <Tooltip title={localization.showHideColumns}>
+        <IconButton
+          aria-label={localization.showHideColumns}
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? menuId : undefined}
+          onClick={e => setAnchorEl(e.currentTarget)}
+        >
+          <ViewColumnIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={() => setAnchorEl(null)}
+        disableScrollLock
+      >
+        <MenuItem
+          disabled={!table.getIsSomeColumnsVisible()}
+          onClick={() => handleToggleAll(false)}
+        >
+          {localization.hideAll}
+        </MenuItem>
+        <MenuItem disabled={table.getIsAllColumnsVisible()} onClick={() => handleToggleAll(true)}>
+          {localization.showAll}
+        </MenuItem>
+        <Divider />
+        {columns.map(column => (
+          <MenuItem
+            key={column.id}
+            disabled={!column.getCanHide()}
+            onClick={() => column.toggleVisibility()}
+          >
+            <Switch
+              size="small"
+              checked={column.getIsVisible()}
+              onChange={() => {}}
+              tabIndex={-1}
+              edge="start"
+              sx={{ mr: 1, pointerEvents: 'none' }}
+            />
+            <ListItemText>{column.columnDef.header}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -32,6 +32,8 @@ import {
   MRT_TableHeadCell,
   MRT_TableInstance,
   MRT_TableOptions as MaterialTableOptions,
+  MRT_ToggleFiltersButton,
+  MRT_ToggleGlobalFilterButton,
   MRT_TopToolbar,
   useMaterialReactTable,
   useMRT_Rows,
@@ -64,6 +66,7 @@ import { useSettings } from '../../App/Settings/hook';
 import { useQueryParamsState } from '../../resourceMap/useQueryParamsState';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
+import { ColumnVisibilityButton } from './ColumnVisibilityButton';
 
 /**
  * Column definition
@@ -292,16 +295,37 @@ export default function Table<RowItem extends Record<string, any>>({
       setPageSize(pagination.pageSize);
     },
     onGlobalFilterChange: setGlobalFilter,
-    renderToolbarInternalActions: props => {
+    renderToolbarInternalActions: ({ table: tbl }) => {
       const isSomeRowsSelected =
-        tableProps.enableRowSelection && props.table.getSelectedRowModel().rows.length !== 0;
-      if (isSomeRowsSelected) {
-        const renderRowSelectionToolbar = tableProps.renderRowSelectionToolbar;
-        if (renderRowSelectionToolbar !== undefined) {
-          return renderRowSelectionToolbar(props);
-        }
+        tableProps.enableRowSelection && tbl.getSelectedRowModel().rows.length !== 0;
+      if (isSomeRowsSelected && tableProps.renderRowSelectionToolbar) {
+        return tableProps.renderRowSelectionToolbar({ table: tbl });
       }
-      return null;
+
+      const {
+        enableFilters = true,
+        enableGlobalFilter = true,
+        enableColumnFilters = true,
+        enableHiding = true,
+        enableColumnOrdering,
+        enableColumnPinning,
+        columnFilterDisplayMode,
+        initialState: initState,
+      } = tbl.options;
+
+      return (
+        <>
+          {enableFilters && enableGlobalFilter && !initState?.showGlobalFilter && (
+            <MRT_ToggleGlobalFilterButton table={tbl} />
+          )}
+          {enableFilters && enableColumnFilters && columnFilterDisplayMode !== 'popover' && (
+            <MRT_ToggleFiltersButton table={tbl} />
+          )}
+          {(enableHiding || enableColumnOrdering || enableColumnPinning) && (
+            <ColumnVisibilityButton table={tbl} />
+          )}
+        </>
+      );
     },
     initialState: useMemo(
       () => ({

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -246,6 +246,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -116,6 +116,8 @@
                 />
               </button>
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -116,6 +116,8 @@
                 />
               </button>
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -208,6 +208,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -162,6 +162,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -99,6 +99,8 @@
               />
             </button>
             <button
+              aria-expanded="false"
+              aria-haspopup="menu"
               aria-label="Show/Hide columns"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -708,6 +708,8 @@
                         />
                       </button>
                       <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
                         aria-label="Show/Hide columns"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -236,6 +236,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -140,6 +140,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -257,6 +257,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -137,6 +137,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -226,6 +226,8 @@
                   />
                 </button>
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -140,6 +140,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -140,6 +140,8 @@
                     />
                   </button>
                   <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"


### PR DESCRIPTION
Fixes #309

- https://github.com/Azure/aks-desktop/issues/309

The built-in MRT_ShowHideColumnsButton renders column visibility toggles using FormControlLabel with Switch wrapped inside Tooltip, which breaks keyboard navigation. The menu items don't respond to Enter/Space and the Hide All/Show All buttons are unreachable via arrow keys.

<img width="290" height="389" alt="image" src="https://github.com/user-attachments/assets/3ec1cdef-2ec7-48f8-a40e-7212ef5775a9" />

Changes
 - Add a custom ColumnVisibilityButton component that replaces MRT's built-in column visibility menu with fully keyboard-accessible MenuItem elements
 - Override renderToolbarInternalActions in Table.tsx to render our custom button alongside MRT's filter toggle buttons
 - All menu items (Hide All, Show All, individual column toggles) are navigable via arrow keys and activatable via Enter/Space


How to test:

1. Find any resourcetable (clusters/resources)
2. Navigate with keyboard to "Show/Hide column"
3. Ensure every item is accessible with keyboard (space/enter to open popup, arrow keys to navigate, space/enter to select column) 