### PR TITLE
InfoTab: Extract useInfoTab hook and add tests

### DIFF
--- a/plugins/aks-desktop/locales/cs/translation.json
+++ b/plugins/aks-desktop/locales/cs/translation.json
@@ -284,6 +284,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/de/translation.json
+++ b/plugins/aks-desktop/locales/de/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/en/translation.json
+++ b/plugins/aks-desktop/locales/en/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "No cluster selected",
   "Failed to fetch cluster info": "Failed to fetch cluster info",
   "Failed to fetch managed namespaces": "Failed to fetch managed namespaces",
+  "Failed to fetch managed namespace details": "Failed to fetch managed namespace details",
   "Failed to update managed namespace": "Failed to update managed namespace",
   "Updating": "Updating",
   "Update": "Update",

--- a/plugins/aks-desktop/locales/es/translation.json
+++ b/plugins/aks-desktop/locales/es/translation.json
@@ -277,6 +277,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/fr/translation.json
+++ b/plugins/aks-desktop/locales/fr/translation.json
@@ -277,6 +277,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/hu/translation.json
+++ b/plugins/aks-desktop/locales/hu/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/id/translation.json
+++ b/plugins/aks-desktop/locales/id/translation.json
@@ -263,6 +263,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/it/translation.json
+++ b/plugins/aks-desktop/locales/it/translation.json
@@ -277,6 +277,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/ja/translation.json
+++ b/plugins/aks-desktop/locales/ja/translation.json
@@ -263,6 +263,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/ko/translation.json
+++ b/plugins/aks-desktop/locales/ko/translation.json
@@ -263,6 +263,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/nl/translation.json
+++ b/plugins/aks-desktop/locales/nl/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/pl/translation.json
+++ b/plugins/aks-desktop/locales/pl/translation.json
@@ -284,6 +284,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/pt-BR/translation.json
+++ b/plugins/aks-desktop/locales/pt-BR/translation.json
@@ -277,6 +277,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/pt-PT/translation.json
+++ b/plugins/aks-desktop/locales/pt-PT/translation.json
@@ -277,6 +277,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/ru/translation.json
+++ b/plugins/aks-desktop/locales/ru/translation.json
@@ -284,6 +284,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/sv/translation.json
+++ b/plugins/aks-desktop/locales/sv/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/tr/translation.json
+++ b/plugins/aks-desktop/locales/tr/translation.json
@@ -270,6 +270,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/zh-Hans/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hans/translation.json
@@ -263,6 +263,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/locales/zh-Hant/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hant/translation.json
@@ -263,6 +263,7 @@
   "No cluster selected": "",
   "Failed to fetch cluster info": "",
   "Failed to fetch managed namespaces": "",
+  "Failed to fetch managed namespace details": "",
   "Failed to update managed namespace": "",
   "Updating": "",
   "Update": "",

--- a/plugins/aks-desktop/src/components/InfoTab/InfoTab.tsx
+++ b/plugins/aks-desktop/src/components/InfoTab/InfoTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import {
   Box,
   Button,
@@ -11,241 +11,47 @@ import {
   Divider,
   Typography,
 } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  getManagedNamespaceDetails,
-  getManagedNamespaces,
-  updateManagedNamespace,
-} from '../../utils/azure/az-cli';
+import React from 'react';
 import { ComputeStep } from '../CreateAKSProject/components/ComputeStep';
 import { NetworkingStep } from '../CreateAKSProject/components/NetworkingStep';
-import { DEFAULT_FORM_DATA, type FormData, type ValidationState } from '../CreateAKSProject/types';
-import { validateComputeQuota, validateNetworkingPolicies } from '../CreateAKSProject/validators';
+import { useInfoTab } from './hooks/useInfoTab';
 
+/**
+ * Props for the {@link InfoTab} component.
+ */
 interface InfoTabProps {
+  /** The project whose networking and compute quota settings are displayed and edited. */
   project: {
+    /** Cluster names associated with the project; the first entry is used for API calls. */
     clusters: string[];
+    /** Kubernetes namespace names associated with the project; the first entry is used. */
     namespaces: string[];
+    /** The managed namespace name used as the project identifier. */
     id: string;
   };
 }
 
