### PR TITLE
Settings: add preview toggle

### DIFF
--- a/plugins/aks-desktop/src/components/PluginSettings/PreviewFeaturesSettings.tsx
+++ b/plugins/aks-desktop/src/components/PluginSettings/PreviewFeaturesSettings.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Box, FormControlLabel, Switch, Typography } from '@mui/material';
+import React from 'react';
+import {
+  PREVIEW_FEATURES_DEFAULTS,
+  type PreviewFeaturesConfig,
+  previewFeaturesStore,
+} from './previewFeaturesStore';
+
+const useStoreConfig = previewFeaturesStore.useConfig();
+
+export default function PreviewFeaturesSettings() {
+  const stored = useStoreConfig();
+  const config: PreviewFeaturesConfig = { ...PREVIEW_FEATURES_DEFAULTS, ...stored };
+
+  function handleToggle(key: keyof PreviewFeaturesConfig, checked: boolean) {
+    previewFeaturesStore.update({ [key]: checked });
+  }
+
+  return (
+    <Box sx={{ maxWidth: 600 }}>
+      <Typography variant="h6">Preview Features</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Enable or disable features that are still in development. Preview features may change or be
+        removed in future releases.
+      </Typography>
+
+      <FormControlLabel
+        control={
+          <Switch
+            checked={config.githubPipelines}
+            onChange={(_e, checked) => handleToggle('githubPipelines', checked)}
+          />
+        }
+        label={
+          <Box>
+            <Typography variant="body1">GitHub Pipelines</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Enable GitHub-based deployment pipelines for AKS projects.
+            </Typography>
+          </Box>
+        }
+        sx={{ alignItems: 'flex-start', ml: 0, mt: 1 }}
+      />
+    </Box>
+  );
+}

--- a/plugins/aks-desktop/src/components/PluginSettings/previewFeaturesStore.ts
+++ b/plugins/aks-desktop/src/components/PluginSettings/previewFeaturesStore.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+
+export interface PreviewFeaturesConfig {
+  githubPipelines: boolean;
+}
+
+export const PREVIEW_FEATURES_DEFAULTS: PreviewFeaturesConfig = {
+  githubPipelines: false,
+};
+
+export const previewFeaturesStore = new ConfigStore<PreviewFeaturesConfig>('aks-desktop');

--- a/plugins/aks-desktop/src/hooks/usePreviewFeatures.test.ts
+++ b/plugins/aks-desktop/src/hooks/usePreviewFeatures.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../components/PluginSettings/previewFeaturesStore', () => {
+  const PREVIEW_FEATURES_DEFAULTS = { githubPipelines: false };
+  let storedConfig: Record<string, unknown> = {};
+  return {
+    PREVIEW_FEATURES_DEFAULTS,
+    previewFeaturesStore: {
+      useConfig: () => () => storedConfig,
+      get: () => storedConfig,
+      update: (partial: Record<string, unknown>) => {
+        storedConfig = { ...storedConfig, ...partial };
+      },
+      _setForTest: (config: Record<string, unknown>) => {
+        storedConfig = config;
+      },
+    },
+  };
+});
+
+import { previewFeaturesStore } from '../components/PluginSettings/previewFeaturesStore';
+import { usePreviewFeatures } from './usePreviewFeatures';
+
+const mockStore = previewFeaturesStore as unknown as {
+  _setForTest: (config: Record<string, unknown>) => void;
+};
+
+describe('usePreviewFeatures', () => {
+  it('returns defaults when store is empty', () => {
+    mockStore._setForTest({});
+
+    const { result } = renderHook(() => usePreviewFeatures());
+
+    expect(result.current).toEqual({ githubPipelines: false });
+  });
+
+  it('returns stored values when present', () => {
+    mockStore._setForTest({ githubPipelines: true });
+
+    const { result } = renderHook(() => usePreviewFeatures());
+
+    expect(result.current).toEqual({ githubPipelines: true });
+  });
+
+  it('merges stored values over defaults', () => {
+    mockStore._setForTest({ githubPipelines: true });
+
+    const { result } = renderHook(() => usePreviewFeatures());
+
+    expect(result.current.githubPipelines).toBe(true);
+  });
+
+  it('falls back to defaults for missing keys', () => {
+    mockStore._setForTest({});
+
+    const { result } = renderHook(() => usePreviewFeatures());
+
+    expect(result.current.githubPipelines).toBe(false);
+  });
+});

