### PR TITLE
BasicsStep: Remove edit icon adornment from project name field

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -304,7 +304,6 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
                     'Project name must contain only lowercase letters, numbers, and hyphens (no spaces)'
                   )
             }
-            endAdornment={<Icon icon="mdi:edit" />}
           />
         </FormControl>
 


### PR DESCRIPTION
Fixes #310 

Steps to test:

1. Open "New managed project" page
2. Edit button is gone