### PR TITLE
upstreamable: headlamp-plugin: Add missing .cmd shim

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -33,6 +33,9 @@ const { PluginManager, MultiPluginManager } = require('@headlamp-k8s/pluginctl')
 const { table } = require('table');
 const tar = require('tar');
 
+// On Windows, use the .cmd shim so execFileSync can run it without a shell.
+const binExt = process.platform === 'win32' ? '.cmd' : '';
+
 // ES imports
 const viteCopyPluginPromise = import('vite-plugin-static-copy');
 const viteConfigPromise = import('../config/vite.config.mjs');
@@ -115,7 +118,7 @@ function create(name, link, noInstall) {
     let useNpmCi = false;
     try {
       const npmJsPkgResponse = child_process.execFileSync(
-        'npm',
+        'npm' + binExt,
         ['view', `@kinvolk/headlamp-plugin@${headlampPluginPkg.version}`, 'dist', '--json'],
         { encoding: 'utf8' }
       );
@@ -684,7 +687,7 @@ function runScriptOnPackages(packageFolder, scriptName, cmdLine, env) {
     const scriptCmd = cmdLine.split(' ')[0];
     const scriptCmdRest = cmdLine.split(' ').slice(1).join(' ');
 
-    const nodeModulesBinCmd = path.join('node_modules', '.bin', scriptCmd);
+    const nodeModulesBinCmd = path.join('node_modules', '.bin', scriptCmd + binExt);
     const upNodeModulesBinCmd = path.join('../', nodeModulesBinCmd);
 
     // When run as npx, find it in the node_modules npx uses
@@ -1469,7 +1472,7 @@ function setupI18n(packageFolder) {
 
       // Run i18next-parser to extract translatable strings
       console.log(`🔍 Extracting translatable strings from source code...`);
-      const i18nextPath = path.join(__dirname, '..', 'node_modules', '.bin', 'i18next');
+      const i18nextPath = path.join(__dirname, '..', 'node_modules', '.bin', 'i18next' + binExt);
       const bundledConfigPath = path.join(__dirname, '..', 'config', 'i18next-parser.config.js');
       const { execFileSync } = require('child_process');
 
@@ -1686,7 +1689,7 @@ function extractI18n(packageFolder, newLocale) {
     // Use npx to run i18next from the headlamp-plugin package
     const headlampPluginPath = path.join(__dirname, '..');
     execFileSync(
-      'npx',
+      'npx' + binExt,
       ['--prefix', headlampPluginPath, 'i18next', 'src/**/*.{ts,tsx,js,jsx}', '-c', configToUse],
       {
         stdio: 'inherit',


### PR DESCRIPTION
These changes fix `headlamp-plugin` CLI commands failing on Windows by using the `.cmd` shims that npm installs in `node_modules/.bin/`, which are required when invoking binaries via `execFileSync` without a shell.

Fixes: #387 

### Testing
- [x] Run commands like `npm test` and `npm run i18n` locally
- [x] Ensure that they do not fail with a vague error message