### PR TITLE
backend: plugins: Add no-cache header for static plugins for local use

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -270,6 +270,11 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	if config.StaticPluginDir != "" {
 		staticPluginsHandler := http.StripPrefix(config.BaseURL+"/static-plugins/",
 			http.FileServer(http.Dir(config.StaticPluginDir)))
+
+		if !config.UseInCluster {
+			staticPluginsHandler = serveWithNoCacheHeader(staticPluginsHandler)
+		}
+
 		r.PathPrefix("/static-plugins/").Handler(staticPluginsHandler)
 	}
 }


### PR DESCRIPTION
Fixes #250
- #250

static-plugins were missing the cache handling, all the other paths have this

How to test:

 1. Build and run the app `cd headlamp/app && npm run build && cd dist/linux-unpacked && ./aks-desktop`
 2. Verify that aks-desktop/package.json and aks-desktop/main.js have `no-cache` in response header