### PR TITLE
ci: install make in 1ES Linux pipeline for builds

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -106,6 +106,25 @@ extends:
                   git log --oneline -1 || echo "Git not available"
                   echo "=== END CHECKOUT DEBUG ==="
                 displayName: "Debug: Checkout"
+              - bash: |
+                  set -e
+                  echo "=== INSTALL MAKE START ==="
+                  if command -v make >/dev/null 2>&1; then
+                    echo "make is already installed, skipping install."
+                  else
+                    echo "make not found, installing via tdnf..."
+                    if [ "$(id -u)" -eq 0 ]; then
+                      tdnf install -y make
+                    else
+                      sudo -n tdnf install -y make
+                    fi
+                    echo "make installed successfully."
+                  fi
+
+                  echo "make version:"
+                  make --version | head -n 1
+                  echo "=== INSTALL MAKE END ==="
+                displayName: "Install make build tool"
               # Build the Windows application
               - bash: |
                   echo "=== BUILD DEBUG START ==="


### PR DESCRIPTION
## Description

Linux Build pipelines are failing as the image "1es-azlinux-3-amd64-custom-disk" doesn't have make installed by default
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

