### PR TITLE
ci: install binutils in 1ES Linux pipeline for builds

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -125,6 +125,25 @@ extends:
                   make --version | head -n 1
                   echo "=== INSTALL MAKE END ==="
                 displayName: "Install make build tool"
+              - bash: |
+                  set -e
+                  echo "=== INSTALL BINUTILS START ==="
+                  if command -v ld >/dev/null 2>&1; then
+                    echo "binutils is already installed, skipping install."
+                  else
+                    echo "binutils not found, installing via tdnf..."
+                    if [ "$(id -u)" -eq 0 ]; then
+                      tdnf install -y binutils
+                    else
+                      sudo -n tdnf install -y binutils
+                    fi
+                    echo "binutils installed successfully."
+                  fi
+
+                  echo "binutils version:"
+                  ld --version | head -n 1
+                  echo "=== INSTALL BINUTILS END ==="
+                displayName: "Install binutils"
               # Build the Windows application
               - bash: |
                   echo "=== BUILD DEBUG START ==="


### PR DESCRIPTION
## Description

Deb builds are failing due to bin utils not being installed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