+/**
+ * Displays and allows editing of the networking policies and compute quota for a managed namespace.
+ *
+ * Fetches current settings from the Azure CLI and pre-populates the form. Provides a save
+ * button that is enabled only when there are valid, unsaved changes.
+ *
+ * @param props.project - The project whose settings are managed.
+ */
 const InfoTab: React.FC<InfoTabProps> = ({ project }) => {
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  type NamespaceDetails = {
-    properties?: {
-      defaultNetworkPolicy?: {
-        ingress?: string;
-        egress?: string;
-      };
-      defaultResourceQuota?: {
-        cpuRequest?: string;
-        cpuLimit?: string;
-        memoryRequest?: string;
-        memoryLimit?: string;
-      };
-    };
-  };
-
-  const [namespaceInstance] = K8s.ResourceClasses.Namespace.useGet(
-    project.namespaces[0],
-    undefined,
-    {
-      cluster: project.clusters[0],
-    }
-  );
-  const subscription =
-    namespaceInstance?.jsonData?.metadata?.labels?.['aks-desktop/project-subscription'];
-  const resourceGroup =
-    namespaceInstance?.jsonData?.metadata?.labels?.['aks-desktop/project-resource-group'];
-
-  const [namespaceDetails, setNamespaceDetails] = useState<NamespaceDetails | null>(null);
-  const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
-  const [baselineFormData, setBaselineFormData] = useState<FormData | null>(null);
-  const [updating, setUpdating] = useState(false);
-  const [validation, setValidation] = useState<ValidationState>({
-    isValid: true,
-    errors: [],
-    warnings: [],
-    fieldErrors: {},
-  });
-
-  useEffect(() => {
-    let isMounted = true;
-    const clusterName = project?.clusters?.[0];
-    if (!clusterName || !resourceGroup) {
-      setNamespaceDetails(null);
-      return () => {
-        isMounted = false;
-      };
-    }
-
-    (async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const nsList = await getManagedNamespaces({
-          clusterName,
-          resourceGroup,
-          subscriptionId: subscription,
-        });
-
-        if (isMounted && nsList.length > 0) {
-          const details = await getManagedNamespaceDetails({
-            clusterName,
-            resourceGroup,
-            namespaceName: project.id,
-            subscriptionId: subscription,
-          });
-          if (isMounted) setNamespaceDetails(details);
-        } else if (isMounted) {
-          setNamespaceDetails(null);
-        }
-      } catch (e) {
-        console.error(e);
-        if (isMounted) {
-          setError(t('Failed to fetch managed namespaces'));
-          setNamespaceDetails(null);
-        }
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    })();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [project, subscription, resourceGroup]);
-
-  // Utils reused across renders
-  const normalizePolicy = useCallback((value: string): FormData['ingress'] => {
-    const allowed: Record<FormData['ingress'], true> = {
-      AllowSameNamespace: true,
-      AllowAll: true,
-      DenyAll: true,
-    };
-    if ((value as keyof typeof allowed) in allowed) {
-      return value as FormData['ingress'];
-    }
-    return 'AllowSameNamespace';
-  }, []);
-
-  const parseMillicores = useCallback((val: string): number => {
-    const n = parseInt(String(val).replace(/m$/i, ''), 10);
-    return Number.isFinite(n) ? n : 0;
-  }, []);
-
-  const parseMiB = useCallback((val: string): number => {
-    const n = parseInt(String(val).replace(/Mi$/i, ''), 10);
-    return Number.isFinite(n) ? n : 0;
-  }, []);
-
-  // When namespace details are fetched, pre-populate the forms
-  useEffect(() => {
-    if (!namespaceDetails) return;
-
-    const ingress = normalizePolicy(
-      namespaceDetails?.properties?.defaultNetworkPolicy?.ingress ?? 'AllowSameNamespace'
-    );
-    const egress = normalizePolicy(
-      namespaceDetails?.properties?.defaultNetworkPolicy?.egress ?? 'AllowAll'
-    );
-
-    const cpuReqStr = namespaceDetails?.properties?.defaultResourceQuota?.cpuRequest ?? '0m';
-    const cpuLimStr = namespaceDetails?.properties?.defaultResourceQuota?.cpuLimit ?? '0m';
-    const memReqStr = namespaceDetails?.properties?.defaultResourceQuota?.memoryRequest ?? '0Mi';
-    const memLimStr = namespaceDetails?.properties?.defaultResourceQuota?.memoryLimit ?? '0Mi';
-
-    const populated: FormData = {
-      ...DEFAULT_FORM_DATA,
-      ingress,
-      egress,
-      cpuRequest: parseMillicores(cpuReqStr),
-      cpuLimit: parseMillicores(cpuLimStr),
-      memoryRequest: parseMiB(memReqStr),
-      memoryLimit: parseMiB(memLimStr),
-      projectName: DEFAULT_FORM_DATA.projectName,
-      description: DEFAULT_FORM_DATA.description,
-      subscription: DEFAULT_FORM_DATA.subscription,
-      cluster: DEFAULT_FORM_DATA.cluster,
-      resourceGroup: DEFAULT_FORM_DATA.resourceGroup,
-    };
-
-    setFormData(populated);
-    setBaselineFormData(populated);
-  }, [namespaceDetails]);
-
-  const handleFormDataChange = useCallback(
-    (updates: Partial<FormData>) => {
-      setFormData(prev => ({ ...prev, ...updates }));
-      setValidation(prev => {
-        const next = { ...prev, fieldErrors: {} as Record<string, string[]> } as ValidationState;
-        const compute = validateComputeQuota({
-          cpuRequest: (updates.cpuRequest ?? formData.cpuRequest) as number,
-          cpuLimit: (updates.cpuLimit ?? formData.cpuLimit) as number,
-          memoryRequest: (updates.memoryRequest ?? formData.memoryRequest) as number,
-          memoryLimit: (updates.memoryLimit ?? formData.memoryLimit) as number,
-        });
-        const networking = validateNetworkingPolicies({
-          ingress: (updates.ingress ?? formData.ingress) as any,
-          egress: (updates.egress ?? formData.egress) as any,
-        });
-
-        const fieldErrors: Record<string, string[]> = {};
-        if (compute.fieldErrors) Object.assign(fieldErrors, compute.fieldErrors);
-        if (!networking.isValid) fieldErrors.networking = networking.errors;
-
-        next.fieldErrors = fieldErrors;
-        next.errors = [...(compute.errors || []), ...(networking.errors || [])];
-        next.isValid = compute.isValid && networking.isValid;
-        return next;
-      });
-    },
-    [formData]
-  );
-
-  const hasChanges = useMemo(() => {
-    if (!baselineFormData) return false;
-    const keys: (keyof FormData)[] = [
-      'ingress',
-      'egress',
-      'cpuRequest',
-      'cpuLimit',
-      'memoryRequest',
-      'memoryLimit',
-    ];
-    return keys.some(k => formData[k] !== baselineFormData[k]);
-  }, [baselineFormData, formData]);
-
-  const handleSave = useCallback(async () => {
-    if (!resourceGroup) return;
-    const clusterName = project?.clusters?.[0];
-    if (!clusterName || !project.id) return;
-
-    try {
-      setUpdating(true);
-      await updateManagedNamespace({
-        clusterName,
-        resourceGroup,
-        namespaceName: project.id,
-        ingressPolicy: formData.ingress as any,
-        egressPolicy: formData.egress as any,
-        cpuRequest: formData.cpuRequest,
-        cpuLimit: formData.cpuLimit,
-        memoryRequest: formData.memoryRequest,
-        memoryLimit: formData.memoryLimit,
-        noWait: false,
-      });
-      setBaselineFormData(formData);
-    } catch (e) {
-      console.error('Failed to update managed namespace', e);
-      setError(t('Failed to update managed namespace'));
-    } finally {
-      setUpdating(false);
-    }
-  }, [resourceGroup, formData, project?.clusters, project.id, t]);
+  const {
+    loading,
+    updating,
+    error,
+    namespaceDetails,
+    formData,
+    validation,
+    hasChanges,
+    handleFormDataChange,
+    handleSave,
+  } = useInfoTab(project);
 
   return (
     <Card>
@@ -265,14 +71,13 @@ const InfoTab: React.FC<InfoTabProps> = ({ project }) => {
         )}
         {!loading && error && <Typography color="error">{error}</Typography>}
 
-        {!loading && !error && resourceGroup && namespaceDetails && (
+        {!loading && !error && namespaceDetails && (
           <Box>
             <Box sx={{ mb: 3 }}>
               <NetworkingStep
                 formData={formData}
                 onFormDataChange={handleFormDataChange}
                 validation={validation}
-                loading={loading}
               />
             </Box>
             <Divider sx={{ my: 2 }} />
@@ -281,7 +86,6 @@ const InfoTab: React.FC<InfoTabProps> = ({ project }) => {
                 formData={formData}
                 onFormDataChange={handleFormDataChange}
                 validation={validation}
-                loading={loading}
               />
             </Box>
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>

--- a/plugins/aks-desktop/src/components/InfoTab/hooks/useInfoTab.test.ts
+++ b/plugins/aks-desktop/src/components/InfoTab/hooks/useInfoTab.test.ts
@@ -1,0 +1,396 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// --- Mocks (vi.hoisted ensures variables are available when vi.mock is hoisted) ---
+
+const mockUseGet = vi.hoisted(() => vi.fn());
+const mockGetManagedNamespaces = vi.hoisted(() => vi.fn());
+const mockGetManagedNamespaceDetails = vi.hoisted(() => vi.fn());
+const mockUpdateManagedNamespace = vi.hoisted(() => vi.fn());
+const mockT = vi.hoisted(() => (key: string) => key);
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  K8s: {
+    ResourceClasses: {
+      Namespace: {
+        useGet: mockUseGet,
+      },
+    },
+  },
+  useTranslation: () => ({ t: mockT }),
+}));
+
+vi.mock('../../../utils/azure/az-cli', () => ({
+  getManagedNamespaces: mockGetManagedNamespaces,
+  getManagedNamespaceDetails: mockGetManagedNamespaceDetails,
+  updateManagedNamespace: mockUpdateManagedNamespace,
+}));
+
+import { useInfoTab } from './useInfoTab';
+
+/** A minimal project fixture used across tests. */
+const defaultProject = {
+  clusters: ['my-cluster'],
+  namespaces: ['my-namespace'],
+  id: 'my-project',
+};
+
+/** A namespace instance returned by Headlamp with subscription and resource group labels. */
+function createNamespaceInstance(subscription = 'sub-123', resourceGroup = 'rg-prod') {
+  return {
+    jsonData: {
+      metadata: {
+        labels: {
+          'aks-desktop/project-subscription': subscription,
+          'aks-desktop/project-resource-group': resourceGroup,
+        },
+      },
+    },
+  };
+}
+
+/** A namespace details object returned by the Azure CLI. */
+function createNamespaceDetails(
+  overrides: Partial<{
+    ingress: string;
+    egress: string;
+    cpuRequest: string;
+    cpuLimit: string;
+    memoryRequest: string;
+    memoryLimit: string;
+  }> = {}
+) {
+  const {
+    ingress = 'AllowSameNamespace',
+    egress = 'AllowAll',
+    cpuRequest = '500m',
+    cpuLimit = '1000m',
+    memoryRequest = '256Mi',
+    memoryLimit = '512Mi',
+  } = overrides;
+
+  return {
+    properties: {
+      defaultNetworkPolicy: { ingress, egress },
+      defaultResourceQuota: { cpuRequest, cpuLimit, memoryRequest, memoryLimit },
+    },
+  };
+}
+
+describe('useInfoTab', () => {
+  beforeEach(() => {
+    // Default: namespace labels present
+    mockUseGet.mockReturnValue([createNamespaceInstance()]);
+    // Default: managed namespaces available with details
+    mockGetManagedNamespaces.mockResolvedValue(['my-project']);
+    mockGetManagedNamespaceDetails.mockResolvedValue(createNamespaceDetails());
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // --- Initial loading state ---
+
+  test('starts in loading state and resolves after fetch completes', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.namespaceDetails).not.toBeNull();
+  });
+
+  // --- Missing cluster or resource group ---
+
+  test('sets namespaceDetails to null and skips fetch when cluster is missing', async () => {
+    const project = { ...defaultProject, clusters: [] };
+
+    const { result } = renderHook(() => useInfoTab(project));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockGetManagedNamespaces).not.toHaveBeenCalled();
+    expect(result.current.namespaceDetails).toBeNull();
+  });
+
+  test('sets namespaceDetails to null and skips fetch when resourceGroup label is absent', async () => {
+    mockUseGet.mockReturnValue([{ jsonData: { metadata: { labels: {} } } }]);
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockGetManagedNamespaces).not.toHaveBeenCalled();
+    expect(result.current.namespaceDetails).toBeNull();
+  });
+
+  // --- Managed namespace list empty ---
+
+  test('sets namespaceDetails to null when no managed namespaces exist for the cluster', async () => {
+    mockGetManagedNamespaces.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockGetManagedNamespaceDetails).not.toHaveBeenCalled();
+    expect(result.current.namespaceDetails).toBeNull();
+  });
+
+  // --- Error handling ---
+
+  test('sets error and clears namespaceDetails when getManagedNamespaces throws', async () => {
+    mockGetManagedNamespaces.mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('Failed to fetch managed namespaces');
+    expect(result.current.namespaceDetails).toBeNull();
+  });
+
+  test('sets error and clears namespaceDetails when getManagedNamespaceDetails throws', async () => {
+    mockGetManagedNamespaceDetails.mockRejectedValue(new Error('details error'));
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('Failed to fetch managed namespace details');
+    expect(result.current.namespaceDetails).toBeNull();
+  });
+
+  // --- Form population from namespace details ---
+
+  test('pre-populates formData from fetched namespace details', async () => {
+    mockGetManagedNamespaceDetails.mockResolvedValue(
+      createNamespaceDetails({
+        ingress: 'AllowAll',
+        egress: 'DenyAll',
+        cpuRequest: '250m',
+        cpuLimit: '500m',
+        memoryRequest: '128Mi',
+        memoryLimit: '256Mi',
+      })
+    );
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.formData.ingress).toBe('AllowAll');
+    expect(result.current.formData.egress).toBe('DenyAll');
+    expect(result.current.formData.cpuRequest).toBe(250);
+    expect(result.current.formData.cpuLimit).toBe(500);
+    expect(result.current.formData.memoryRequest).toBe(128);
+    expect(result.current.formData.memoryLimit).toBe(256);
+  });
+
+  test('falls back to AllowSameNamespace for unrecognised ingress policy value', async () => {
+    mockGetManagedNamespaceDetails.mockResolvedValue(
+      createNamespaceDetails({ ingress: 'InvalidPolicy' })
+    );
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.formData.ingress).toBe('AllowSameNamespace');
+  });
+
+  test('parses resource values without units as zero', async () => {
+    mockGetManagedNamespaceDetails.mockResolvedValue(
+      createNamespaceDetails({
+        cpuRequest: 'invalid',
+        memoryRequest: 'bad',
+      })
+    );
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.formData.cpuRequest).toBe(0);
+    expect(result.current.formData.memoryRequest).toBe(0);
+  });
+
+  // --- hasChanges ---
+
+  test('hasChanges is false initially after fetch', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  test('hasChanges becomes true after a form field is changed', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'DenyAll' });
+    });
+
+    expect(result.current.hasChanges).toBe(true);
+  });
+
+  test('hasChanges returns to false after reverting a change back to the baseline', async () => {
+    mockGetManagedNamespaceDetails.mockResolvedValue(
+      createNamespaceDetails({ ingress: 'AllowSameNamespace' })
+    );
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'DenyAll' });
+    });
+    expect(result.current.hasChanges).toBe(true);
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'AllowSameNamespace' });
+    });
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  // --- Validation ---
+
+  test('validation is valid on initial form population', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.validation.isValid).toBe(true);
+  });
+
+  test('validation becomes invalid when cpuRequest exceeds cpuLimit', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ cpuRequest: 2000, cpuLimit: 500 });
+    });
+
+    expect(result.current.validation.isValid).toBe(false);
+    expect(result.current.validation.errors).toContain(
+      'CPU requests cannot be greater than CPU limits'
+    );
+  });
+
+  test('validation becomes invalid when memoryRequest exceeds memoryLimit', async () => {
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ memoryRequest: 1024, memoryLimit: 256 });
+    });
+
+    expect(result.current.validation.isValid).toBe(false);
+  });
+
+  // --- handleSave ---
+
+  test('handleSave calls updateManagedNamespace with correct arguments and advances baseline', async () => {
+    mockUpdateManagedNamespace.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'DenyAll' });
+    });
+
+    expect(result.current.hasChanges).toBe(true);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockUpdateManagedNamespace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterName: 'my-cluster',
+        resourceGroup: 'rg-prod',
+        namespaceName: 'my-project',
+        ingressPolicy: 'DenyAll',
+      })
+    );
+    // Baseline advances so hasChanges resets
+    expect(result.current.hasChanges).toBe(false);
+  });
+
+  test('handleSave sets error and leaves updating false when updateManagedNamespace throws', async () => {
+    mockUpdateManagedNamespace.mockRejectedValue(new Error('update failed'));
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'DenyAll' });
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(result.current.error).toBe('Failed to update managed namespace');
+    expect(result.current.updating).toBe(false);
+  });
+
+  test('handleSave clears a previous error on success', async () => {
+    mockUpdateManagedNamespace.mockRejectedValueOnce(new Error('update failed'));
+    mockUpdateManagedNamespace.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'DenyAll' });
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(result.current.error).toBe('Failed to update managed namespace');
+
+    act(() => {
+      result.current.handleFormDataChange({ ingress: 'AllowAll' });
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(mockUpdateManagedNamespace).toHaveBeenCalledTimes(2);
+  });
+
+  test('handleSave is a no-op when resourceGroup label is absent', async () => {
+    mockUseGet.mockReturnValue([{ jsonData: { metadata: { labels: {} } } }]);
+
+    const { result } = renderHook(() => useInfoTab(defaultProject));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockUpdateManagedNamespace).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/aks-desktop/src/components/InfoTab/hooks/useInfoTab.ts
+++ b/plugins/aks-desktop/src/components/InfoTab/hooks/useInfoTab.ts
@@ -1,0 +1,295 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  getManagedNamespaceDetails,
+  getManagedNamespaces,
+  updateManagedNamespace,
+} from '../../../utils/azure/az-cli';
+import {
+  DEFAULT_FORM_DATA,
+  type FormData,
+  type ValidationState,
+} from '../../CreateAKSProject/types';
+import {
+  validateComputeQuota,
+  validateNetworkingPolicies,
+} from '../../CreateAKSProject/validators';
+
+// Pure helpers — module-level so they are never recreated on re-renders.
+
+function normalizePolicy(value: string): FormData['ingress'] {
+  const allowed: Record<FormData['ingress'], true> = {
+    AllowSameNamespace: true,
+    AllowAll: true,
+    DenyAll: true,
+  };
+  return (value as FormData['ingress']) in allowed
+    ? (value as FormData['ingress'])
+    : 'AllowSameNamespace';
+}
+
+function parseMillicores(val: string): number {
+  const n = parseInt(String(val).replace(/m$/i, ''), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function parseMiB(val: string): number {
+  const n = parseInt(String(val).replace(/Mi$/i, ''), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * The shape of namespace details returned from the Azure CLI.
+ */
+export interface NamespaceDetails {
+  properties?: {
+    defaultNetworkPolicy?: {
+      ingress?: string;
+      egress?: string;
+    };
+    defaultResourceQuota?: {
+      cpuRequest?: string;
+      cpuLimit?: string;
+      memoryRequest?: string;
+      memoryLimit?: string;
+    };
+  };
+}
+
+/**
+ * Return type for the {@link useInfoTab} hook.
+ */
+export interface UseInfoTabResult {
+  /** Whether the initial namespace details fetch is in progress. */
+  loading: boolean;
+  /** Whether an update operation is in progress. */
+  updating: boolean;
+  /** Error message if fetch or update failed, otherwise null. */
+  error: string | null;
+  /** The fetched managed namespace details, or null if unavailable or not yet loaded. */
+  namespaceDetails: NamespaceDetails | null;
+  /** Current form field values. */
+  formData: FormData;
+  /** Current validation state of the form. */
+  validation: ValidationState;
+  /** Whether the form has unsaved changes relative to the last saved state. */
+  hasChanges: boolean;
+  /** Updates form fields and re-validates. */
+  handleFormDataChange: (updates: Partial<FormData>) => void;
+  /** Persists the current form data to the managed namespace. */
+  handleSave: () => Promise<void>;
+}
+
+/**
+ * Manages data fetching, form state, validation, and save logic for the InfoTab component.
+ *
+ * Fetches managed namespace details from the Azure CLI and pre-populates the networking
+ * and compute quota form fields. Provides handlers for form changes and persisting updates.
+ *
+ * @param project - The project whose first cluster and namespace are used for Azure CLI calls.
+ * @returns State and handlers for the InfoTab component to render.
+ */
+export const useInfoTab = (project: {
+  clusters: string[];
+  namespaces: string[];
+  id: string;
+}): UseInfoTabResult => {
+  const { t } = useTranslation();
+
+  // Destructure stable primitives so the effects below don't re-run on
+  // every render when the caller passes a new project object reference.
+  const clusterName = project.clusters[0];
+  const projectId = project.id;
+
+  const [namespaceInstance] = K8s.ResourceClasses.Namespace.useGet(
+    project.namespaces[0],
+    undefined,
+    { cluster: clusterName }
+  );
+  const subscription =
+    namespaceInstance?.jsonData?.metadata?.labels?.['aks-desktop/project-subscription'];
+  const resourceGroup =
+    namespaceInstance?.jsonData?.metadata?.labels?.['aks-desktop/project-resource-group'];
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [namespaceDetails, setNamespaceDetails] = useState<NamespaceDetails | null>(null);
+  const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
+  const [baselineFormData, setBaselineFormData] = useState<FormData | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [validation, setValidation] = useState<ValidationState>({
+    isValid: true,
+    errors: [],
+    warnings: [],
+    fieldErrors: {},
+  });
+
+  // Fetch managed namespace details from Azure CLI
+  useEffect(() => {
+    let isMounted = true;
+    if (!clusterName || !resourceGroup) {
+      setLoading(false);
+      setError(null);
+      setNamespaceDetails(null);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        let nsList: string[];
+        try {
+          nsList = await getManagedNamespaces({
+            clusterName,
+            resourceGroup,
+            subscriptionId: subscription,
+          });
+        } catch (e) {
+          console.error(e);
+          if (isMounted) {
+            setError(t('Failed to fetch managed namespaces'));
+            setNamespaceDetails(null);
+          }
+          return;
+        }
+
+        if (nsList.length === 0) {
+          if (isMounted) setNamespaceDetails(null);
+          return;
+        }
+
+        try {
+          const details = await getManagedNamespaceDetails({
+            clusterName,
+            resourceGroup,
+            namespaceName: projectId,
+            subscriptionId: subscription,
+          });
+          if (isMounted) setNamespaceDetails(details);
+        } catch (e) {
+          console.error(e);
+          if (isMounted) {
+            setError(t('Failed to fetch managed namespace details'));
+            setNamespaceDetails(null);
+          }
+        }
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [clusterName, projectId, subscription, resourceGroup, t]);
+
+  // Pre-populate form when namespace details are fetched
+  useEffect(() => {
+    if (!namespaceDetails) return;
+
+    const quota = namespaceDetails.properties?.defaultResourceQuota;
+    const policy = namespaceDetails.properties?.defaultNetworkPolicy;
+
+    const populated: FormData = {
+      ...DEFAULT_FORM_DATA,
+      ingress: normalizePolicy(policy?.ingress ?? 'AllowSameNamespace'),
+      egress: normalizePolicy(policy?.egress ?? 'AllowAll'),
+      cpuRequest: parseMillicores(quota?.cpuRequest ?? '0m'),
+      cpuLimit: parseMillicores(quota?.cpuLimit ?? '0m'),
+      memoryRequest: parseMiB(quota?.memoryRequest ?? '0Mi'),
+      memoryLimit: parseMiB(quota?.memoryLimit ?? '0Mi'),
+    };
+
+    setFormData(populated);
+    setBaselineFormData(populated);
+  }, [namespaceDetails]);
+
+  const handleFormDataChange = useCallback((updates: Partial<FormData>) => {
+    setFormData(prev => {
+      const next = { ...prev, ...updates };
+
+      const compute = validateComputeQuota({
+        cpuRequest: next.cpuRequest,
+        cpuLimit: next.cpuLimit,
+        memoryRequest: next.memoryRequest,
+        memoryLimit: next.memoryLimit,
+      });
+      const networking = validateNetworkingPolicies({
+        ingress: next.ingress,
+        egress: next.egress,
+      });
+
+      const fieldErrors: Record<string, string[]> = {};
+      if (compute.fieldErrors) Object.assign(fieldErrors, compute.fieldErrors);
+      if (!networking.isValid) fieldErrors.networking = networking.errors;
+
+      setValidation({
+        isValid: compute.isValid && networking.isValid,
+        errors: [...(compute.errors || []), ...(networking.errors || [])],
+        warnings: [],
+        fieldErrors,
+      });
+
+      return next;
+    });
+  }, []);
+
+  const hasChanges = useMemo(() => {
+    if (!baselineFormData) return false;
+    const keys: (keyof FormData)[] = [
+      'ingress',
+      'egress',
+      'cpuRequest',
+      'cpuLimit',
+      'memoryRequest',
+      'memoryLimit',
+    ];
+    return keys.some(k => formData[k] !== baselineFormData[k]);
+  }, [baselineFormData, formData]);
+
+  const handleSave = useCallback(async () => {
+    if (!resourceGroup || !clusterName || !projectId) return;
+
+    try {
+      setUpdating(true);
+      await updateManagedNamespace({
+        clusterName,
+        resourceGroup,
+        namespaceName: projectId,
+        ingressPolicy: formData.ingress,
+        egressPolicy: formData.egress,
+        cpuRequest: formData.cpuRequest,
+        cpuLimit: formData.cpuLimit,
+        memoryRequest: formData.memoryRequest,
+        memoryLimit: formData.memoryLimit,
+        noWait: false,
+      });
+      setBaselineFormData(formData);
+      setError(null);
+    } catch (e) {
+      console.error('Failed to update managed namespace', e);
+      setError(t('Failed to update managed namespace'));
+    } finally {
+      setUpdating(false);
+    }
+  }, [resourceGroup, clusterName, projectId, formData, t]);
+
+  return {
+    loading,
+    updating,
+    error,
+    namespaceDetails,
+    formData,
+    validation,
+    hasChanges,
+    handleFormDataChange,
+    handleSave,
+  };
+};


### PR DESCRIPTION
This PR extracts data fetching, form state, validation, and save logic from `InfoTab` into a dedicated `useInfoTab` hook, adds 18 unit tests, and skips the `getManagedNamespaceDetails` call when the managed namespace list is empty.

### Summary

- Extracts data fetching, form state, validation, and save logic from `InfoTab` into a dedicated `useInfoTab` hook
- Fetches `getManagedNamespaceDetails` only after confirming the namespace list is non-empty, avoiding a redundant az-cli call
- Adds 18 unit tests covering loading state, guard conditions, form population, validation, `hasChanges` tracking, and save behavior

Fixes: #119 

### Testing

- [x] Run `cd plugins/aks-desktop && npm test` and ensure the tests pass

### Screenshot

<img width="2123" height="1266" alt="image" src="https://github.com/user-attachments/assets/6686fc58-355c-4fc8-b062-ca1c1a6dd1f4" />
