### PR TITLE
Headlamp: fix ipc listener leak in runCommand and pluginManager

### DIFF
--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -66,13 +66,17 @@ contextBridge.exposeInMainWorld('desktopApi', {
     ];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`
-      ipcRenderer.on(channel, (event, ...args) => func(...args));
+      const wrapper = (_event: Electron.IpcRendererEvent, ...args: unknown[]) => func(...args);
+      ipcRenderer.on(channel, wrapper);
+      return () => {
+        ipcRenderer.removeListener(channel, wrapper);
+      };
     }
+    return () => {};
   },
 
-  removeListener: (channel: string, func: (...args: unknown[]) => void) => {
-    ipcRenderer.removeListener(channel, func);
-  },
+  // No-op removeListener for backwards compatibility
+  removeListener: () => {},
 
   // Register AKS cluster
   registerAKSCluster: (

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -357,6 +357,9 @@ export async function handleRunCommand(
   const [isValid, errorMessage] = validateCommandData(eventData);
   if (!isValid) {
     console.error(errorMessage);
+    if (eventData.id) {
+      event.sender.send('command-exit', eventData.id, -1);
+    }
     return;
   }
   const commandData = eventData as CommandData;
@@ -364,9 +367,11 @@ export async function handleRunCommand(
   const [permissionsValid, permissionError] = checkPermissionSecret(commandData, permissionSecrets);
   if (!permissionsValid) {
     console.error(permissionError);
+    event.sender.send('command-exit', commandData.id, -2);
     return;
   }
   if (!checkCommandConsent(commandData.command, commandData.args, mainWindow)) {
+    event.sender.send('command-exit', commandData.id, -3);
     return;
   }
 
@@ -413,7 +418,7 @@ export async function handleRunCommand(
     event.sender.send('command-stderr', commandData.id, data.toString());
   });
 
-  child.on('exit', (code: number | null) => {
+  child.on('close', (code: number | null) => {
     event.sender.send('command-exit', commandData.id, code);
   });
 }

--- a/frontend/src/components/App/pluginManager.ts
+++ b/frontend/src/components/App/pluginManager.ts
@@ -53,20 +53,20 @@ export class PluginManager {
         const parsedResponse = JSON.parse(response);
         if (parsedResponse.identifier === identifier) {
           clearTimeout(timeoutId);
-          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          unsubscribe();
           resolve(parsedResponse);
         } else if (++count >= waitCount) {
           clearTimeout(timeoutId);
-          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          unsubscribe();
           reject(new Error('Message limit exceeded without a matching response'));
         }
       };
 
-      window.desktopApi.receive('plugin-manager', handleResponse);
+      const unsubscribe = window.desktopApi.receive('plugin-manager', handleResponse);
 
       // Add a timeout to ensure the promise is rejected if no response is received within a reasonable time
       const timeoutId = setTimeout(() => {
-        window.desktopApi.removeListener('plugin-manager', handleResponse);
+        unsubscribe();
         reject(new Error('Timeout exceeded without a matching response'));
       }, 10000);
     });

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -67,7 +67,7 @@ export function runCommand(
   desktopApiReceive?: (
     channel: string,
     listener: (cmdId: string, data: string | number) => void
-  ) => void
+  ) => (() => void) | void
 ): {
   stdout: { on: (event: string, listener: (chunk: any) => void) => void };
   stderr: { on: (event: string, listener: (chunk: any) => void) => void };
@@ -89,24 +89,35 @@ export function runCommand(
   const id = `${new Date().getTime()}-${Math.random().toString(36)}`;
 
   const stdout = new EventTarget();
-  desktopApiReceive('command-stdout', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stdout.dispatchEvent(event);
+  const removeStdout = desktopApiReceive(
+    'command-stdout',
+    (cmdId: string, data: string | number) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stdout.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const stderr = new EventTarget();
-  desktopApiReceive('command-stderr', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stderr.dispatchEvent(event);
+  const removeStderr = desktopApiReceive(
+    'command-stderr',
+    (cmdId: string, data: string | number) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stderr.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const exit = new EventTarget();
-  desktopApiReceive('command-exit', (cmdId: string, code: string | number) => {
+  const removeExit = desktopApiReceive('command-exit', (cmdId: string, code: string | number) => {
     if (cmdId === id) {
+      // Clean up all IPC listeners for this command to prevent memory leaks.
+      removeStdout?.();
+      removeStderr?.();
+      removeExit?.();
+
       const event = new CustomEvent('exit', { detail: code });
       exit.dispatchEvent(event);
     }


### PR DESCRIPTION
## Description

Observed that using command-heavy features, such as adding aks clusters or creating projects would flood the console with `MaxListenersExceededWarning`s for command-stdout, command-stderr, and command-exit channels.

It appears that each call to `runCommand` registered those 3 IPC listeners for `stdout`, `sterr`, `exit`, but they were not removed after the command exited, because the `receive()` in preload.ts wrapped the callback in an anonymous function before passing it to `ipcRenderer.on`, so the `removeListener` couldn't match any reference to remove it. Which led to the listeners indefinitely accumulating. 

I've made it such that `receive()` now returns an unsubscribe function that captures the wrapper reference & callers can use it to clean up when done. Also fixed the same pattern in `pluginManager.ts` which had the same broken `removeListener` usage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Changes Made

- `preload.ts`: `receive()` returns unsubscribe func 
- `runCommand.ts`: cleans up listeners when command exits
- `pluginManager.ts`:  switched to unsubscribe pattern

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

Manually tested to confirm MaxListener warnings were no longer flooding the console. 
By creating a project I was able to reproduce the listener warning errors in console that pointed to the issue.