### PR TITLE
aksd: Remove azure format from get-credentials

### DIFF
--- a/app/electron/aks-cluster.ts
+++ b/app/electron/aks-cluster.ts
@@ -250,7 +250,7 @@ export async function registerAKSCluster(
   const tempKubeconfigPath = path.join(os.tmpdir(), `kubeconfig-${Date.now()}.yaml`);
 
   try {
-    // Step 1: Get the kubeconfig to a temporary file with --format azure
+    // Step 1: Get the kubeconfig to a temporary file
     // Use namespace get-credentials if a managed namespace is provided
     const args: string[] = ['aks'];
 
@@ -282,9 +282,7 @@ export async function registerAKSCluster(
         '--resource-group',
         resourceGroup,
         '--name',
-        clusterName,
-        '--format',
-        'azure'
+        clusterName
       );
     }
 


### PR DESCRIPTION


## Description
Removes "--format azure" from "az aks get-credentials" to allow 
kubeconfig generation compatible with the custom kubelogin 
conversion step.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #342 


