### PR TITLE
plugins/aks-desktop: CreateAKSProject: Make errors more accessible

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
@@ -653,12 +653,20 @@ function CreateAKSProject() {
                     </Box>
                     {/* Scrollable error content */}
                     <Box
+                      tabIndex={0}
+                      role="region"
+                      aria-label={t('Error details')}
                       sx={{
                         flex: 1,
                         overflowY: 'auto',
                         mb: 2,
                         minHeight: '100px',
                         maxHeight: '400px',
+                        '&:focus': {
+                          outline: '2px solid',
+                          outlineColor: theme => theme.palette.error.main,
+                          outlineOffset: '2px',
+                        },
                       }}
                     >
                       <Typography

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ReviewStep.tsx
@@ -177,13 +177,22 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({ formData, subscriptions,
               })}
             </Typography>
             <Box
-              sx={{
+              tabIndex={0}
+              role="region"
+              aria-label={t('Access Control ({{count}} assignee)', {
+                count: formData.userAssignments.length,
+              })}
+              sx={theme => ({
                 maxHeight: '200px',
                 overflowY: 'auto',
                 border: '1px solid #e0e0e0',
                 borderRadius: 1,
                 p: 1,
-              }}
+                '&:focus': {
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: '2px',
+                },
+              })}
             >
               {formData.userAssignments.map((assignment, idx) => (
                 <Box


### PR DESCRIPTION
- Have a focus outline.
- Make errors keyboard scrollable.
- Also add an aria title.

Keyboard-only users couldn't Tab into scrollable regions (project creation failure panel, access control assignees list in Review step), making full error content unreachable without a mouse.

Fixes #300
- https://github.com/Azure/aks-desktop/issues/300


## Description

Adds `tabIndex={0}`, `role="region"`, `aria-label`, and a visible `:focus` outline to the two scrollable `Box` containers that were previously keyboard-inaccessible. Once focused, users can scroll with Arrow keys, Page Up/Down, and Home/End.

```tsx
<Box
  tabIndex={0}
  role="region"
  aria-label={t('Error details')}
  sx={{
    overflowY: 'auto',
    '&:focus': { outline: '2px solid', outlineColor: 'error.main', outlineOffset: '2px' },
  }}
>
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: ****___****

## Related Issues

## Changes Made

- `CreateAKSProject.tsx`: `tabIndex={0}` + `role="region"` + `aria-label` + focus outline on the scrollable error details panel
- `ReviewStep.tsx`: same treatment on the scrollable access control assignees list

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [x] Accessibility tested (if applicable)

### Test Cases

1. Tab to the error panel after a failed project creation — focus lands on the region and a visible outline appears; Arrow keys / Page Up/Down scroll the content
2. Tab to the Access Control list in the Review step — same focus and scroll behavior
3. Screen reader announces the region label on focus

## Screenshots/Videos

If applicable, add screenshots or videos to demonstrate the changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why this is acceptable)

## Documentation Updates

- [ ] README.md updated
- [ ] API documentation updated
- [ ] Code comments updated
- [ ] User guide updated
- [x] No documentation updates needed

## Reviewer Notes

Both scrollable containers now receive the same accessibility treatment for consistency. Focus outline color matches the context: `error.main` for the failure panel, `primary.main` for the access control list.
