### PR TITLE
plugins/aks-desktop: Clean up console.log statements

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
@@ -87,7 +87,7 @@ function CreateAKSProject() {
   useEffect(() => {
     (async () => {
       const azureCheck = await checkAzureCliAndAksPreview();
-      console.log('Azure CLI check results:', azureCheck);
+      console.debug('Azure CLI check results:', azureCheck);
       setCliSuggestions(azureCheck.suggestions);
     })();
   }, []);
@@ -153,8 +153,8 @@ function CreateAKSProject() {
 
   const handleSubmit = async () => {
     try {
-      console.log('handleSubmit', formData);
-      console.log('Selected cluster details:', {
+      console.debug('handleSubmit', formData);
+      console.debug('Selected cluster details:', {
         name: formData.cluster,
         resourceGroup: formData.resourceGroup,
         subscription: formData.subscription,
@@ -209,15 +209,8 @@ function CreateAKSProject() {
         }
 
         setCreationProgress(`${t('Namespace creation initiated! Monitoring creation status')}...`);
-        console.log('🚀 Namespace creation initiated for:', {
-          cluster: formData.cluster,
-          resourceGroup: formData.resourceGroup,
-          namespace: formData.projectName,
-          subscription: formData.subscription,
-        });
 
         // Give the namespace a moment to propagate before verification
-        console.log('⏳ Waiting 5 seconds for namespace to propagate...');
         setCreationProgress(`${t('Waiting for namespace to propagate')}...`);
         await new Promise(resolve => setTimeout(resolve, 5000));
 
@@ -229,12 +222,6 @@ function CreateAKSProject() {
 
         while (!namespaceVerified && retryCount < maxRetries) {
           try {
-            console.log(`🔍 Verification attempt ${retryCount + 1}:`);
-            console.log(`   Cluster: ${formData.cluster}`);
-            console.log(`   Resource Group: ${formData.resourceGroup}`);
-            console.log(`   Namespace: ${formData.projectName}`);
-            console.log(`   Subscription: ${formData.subscription}`);
-
             // Call the check function directly instead of using the hook
             const result = await checkNamespaceExists(
               formData.cluster,
@@ -243,11 +230,7 @@ function CreateAKSProject() {
               formData.subscription
             );
 
-            console.log(`   Direct result exists: ${result.exists}`);
-            console.log(`   Direct result error: ${result.error || 'None'}`);
-
             if (result.error) {
-              console.log(`   ❌ Namespace check error: ${result.error}`);
               throw new Error(
                 t('Namespace status check failed: {{message}}', { message: result.error })
               );
@@ -255,19 +238,14 @@ function CreateAKSProject() {
 
             if (result.exists === true) {
               namespaceVerified = true;
-              console.log('✅ Namespace verified successfully');
             } else {
               retryCount++;
               if (retryCount < maxRetries) {
-                console.log(`⏳ Namespace not found yet, retrying in ${retryDelay / 1000}s...`);
                 setCreationProgress(`${t('Waiting for namespace to be created')}...`);
                 await new Promise(resolve => setTimeout(resolve, retryDelay));
-              } else {
-                console.log(`❌ Max retries reached, namespace still not found`);
               }
             }
           } catch (statusError) {
-            console.log(`❌ Verification attempt failed:`, statusError.message);
             throw new Error(
               t('Namespace status verification failed: {{message}}', {
                 message: statusError.message,
@@ -277,10 +255,7 @@ function CreateAKSProject() {
         }
 
         if (!namespaceVerified) {
-          console.log('⚠️ Namespace verification failed, but continuing with creation process...');
-          console.log('   This might be due to timing issues with Azure API propagation.');
-          console.log('   The namespace creation API call succeeded, so we will proceed.');
-          // Don't throw error, just log warning and continue
+          // Don't throw error, just continue - namespace creation API call succeeded
           setCreationProgress(
             `${t('Namespace creation API succeeded, proceeding with user assignments')}...`
           );
@@ -455,9 +430,7 @@ function CreateAKSProject() {
 
             if (result.exists) {
               finalVerified = true;
-              console.log('✅ Final namespace verification successful');
             } else if (attempt === 0) {
-              console.log('⏳ Final verification: namespace not found, retrying once...');
               await new Promise(resolve => setTimeout(resolve, 2000)); // 2 second delay
             }
           } catch (finalError) {
@@ -467,13 +440,6 @@ function CreateAKSProject() {
               })
             );
           }
-        }
-
-        if (!finalVerified) {
-          console.log('⚠️ Final verification failed, but namespace creation API succeeded');
-          console.log('   This might be due to timing issues with Azure API propagation.');
-          console.log('   The project creation process will be marked as successful.');
-          // Don't throw error, just log warning and continue
         }
 
         setCreationProgress(t('All verifications completed successfully!'));
@@ -781,7 +747,7 @@ function CreateAKSProject() {
                             const projectName = encodeURIComponent(formData.projectName);
                             const appName = encodeURIComponent(applicationName.trim());
                             const projectUrl = `/project/${projectName}?openDeploy=true&applicationName=${appName}`;
-                            console.log('navigating to project page', projectUrl);
+                            console.debug('navigating to project page', projectUrl);
                             history.push(projectUrl);
                           }
                         }}

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -501,16 +501,16 @@ function RegisterCluster({
 
     try {
       // Register the cluster by running az aks get-credentials and setting up kubeconfig
-      console.log('[AKS] Registering cluster...');
+      console.debug('[AKS] Registering cluster...');
       const result = await registerAKSCluster(subscription, resourceGroup, cluster);
-      console.log('[AKS] Register cluster result:', result);
+      console.debug('[AKS] Register cluster result:', result);
       if (!result.success) {
         setError(result.message);
         setLoading(false);
         return;
       }
 
-      console.log('[AKS] Cluster registered successfully:', result.message);
+      console.debug('[AKS] Cluster registered successfully:', result.message);
       setSuccess(t("Cluster '{{cluster}}' successfully merged in kubeconfig", { cluster }));
       setLoading(false);
     } catch (err) {

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useNamespaceCheck.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useNamespaceCheck.ts
@@ -35,7 +35,7 @@ export const useNamespaceCheck = () => {
       try {
         setStatus(prev => ({ ...prev, checking: true, error: null }));
 
-        console.log('🔍 Checking namespace existence:', {
+        console.debug('Checking namespace existence:', {
           cluster: clusterName,
           resourceGroup,
           namespace: namespaceName,
@@ -49,7 +49,7 @@ export const useNamespaceCheck = () => {
           subscriptionId
         );
 
-        console.log('📋 Namespace check result:', result);
+        console.debug('Namespace check result:', result);
 
         if (result.error) {
           setStatus(prev => ({

--- a/plugins/aks-desktop/src/components/DeleteAKSProject/AKSProjectDeleteButton.tsx
+++ b/plugins/aks-desktop/src/components/DeleteAKSProject/AKSProjectDeleteButton.tsx
@@ -64,7 +64,7 @@ const AKSProjectDeleteButton: React.FC<AKSProjectDeleteButtonProps> = ({ project
           const editable = updateAuth?.status?.allowed ?? false;
           const deletable = deleteAuth?.status?.allowed ?? false;
 
-          console.log(`Namespace permissions for ${namespaceName}:`, {
+          console.debug(`Namespace permissions for ${namespaceName}:`, {
             namespace: namespaceName,
             update: updateAuth,
             delete: deleteAuth,

--- a/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
+++ b/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
@@ -209,7 +209,7 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
             .map(([key, value]) => `${key}=${value}`)
             .join(',');
 
-          console.log('MetricsTab: Using label selector for pods:', labelSelector);
+          console.debug('MetricsTab: Using label selector for pods:', labelSelector);
 
           // Now use the deployment's selector to find pods
           K8s.ResourceClasses.Pod.apiList(

--- a/plugins/aks-desktop/src/components/MetricsTab/getPrometheusEndpoint.tsx
+++ b/plugins/aks-desktop/src/components/MetricsTab/getPrometheusEndpoint.tsx
@@ -13,11 +13,11 @@ export async function getPrometheusEndpoint(
   try {
     // Configure Azure CLI to auto-install extensions without prompts
     // This allows the az alerts-management command to automatically install the extension if needed
-    console.log('Configuring Azure CLI for automatic extension installation...');
+    console.debug('Configuring Azure CLI for automatic extension installation...');
     await configureAzureCliExtensions();
 
-    console.log('[getPrometheusEndpoint] Querying prometheus rule groups...');
-    console.log('[getPrometheusEndpoint] Parameters:', {
+    console.debug('[getPrometheusEndpoint] Querying prometheus rule groups...');
+    console.debug('[getPrometheusEndpoint] Parameters:', {
       resourceGroup,
       clusterName,
       subscription,
@@ -37,9 +37,9 @@ export async function getPrometheusEndpoint(
       subscription,
     ]);
 
-    console.log('[getPrometheusEndpoint] All rule groups query result:');
-    console.log('[getPrometheusEndpoint]   stdout length:', allGroupsStdout.length);
-    console.log('[getPrometheusEndpoint]   stderr:', allGroupsStderr);
+    console.debug('[getPrometheusEndpoint] All rule groups query result:');
+    console.debug('[getPrometheusEndpoint]   stdout length:', allGroupsStdout.length);
+    console.debug('[getPrometheusEndpoint]   stderr:', allGroupsStderr);
 
     if (!allGroupsStdout.trim()) {
       throw new Error(
@@ -52,8 +52,8 @@ export async function getPrometheusEndpoint(
     let ruleGroups;
     try {
       ruleGroups = JSON.parse(allGroupsStdout);
-      console.log('[getPrometheusEndpoint] Found', ruleGroups.length, 'rule groups');
-      console.log(
+      console.debug('[getPrometheusEndpoint] Found', ruleGroups.length, 'rule groups');
+      console.debug(
         '[getPrometheusEndpoint] Rule group names:',
         ruleGroups.map((rg: any) => ({
           name: rg.name,
@@ -82,7 +82,7 @@ export async function getPrometheusEndpoint(
       );
     }
 
-    console.log('[getPrometheusEndpoint] Found matching rule group:', matchingGroup.name);
+    console.debug('[getPrometheusEndpoint] Found matching rule group:', matchingGroup.name);
 
     // Get the workspace scope from the first scope
     const workspaceScope = matchingGroup.scopes?.[0];
@@ -90,7 +90,7 @@ export async function getPrometheusEndpoint(
       throw new Error('Rule group has no scopes defined');
     }
 
-    console.log('[getPrometheusEndpoint] Found workspace scope:', workspaceScope);
+    console.debug('[getPrometheusEndpoint] Found workspace scope:', workspaceScope);
 
     const { stdout: endpointStdout } = await runCommandWithOutput('az', [
       'monitor',
@@ -106,7 +106,7 @@ export async function getPrometheusEndpoint(
       subscription,
     ]);
 
-    console.log('[getPrometheusEndpoint] Prometheus endpoint:', endpointStdout.trim());
+    console.debug('[getPrometheusEndpoint] Prometheus endpoint:', endpointStdout.trim());
 
     return endpointStdout.trim();
   } catch (error) {

--- a/plugins/aks-desktop/src/utils/azure/aks.ts
+++ b/plugins/aks-desktop/src/utils/azure/aks.ts
@@ -98,7 +98,7 @@ export async function registerAKSCluster(
   message: string;
 }> {
   try {
-    console.log(
+    console.debug(
       '[AKS] Registering cluster:',
       clusterName,
       managedNamespace ? `with managed namespace: ${managedNamespace}` : ''
@@ -123,7 +123,7 @@ export async function registerAKSCluster(
       managedNamespace
     );
 
-    console.log('[AKS] Registration result:', result);
+    console.debug('[AKS] Registration result:', result);
     return result;
   } catch (error) {
     console.error('[AKS] Error registering AKS cluster:', error);

--- a/plugins/aks-desktop/src/utils/azure/az-cli-path.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-cli-path.ts
@@ -34,20 +34,20 @@ function getPlatform(): string {
  */
 export function getBundledAzPath(): string | null {
   if (!isElectron()) {
-    console.log('[AZ-CLI] Not running in Electron');
+    console.debug('[AZ-CLI] Not running in Electron');
     return null;
   }
 
   try {
     const platform = getPlatform();
-    console.log('[AZ-CLI] Platform detected:', platform);
+    console.debug('[AZ-CLI] Platform detected:', platform);
 
     // Get resources path from Electron
     // In production: process.resourcesPath
     // In development: we won't have bundled CLI
     if (typeof process !== 'undefined' && (process as any).resourcesPath) {
       const resourcesPath = (process as any).resourcesPath;
-      console.log('[AZ-CLI] Resources path:', resourcesPath);
+      console.debug('[AZ-CLI] Resources path:', resourcesPath);
 
       let fs: any = null;
       try {
@@ -61,9 +61,9 @@ export function getBundledAzPath(): string | null {
       if (platform === 'win32') {
         // Windows: Use .cmd wrapper
         const azPath = `${resourcesPath}/az-cli/bin/az.cmd`;
-        console.log('[AZ-CLI] Checking bundled Windows path:', azPath);
+        console.debug('[AZ-CLI] Checking bundled Windows path:', azPath);
         if (fs && fs.existsSync(azPath)) {
-          console.log('[AZ-CLI] ✅ Found bundled Windows Azure CLI');
+          console.debug('[AZ-CLI] ✅ Found bundled Windows Azure CLI');
           return azPath;
         } else {
           console.warn('[AZ-CLI] ❌ Bundled Windows Azure CLI not found at:', azPath);
@@ -73,14 +73,14 @@ export function getBundledAzPath(): string | null {
         const wrapperPath = `${resourcesPath}/az-cli/bin/az-wrapper`;
         const directPath = `${resourcesPath}/az-cli/bin/az`;
 
-        console.log('[AZ-CLI] Checking bundled macOS paths:', { wrapperPath, directPath });
+        console.debug('[AZ-CLI] Checking bundled macOS paths:', { wrapperPath, directPath });
 
         if (fs) {
           if (fs.existsSync(wrapperPath)) {
-            console.log('[AZ-CLI] ✅ Found bundled macOS portable install (wrapper)');
+            console.debug('[AZ-CLI] ✅ Found bundled macOS portable install (wrapper)');
             return wrapperPath;
           } else if (fs.existsSync(directPath)) {
-            console.log('[AZ-CLI] ✅ Found bundled macOS binary (direct)');
+            console.debug('[AZ-CLI] ✅ Found bundled macOS binary (direct)');
             return directPath;
           } else {
             console.warn(
@@ -92,7 +92,7 @@ export function getBundledAzPath(): string | null {
           }
         } else {
           // No fs available, return wrapper path and hope it exists
-          console.log('[AZ-CLI] No fs module, returning wrapper path');
+          console.debug('[AZ-CLI] No fs module, returning wrapper path');
           return wrapperPath;
         }
       } else if (platform === 'linux') {
@@ -100,14 +100,14 @@ export function getBundledAzPath(): string | null {
         const wrapperPath = `${resourcesPath}/az-cli/bin/az-wrapper`;
         const directPath = `${resourcesPath}/az-cli/bin/az`;
 
-        console.log('[AZ-CLI] Checking bundled Linux paths:', { wrapperPath, directPath });
+        console.debug('[AZ-CLI] Checking bundled Linux paths:', { wrapperPath, directPath });
 
         if (fs) {
           if (fs.existsSync(wrapperPath)) {
-            console.log('[AZ-CLI] ✅ Found bundled Linux portable install (wrapper)');
+            console.debug('[AZ-CLI] ✅ Found bundled Linux portable install (wrapper)');
             return wrapperPath;
           } else if (fs.existsSync(directPath)) {
-            console.log('[AZ-CLI] ✅ Found bundled Linux binary (direct)');
+            console.debug('[AZ-CLI] ✅ Found bundled Linux binary (direct)');
             return directPath;
           } else {
             console.warn(
@@ -119,7 +119,7 @@ export function getBundledAzPath(): string | null {
           }
         } else {
           // No fs available, return wrapper path and hope it exists
-          console.log('[AZ-CLI] No fs module, returning wrapper path');
+          console.debug('[AZ-CLI] No fs module, returning wrapper path');
           return wrapperPath;
         }
       }
@@ -130,7 +130,7 @@ export function getBundledAzPath(): string | null {
     console.error('[AZ-CLI] Error detecting bundled path:', error);
   }
 
-  console.log('[AZ-CLI] No bundled Azure CLI found, will fall back to system CLI');
+  console.debug('[AZ-CLI] No bundled Azure CLI found, will fall back to system CLI');
   return null;
 }
 

--- a/plugins/aks-desktop/src/utils/azure/az-cli.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-cli.ts
@@ -15,7 +15,7 @@ const DEBUG_LOGS = process.env.NODE_ENV === 'development' || process.env.DEBUG_A
 // Helper function for debug logging
 const debugLog = (...args: any[]) => {
   if (DEBUG_LOGS) {
-    console.log(...args);
+    console.debug(...args);
   }
 };
 
@@ -50,8 +50,7 @@ export function runCommandAsync(
 export async function isAzCliInstalled(): Promise<boolean> {
   try {
     const { stdout, stderr } = await runCommandAsync('az', ['version']);
-    console.debug('Azure CLI version check:', stderr, stdout);
-    console.log('Azure CLI version check:', stderr, stdout);
+    debugLog('Azure CLI version check:', stderr, stdout);
 
     // Check if stderr contains "command not found" or "not found" messages
     if (
@@ -60,7 +59,7 @@ export async function isAzCliInstalled(): Promise<boolean> {
         stderr.includes('not found') ||
         stderr.includes('Azure CLI (az) command not found'))
     ) {
-      console.log('Azure CLI not found in PATH');
+      debugLog('Azure CLI not found in PATH');
       return false;
     }
 
@@ -69,18 +68,18 @@ export async function isAzCliInstalled(): Promise<boolean> {
       try {
         const versionData = JSON.parse(stdout);
         if (versionData['azure-cli']) {
-          console.log('Azure CLI found, version:', versionData['azure-cli']);
+          debugLog('Azure CLI found, version:', versionData['azure-cli']);
           return true; // Azure CLI is installed
         } else {
-          console.log('Azure CLI version not detected in JSON output');
+          debugLog('Azure CLI version not detected in JSON output');
           return false;
         }
       } catch (parseError) {
-        console.log('Failed to parse Azure CLI version JSON:', parseError);
+        debugLog('Failed to parse Azure CLI version JSON:', parseError);
         return false;
       }
     } else {
-      console.log('Azure CLI version not detected in output');
+      debugLog('Azure CLI version not detected in output');
       return false; // Azure CLI not found
     }
   } catch (error) {
@@ -167,19 +166,19 @@ export async function isAlertsManagementExtensionInstalled(): Promise<{
       'alertsmanagement',
     ]);
 
-    console.log('[AZ-CLI] alertsmanagement extension check - stdout:', stdout);
-    console.log('[AZ-CLI] alertsmanagement extension check - stderr:', stderr);
+    debugLog('[AZ-CLI] alertsmanagement extension check - stdout:', stdout);
+    debugLog('[AZ-CLI] alertsmanagement extension check - stderr:', stderr);
 
     if (stderr && stderr.includes('not installed')) {
-      console.log('[AZ-CLI] alertsmanagement extension is NOT installed');
+      debugLog('[AZ-CLI] alertsmanagement extension is NOT installed');
       return { installed: false };
     }
 
-    console.log('[AZ-CLI] alertsmanagement extension is installed');
+    debugLog('[AZ-CLI] alertsmanagement extension is installed');
     return { installed: true };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.log('[AZ-CLI] alertsmanagement extension check - error:', errorMessage);
+    debugLog('[AZ-CLI] alertsmanagement extension check - error:', errorMessage);
     if (errorMessage.includes('not installed')) {
       return { installed: false };
     }
@@ -195,7 +194,7 @@ export async function installAlertsManagementExtension(): Promise<{
   error?: string;
 }> {
   try {
-    console.log('[AZ-CLI] Installing alertsmanagement extension...');
+    debugLog('[AZ-CLI] Installing alertsmanagement extension...');
     const { stdout, stderr } = await runCommandAsync('az', [
       'extension',
       'add',
@@ -205,11 +204,11 @@ export async function installAlertsManagementExtension(): Promise<{
       'true',
     ]);
 
-    console.log('[AZ-CLI] alertsmanagement extension install - stdout:', stdout);
-    console.log('[AZ-CLI] alertsmanagement extension install - stderr:', stderr);
+    debugLog('[AZ-CLI] alertsmanagement extension install - stdout:', stdout);
+    debugLog('[AZ-CLI] alertsmanagement extension install - stderr:', stderr);
 
     if (stderr && (stderr.includes('ERROR') || stderr.includes('error'))) {
-      console.log('[AZ-CLI] alertsmanagement extension installation FAILED');
+      debugLog('[AZ-CLI] alertsmanagement extension installation FAILED');
       return {
         success: false,
         stdout,
@@ -218,7 +217,7 @@ export async function installAlertsManagementExtension(): Promise<{
       };
     }
 
-    console.log('[AZ-CLI] alertsmanagement extension installed successfully');
+    debugLog('[AZ-CLI] alertsmanagement extension installed successfully');
     return {
       success: true,
       stdout,
@@ -226,7 +225,7 @@ export async function installAlertsManagementExtension(): Promise<{
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.log('[AZ-CLI] alertsmanagement extension install - error:', errorMessage);
+    debugLog('[AZ-CLI] alertsmanagement extension install - error:', errorMessage);
     return {
       success: false,
       stdout: '',
@@ -242,14 +241,14 @@ export async function configureAzureCliExtensions(): Promise<{
   error?: string;
 }> {
   try {
-    console.log('[AZ-CLI] Configuring Azure CLI to auto-install extensions...');
+    debugLog('[AZ-CLI] Configuring Azure CLI to auto-install extensions...');
 
     const result1 = await runCommandAsync('az', [
       'config',
       'set',
       'extension.use_dynamic_install=yes_without_prompt',
     ]);
-    console.log(
+    debugLog(
       '[AZ-CLI] Config set use_dynamic_install - stdout:',
       result1.stdout,
       'stderr:',
@@ -261,18 +260,18 @@ export async function configureAzureCliExtensions(): Promise<{
       'set',
       'extension.dynamic_install_allow_preview=true',
     ]);
-    console.log(
+    debugLog(
       '[AZ-CLI] Config set allow_preview - stdout:',
       result2.stdout,
       'stderr:',
       result2.stderr
     );
 
-    console.log('[AZ-CLI] Azure CLI extension auto-install configured successfully');
+    debugLog('[AZ-CLI] Azure CLI extension auto-install configured successfully');
     return { success: true };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.log('[AZ-CLI] Failed to configure Azure CLI extensions:', errorMessage);
+    debugLog('[AZ-CLI] Failed to configure Azure CLI extensions:', errorMessage);
     return {
       success: false,
       error: `Failed to configure Azure CLI extensions: ${errorMessage}`,
@@ -429,7 +428,7 @@ export async function isAzCliLoggedIn(): Promise<boolean> {
         stderr.includes('not found') ||
         stderr.includes('Azure CLI (az) command not found'))
     ) {
-      console.log('Azure CLI not found when checking login status');
+      debugLog('Azure CLI not found when checking login status');
       return false;
     }
 
@@ -784,7 +783,7 @@ export async function getClusters(subscriptionId?: string, query?: string): Prom
 }
 
 export async function getResourceGroups(subscriptionId: string): Promise<any[]> {
-  console.log('Fetching resource groups for subscription:', subscriptionId);
+  debugLog('Fetching resource groups for subscription:', subscriptionId);
   const { stdout } = await runCommandAsync('az', [
     'group',
     'list',
@@ -820,7 +819,7 @@ export async function getResourceGroups(subscriptionId: string): Promise<any[]> 
 }
 
 export async function getLocations(subscriptionId: string): Promise<any[]> {
-  console.log('Fetching Azure locations for subscription:', subscriptionId);
+  debugLog('Fetching Azure locations for subscription:', subscriptionId);
   const { stdout, stderr } = await runCommandAsync('az', [
     'account',
     'list-locations',
@@ -864,7 +863,7 @@ export async function getLocations(subscriptionId: string): Promise<any[]> {
 }
 
 export async function getVmSizes(subscriptionId: string, location: string): Promise<any[]> {
-  console.log('Fetching VM sizes for location:', location);
+  debugLog('Fetching VM sizes for location:', location);
   const { stdout, stderr } = await runCommandAsync('az', [
     'vm',
     'list-sizes',
@@ -938,7 +937,7 @@ export async function getAksClusterStatus(options: {
     'json',
   ];
 
-  console.log('Checking AKS cluster status:', 'az', args.join(' '));
+  debugLog('Checking AKS cluster status:', 'az', args.join(' '));
 
   const { stdout, stderr } = await runCommandAsync('az', args);
 
@@ -958,7 +957,7 @@ export async function getAksClusterStatus(options: {
     const kubernetesVersion = result.kubernetesVersion || 'Unknown';
     const ready = provisioningState === 'Succeeded' && powerState === 'Running';
 
-    console.log(
+    debugLog(
       `Cluster status: provisioningState=${provisioningState}, powerState=${powerState}, ready=${ready}`
     );
 
@@ -1104,7 +1103,7 @@ export async function getAksKubeconfig(options: {
     args.push('--file', `~/.kube/config-${clusterName}`);
   }
 
-  console.log('Getting AKS kubeconfig:', 'az', args.join(' '));
+  debugLog('Getting AKS kubeconfig:', 'az', args.join(' '));
 
   const { stderr } = await runCommandAsync('az', args);
 
@@ -1240,7 +1239,7 @@ async function getImagesFromRegistry(subscriptionId: string, registryName: strin
     try {
       // Early termination if we have enough images
       if (allImages.length >= MAX_IMAGES_TOTAL) {
-        console.log(`Limiting results to ${MAX_IMAGES_TOTAL} images for performance`);
+        debugLog(`Limiting results to ${MAX_IMAGES_TOTAL} images for performance`);
         break;
       }
 
@@ -1322,7 +1321,7 @@ export async function getManagedNamespaces(options: {
 
   args.push('--output', 'json');
 
-  console.log('Getting managed namespaces:', 'az', args.join(' '));
+  debugLog('Getting managed namespaces:', 'az', args.join(' '));
 
   const { stdout, stderr } = await runCommandAsync('az', args);
 
@@ -1367,7 +1366,7 @@ export async function getManagedNamespacesForSubscription(subscriptionId: string
 > {
   const args = ['aks', 'namespace', 'list', '--subscription', subscriptionId, '--output', 'json'];
 
-  console.log('Getting managed namespaces for subscription:', 'az', args.join(' '));
+  debugLog('Getting managed namespaces for subscription:', 'az', args.join(' '));
 
   const { stdout, stderr } = await runCommandAsync('az', args);
 
@@ -1381,16 +1380,12 @@ export async function getManagedNamespacesForSubscription(subscriptionId: string
   }
 
   try {
-    console.log('Raw stdout from az aks namespace list:', stdout);
     const result = JSON.parse(stdout || '[]');
-    console.log('Parsed result:', JSON.stringify(result, null, 2));
 
     if (Array.isArray(result)) {
       // Parse the response to extract namespace details
       // The name field is in format "clusterName/namespaceName"
       const mapped = result.map((ns: any) => {
-        console.log('Processing namespace object:', JSON.stringify(ns, null, 2));
-
         // Split the name to get cluster and namespace
         const nameParts = (ns.name || '').split('/');
         const clusterName = nameParts.length > 1 ? nameParts[0] : '';
@@ -1403,14 +1398,11 @@ export async function getManagedNamespacesForSubscription(subscriptionId: string
           properties: ns.properties || {},
         };
       });
-      console.log('Mapped namespaces:', JSON.stringify(mapped, null, 2));
 
       const filtered = mapped.filter(ns => ns.name && ns.clusterName);
-      console.log('Filtered namespaces:', JSON.stringify(filtered, null, 2));
       return filtered;
     }
 
-    console.log('Result is not an array, returning empty array');
     return [];
   } catch (error) {
     console.error('Failed to parse managed namespaces response:', error);
@@ -1447,7 +1439,7 @@ export async function getManagedNamespaceDetails(options: {
 
   args.push('--output', 'json');
 
-  console.log('Getting managed namespace details:', 'az', args.join(' '));
+  debugLog('Getting managed namespace details:', 'az', args.join(' '));
 
   const { stdout, stderr } = await runCommandAsync('az', args);
 
@@ -1596,7 +1588,7 @@ export async function getClusterResourceGroupViaGraph(
     ]);
 
     if (stderr) {
-      console.debug(stderr);
+      debugLog(stderr);
     }
 
     if (stderr && needsRelogin(stderr)) {
@@ -1805,7 +1797,7 @@ export async function getClusterInfo(clusterName?: string): Promise<{
           if (clusters.length > 0) {
             result.clusterName = clusters[0].name;
             result.resourceGroup = clusters[0].resourceGroup;
-            console.log(`Found cluster info for ${clusterName}:`, result);
+            debugLog(`Found cluster info for ${clusterName}:`, result);
           } else {
             console.warn(
               `Cluster ${clusterName} not found in subscription ${result.subscriptionId}`
@@ -1860,7 +1852,7 @@ export async function getClusterInfo(clusterName?: string): Promise<{
           if (clusters.length > 0) {
             result.clusterName = clusters[0].name;
             result.resourceGroup = clusters[0].resourceGroup;
-            console.log('Using first available cluster:', result);
+            debugLog('Using first available cluster:', result);
           }
         }
       } catch (azError) {
@@ -1868,7 +1860,7 @@ export async function getClusterInfo(clusterName?: string): Promise<{
       }
     }
 
-    console.log('Cluster info resolved:', result);
+    debugLog('Cluster info resolved:', result);
     return result;
   } catch (error) {
     console.error('Failed to get cluster info:', error);
@@ -1891,7 +1883,7 @@ export async function getClusterResourceIdAndGroup(
   subscription: string
 ): Promise<{ resourceId: string; resourceGroup: string } | null> {
   if (!clusterName) return null;
-  console.log('cluster name:', clusterName, 'subscription:', subscription);
+  debugLog('cluster name:', clusterName, 'subscription:', subscription);
   const { stdout, stderr } = await runCommandAsync('az', [
     'aks',
     'list',
@@ -1903,8 +1895,8 @@ export async function getClusterResourceIdAndGroup(
     subscription,
   ]);
 
-  console.log('stdout:', stdout);
-  console.log('stderr:', stderr);
+  debugLog('stdout:', stdout);
+  debugLog('stderr:', stderr);
   if (stderr && needsRelogin(stderr)) {
     throw new Error('Authentication required. Please log in to Azure CLI: az login');
   }
@@ -1929,7 +1921,7 @@ export async function getClusterResourceIdAndGroup(
     if (!resourceId) return null;
     return { resourceId, resourceGroup };
   } catch (parseError) {
-    console.log('parseError:', parseError);
+    debugLog('parseError:', parseError);
     throw new Error('Failed to parse AKS list response');
   }
 }

--- a/plugins/aks-desktop/src/utils/kubernetes/cli-runner.ts
+++ b/plugins/aks-desktop/src/utils/kubernetes/cli-runner.ts
@@ -9,7 +9,7 @@ function runCommandAsync(
   command: 'az',
   args: string[]
 ): Promise<{ stdout: string; stderr: string }> {
-  console.log('command called:', command, args);
+  console.debug('command called:', command, args);
   return new Promise(resolve => {
     try {
       const cmd = pluginRunCommand(command, args, {});


### PR DESCRIPTION
These changes replace `console.log` with `console.debug` throughout the plugin code so diagnostic output is hidden by default in browser devtools. They also remove a handful of overly verbose logs (per-retry namespace verification steps, raw JSON dumps) and ensure all debug calls in `az-cli.ts` go through the existing `debugLog` helper to respect the `DEBUG_LOGS` flag.

Fixes: #37 