### PR TITLE
plugins/aks-desktop: Extract shared DeploymentSelector

### DIFF
--- a/plugins/aks-desktop/src/components/Metrics/MetricsCard.tsx
+++ b/plugins/aks-desktop/src/components/Metrics/MetricsCard.tsx
@@ -4,21 +4,13 @@
 import { Icon } from '@iconify/react';
 import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import Deployment from '@kinvolk/headlamp-plugin/lib/lib/k8s/deployment';
-import {
-  Box,
-  CircularProgress,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 import { getClusterResourceIdAndGroup } from '../../utils/azure/az-cli';
 import { RESOURCE_GROUP_LABEL, SUBSCRIPTION_LABEL } from '../../utils/constants/projectLabels';
 import { getPrometheusEndpoint } from '../MetricsTab/getPrometheusEndpoint';
 import { queryPrometheus } from '../MetricsTab/queryPrometheus';
+import { DeploymentSelector } from '../shared/DeploymentSelector';
 
 export interface ProjectDefinition {
   id: string;
@@ -278,10 +270,6 @@ function MetricsCard({ project }: MetricsCardProps) {
     return () => clearInterval(interval);
   }, [selectedDeployment, subscription, fetchMetrics]);
 
-  const handleDeploymentChange = (event: any) => {
-    setSelectedDeployment(event.target.value as string);
-  };
-
   return (
     <Box
       sx={{ flex: 1, display: 'flex', flexDirection: 'column', p: 0, '&:last-child': { pb: 0 } }}
@@ -296,30 +284,12 @@ function MetricsCard({ project }: MetricsCardProps) {
         }}
       >
         <Typography variant="h6">{t('Metrics')}</Typography>
-        <FormControl sx={{ minWidth: 200 }} size="small" variant="outlined">
-          <InputLabel>{t('Select Deployment')}</InputLabel>
-          <Select
-            value={selectedDeployment || ''}
-            onChange={handleDeploymentChange}
-            label={t('Select Deployment')}
-            disabled={loading || deployments.length === 0}
-          >
-            {loading ? (
-              <MenuItem disabled>
-                <CircularProgress size={16} style={{ marginRight: 8 }} />
-                {t('Loading deployments')}...
-              </MenuItem>
-            ) : deployments.length === 0 ? (
-              <MenuItem disabled>{t('No deployments found')}</MenuItem>
-            ) : (
-              deployments.map(deployment => (
-                <MenuItem key={deployment.name} value={deployment.name}>
-                  {deployment.name}
-                </MenuItem>
-              ))
-            )}
-          </Select>
-        </FormControl>
+        <DeploymentSelector
+          selectedDeployment={selectedDeployment}
+          deployments={deployments}
+          loading={loading}
+          onDeploymentChange={setSelectedDeployment}
+        />
       </Box>
 
       {error && (

--- a/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
+++ b/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
@@ -11,11 +11,7 @@ import {
   Box,
   Card,
   CircularProgress,
-  FormControl,
   Grid,
-  InputLabel,
-  MenuItem,
-  Select,
   Skeleton,
   Table,
   TableBody,
@@ -37,6 +33,7 @@ import {
 } from 'recharts';
 import { getClusterResourceIdAndGroup } from '../../utils/azure/az-cli';
 import { RESOURCE_GROUP_LABEL, SUBSCRIPTION_LABEL } from '../../utils/constants/projectLabels';
+import { DeploymentSelector } from '../shared/DeploymentSelector';
 import { getPrometheusEndpoint } from './getPrometheusEndpoint';
 import { queryPrometheus } from './queryPrometheus';
 
@@ -588,10 +585,6 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
     return () => clearInterval(interval);
   }, [selectedDeployment, fetchMetrics, subscription]);
 
-  const handleDeploymentChange = (event: any) => {
-    setSelectedDeployment(event.target.value as string);
-  };
-
   if (loading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
@@ -618,26 +611,12 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
         <Typography variant="h5" sx={{ mb: 2 }}>
           {t('Application Metrics')}
         </Typography>
-        <FormControl sx={{ minWidth: 300 }}>
-          <InputLabel shrink>{t('Select Deployment')}</InputLabel>
-          <Select
-            value={selectedDeployment}
-            onChange={handleDeploymentChange}
-            label={t('Select Deployment')}
-            disabled={deployments.length === 0}
-            displayEmpty
-            notched
-          >
-            <MenuItem value="" disabled>
-              {deployments.length === 0 ? t('No deployments available') : t('Select a deployment')}
-            </MenuItem>
-            {deployments.map(dep => (
-              <MenuItem key={dep.name} value={dep.name}>
-                {dep.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <DeploymentSelector
+          selectedDeployment={selectedDeployment}
+          deployments={deployments}
+          onDeploymentChange={setSelectedDeployment}
+          sx={{ minWidth: 300 }}
+        />
       </Box>
 
       {deployments.length === 0 ? (

--- a/plugins/aks-desktop/src/components/Scaling/ScalingCard.tsx
+++ b/plugins/aks-desktop/src/components/Scaling/ScalingCard.tsx
@@ -6,7 +6,7 @@ import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Alert, Box, Typography } from '@mui/material';
 import React from 'react';
 import { RESOURCE_GROUP_LABEL, SUBSCRIPTION_LABEL } from '../../utils/constants/projectLabels';
-import { DeploymentSelector } from './components/DeploymentSelector';
+import { DeploymentSelector } from '../shared/DeploymentSelector';
 import { ScalingChart } from './components/ScalingChart';
 import { ScalingMetrics } from './components/ScalingMetrics';
 import { useChartData } from './hooks/useChartData';

--- a/plugins/aks-desktop/src/components/Scaling/ScalingTab.tsx
+++ b/plugins/aks-desktop/src/components/Scaling/ScalingTab.tsx
@@ -5,7 +5,7 @@ import { Icon } from '@iconify/react';
 import { K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Alert, Box, Button, Card, CircularProgress, Typography } from '@mui/material';
 import React from 'react';
-import { DeploymentSelector } from './components/DeploymentSelector';
+import { DeploymentSelector } from '../shared/DeploymentSelector';
 import { ScalingChart } from './components/ScalingChart';
 import { ScalingEditDialog } from './components/ScalingEditDialog';
 import { ScalingMetrics } from './components/ScalingMetrics';

--- a/plugins/aks-desktop/src/components/shared/DeploymentSelector.stories.tsx
+++ b/plugins/aks-desktop/src/components/shared/DeploymentSelector.stories.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { DeploymentSelector } from './DeploymentSelector';
+
+const deployments = [{ name: 'api-server' }, { name: 'worker' }, { name: 'frontend' }];
+
+export default {
+  title: 'shared/DeploymentSelector',
+  component: DeploymentSelector,
+  args: {
+    onDeploymentChange: () => {},
+  },
+} as Meta<typeof DeploymentSelector>;
+
+const Template: StoryFn<typeof DeploymentSelector> = args => <DeploymentSelector {...args} />;
+
+export const WithDeployments = Template.bind({});
+WithDeployments.args = {
+  selectedDeployment: 'api-server',
+  deployments,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  selectedDeployment: '',
+  deployments: [],
+  loading: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  selectedDeployment: '',
+  deployments: [],
+  loading: false,
+};
+
+export const CustomWidth = Template.bind({});
+CustomWidth.args = {
+  selectedDeployment: 'frontend',
+  deployments,
+  sx: { minWidth: 350 },
+};

--- a/plugins/aks-desktop/src/components/shared/DeploymentSelector.tsx
+++ b/plugins/aks-desktop/src/components/shared/DeploymentSelector.tsx
@@ -3,29 +3,35 @@
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { CircularProgress, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 import React from 'react';
-import type { DeploymentInfo } from '../hooks/useDeployments';
 
 interface DeploymentSelectorProps {
   selectedDeployment: string;
-  deployments: DeploymentInfo[];
-  loading: boolean;
+  deployments: Array<{ name: string }>;
+  loading?: boolean;
   onDeploymentChange: (deploymentName: string) => void;
+  sx?: SxProps<Theme>;
 }
 
 /**
- * Dropdown selector for choosing a deployment to view scaling metrics
+ * Dropdown selector for choosing a deployment
  */
 export const DeploymentSelector: React.FC<DeploymentSelectorProps> = ({
   selectedDeployment,
   deployments,
-  loading,
+  loading = false,
   onDeploymentChange,
+  sx,
 }) => {
   const { t } = useTranslation();
 
   return (
-    <FormControl sx={{ minWidth: 200 }} size="small" variant="outlined">
+    <FormControl
+      sx={[{ minWidth: 200 }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
+      size="small"
+      variant="outlined"
+    >
       <InputLabel>{t('Select Deployment')}</InputLabel>
       <Select
         value={selectedDeployment || ''}


### PR DESCRIPTION
This change extracts `DeploymentSelector` from `Scaling/components/` into the `shared/` folder and reuses it in `MetricsCard` and `MetricsTab`, removing duplicate inline dropdown code. Also added is a Storybook story file covering the loading, empty, and populated states.

### Testing
- [x] Run `npm run storybook` and test the component