### PR TITLE
Scaling: Make chart colors responsive

### DIFF
--- a/plugins/aks-desktop/src/components/Scaling/components/ScalingChart.tsx
+++ b/plugins/aks-desktop/src/components/Scaling/components/ScalingChart.tsx
@@ -3,6 +3,7 @@
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Alert, AlertTitle, Box, CircularProgress, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import React from 'react';
 import {
   CartesianGrid,
@@ -21,14 +22,16 @@ const AngledTick = ({
   x,
   y,
   payload,
+  fill,
 }: {
   x: string | number;
   y: string | number;
   payload: { value: string };
+  fill?: string;
 }) => {
   return (
     <g transform={`translate(${x},${y})`}>
-      <text x={0} y={0} dy={12} textAnchor="end" fill="#888" fontSize={9} transform="rotate(-35)">
+      <text x={0} y={0} dy={12} textAnchor="end" fill={fill} fontSize={9} transform="rotate(-35)">
         {payload.value}
       </text>
     </g>
@@ -50,6 +53,7 @@ interface ScalingChartProps {
  */
 export const ScalingChart: React.FC<ScalingChartProps> = ({ chartData, loading, error }) => {
   const { t } = useTranslation();
+  const theme = useTheme();
 
   if (loading) {
     return (
@@ -100,31 +104,35 @@ export const ScalingChart: React.FC<ScalingChartProps> = ({ chartData, loading, 
           bottom: 30,
         }}
       >
-        <CartesianGrid strokeDasharray="3 3" stroke="#e8e8e8" />
+        <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
         <XAxis
           dataKey="time"
-          stroke="#888"
+          stroke={theme.palette.text.secondary}
           fontSize={10}
-          tick={AngledTick}
-          tickLine={{ stroke: '#e0e0e0' }}
+          tick={
+            <AngledTick fill={theme.palette.text.secondary} x={0} y={0} payload={{ value: '' }} />
+          }
+          tickLine={{ stroke: theme.palette.divider }}
           interval={0} // Show all ticks (12 labels over 24 hours)
           height={50}
         />
         <YAxis
-          stroke="#888"
+          stroke={theme.palette.text.secondary}
           fontSize={10}
           tick={{ fontSize: 10 }}
-          tickLine={{ stroke: '#e0e0e0' }}
+          tickLine={{ stroke: theme.palette.divider }}
           domain={[0, 'dataMax + 1']}
         />
         <Tooltip
           contentStyle={{
-            backgroundColor: '#fff',
-            border: '1px solid #ddd',
+            backgroundColor: theme.palette.background.paper,
+            border: `1px solid ${theme.palette.divider}`,
             borderRadius: '6px',
             fontSize: '11px',
             boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            color: theme.palette.text.primary,
           }}
+          labelStyle={{ color: theme.palette.text.secondary }}
         />
         <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '5px' }} />
         <Line
@@ -134,7 +142,7 @@ export const ScalingChart: React.FC<ScalingChartProps> = ({ chartData, loading, 
           stroke="#66BB6A"
           strokeWidth={2}
           dot={{ fill: '#66BB6A', strokeWidth: 0, r: 2 }}
-          activeDot={{ r: 4, stroke: '#66BB6A', strokeWidth: 2, fill: '#fff' }}
+          activeDot={{ r: 4, stroke: '#66BB6A', strokeWidth: 0, fill: '#66BB6A' }}
         />
         <Line
           type="monotone"
@@ -143,7 +151,7 @@ export const ScalingChart: React.FC<ScalingChartProps> = ({ chartData, loading, 
           stroke="#42A5F5"
           strokeWidth={2}
           dot={{ fill: '#42A5F5', strokeWidth: 0, r: 2 }}
-          activeDot={{ r: 4, stroke: '#42A5F5', strokeWidth: 2, fill: '#fff' }}
+          activeDot={{ r: 4, stroke: '#42A5F5', strokeWidth: 0, fill: '#42A5F5' }}
         />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
These changes replace hardcoded colors in `ScalingChart` with MUI theme tokens so the chart renders correctly in light/dark mode.

- Tooltip background, border, and text now use `theme.palette` values
- Grid lines, axis lines, tick lines, and axis labels use theme-aware colors
- Active dots on hover are now solid-filled to match the regular dot style