--- a/plugins/aks-desktop/src/hooks/usePreviewFeatures.ts
+++ b/plugins/aks-desktop/src/hooks/usePreviewFeatures.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import {
+  PREVIEW_FEATURES_DEFAULTS,
+  type PreviewFeaturesConfig,
+  previewFeaturesStore,
+} from '../components/PluginSettings/previewFeaturesStore';
+
+const useStoreConfig = previewFeaturesStore.useConfig();
+
+export function usePreviewFeatures(): PreviewFeaturesConfig {
+  const stored = useStoreConfig();
+  return { ...PREVIEW_FEATURES_DEFAULTS, ...stored };
+}

--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -7,6 +7,7 @@ import {
   registerAppLogo,
   registerAppTheme,
   registerCustomCreateProject,
+  registerPluginSettings,
   registerProjectDeleteButton,
   registerProjectDetailsTab,
   // @ts-ignore todo: registerProjectHeaderAction is not exported properly
@@ -30,6 +31,7 @@ import AzureLogo from './components/Logo/Logo';
 import LogsTab from './components/LogsTab/LogsTab';
 import MetricsCard from './components/Metrics/MetricsCard';
 import MetricsTab from './components/MetricsTab/MetricsTab';
+import PreviewFeaturesSettings from './components/PluginSettings/PreviewFeaturesSettings';
 import ScalingCard from './components/Scaling/ScalingCard';
 import ScalingTab from './components/ScalingTab/ScalingTab';
 import { getLoginStatus } from './utils/azure/az-cli';
@@ -262,6 +264,8 @@ if (Headlamp.isRunningAsApp()) {
     noAuthRequired: true,
   });
 }
+
+registerPluginSettings('aks-desktop', PreviewFeaturesSettings, false);
 
 registerProjectOverviewSection({
   id: 'cluster-capabilities',


### PR DESCRIPTION
## Description

Add a "Preview Features" settings page for the AKS Desktop plugin using Headlamp's `registerPluginSettings` API. This provides a UI at `/settings/plugins/aks-desktop` where users can toggle preview features on and off. The first toggle controls the **GitHub Pipelines** feature (defaults to disabled).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### New files
- **`src/components/PluginSettings/previewFeaturesStore.ts`** — `ConfigStore<PreviewFeaturesConfig>` instance with `{ githubPipelines: false }` default. Exports the store, interface, and defaults constant.
- **`src/components/PluginSettings/PreviewFeaturesSettings.tsx`** — Settings UI with a "Preview Features" section header, explanatory subtitle, and a MUI Switch toggle for GitHub Pipelines. Uses auto-save via `store.update()` (no save button).
- **`src/hooks/usePreviewFeatures.ts`** — Shared read-only hook wrapping `store.useConfig()` with defaults fallback. Consumers call `const { githubPipelines } = usePreviewFeatures()`.
- **`src/hooks/usePreviewFeatures.test.ts`** — Unit tests covering defaults, stored values, merge behavior, and missing key fallback.

### Modified files
- **`src/index.tsx`** — Added `registerPluginSettings` import and `registerPluginSettings('aks-desktop', PreviewFeaturesSettings, false)` call outside the `isRunningAsApp()` block so settings are available in all environments.

### Adding future toggles
1. Add a field to `PreviewFeaturesConfig`
2. Add a default to `PREVIEW_FEATURES_DEFAULTS`
3. Add a `<FormControlLabel>` in `PreviewFeaturesSettings`

## Testing

- [x] Unit tests pass (`usePreviewFeatures.test.ts` — 4/4)
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] Plugin build succeeds

### Test Cases

1. `usePreviewFeatures` returns defaults when store is empty
2. `usePreviewFeatures` returns stored values when present
3. `usePreviewFeatures` merges stored values over defaults
4. `usePreviewFeatures` falls back to defaults for missing keys

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Closes:
-  #361 