### PR TITLE
guardian: Update baseline filename and signature

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -11,12 +11,12 @@
     }
   },
   "results": {
-    "843b66aa96c0874ad7f53b856e126270fa4fbed3d204592bf12c8d77d13e0e45": {
-      "signature": "843b66aa96c0874ad7f53b856e126270fa4fbed3d204592bf12c8d77d13e0e45",
+    "e757073450d58933c523bbe65c9621933ad9851d20de8956a58b1c7b52d468cb": {
+      "signature": "e757073450d58933c523bbe65c9621933ad9851d20de8956a58b1c7b52d468cb",
       "alternativeSignatures": [
         "09484848b5db84a7bad081ef7803ed2a91c61ff1270728a8dce1f1a81a086d6b"
       ],
-      "target": "file:///C:/a/_work/1/aks-desktop-exe-unsigned/aks-desktop-0.1.0-alpha-win-x64.exe",
+      "target": "file:///C:/a/_work/1/aks-desktop-exe-unsigned/aks-desktop-0.2.0-alpha-win-x64.exe",
       "memberOf": [
         "default"
       ],


### PR DESCRIPTION
this is the fix we used for 0.2.0 release but didn't merge in the main branch