### PR TITLE
aksd: pass setSelectedTab to project header action components

### DIFF
--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -446,6 +446,9 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
     };
   }, [customDeleteButton, project]);
 
+  const [selectedTab, setSelectedTab] = useState<string>();
+  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
+
   // Load custom header actions
   useEffect(() => {
     let isCurrent = true;
@@ -472,7 +475,11 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
 
       if (isCurrent) {
         const actions = enabledActions
-          .map(action => (action ? <action.component key={action.id} project={project} /> : null))
+          .map(action =>
+            action ? (
+              <action.component key={action.id} project={project} setSelectedTab={setSelectedTab} />
+            ) : null
+          )
           .filter(Boolean);
         setHeaderActions(actions);
       }
@@ -483,10 +490,7 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
     return () => {
       isCurrent = false;
     };
-  }, [registeredHeaderActions, project]);
-
-  const [selectedTab, setSelectedTab] = useState<string>();
-  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
+  }, [registeredHeaderActions, project, setSelectedTab]);
 
   const { items, isLoading } = useProjectItems(project);
 

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -68,7 +68,10 @@ export interface ProjectDeleteButton {
 
 export interface ProjectHeaderAction {
   id: string;
-  component: (props: { project: ProjectDefinition }) => ReactNode;
+  component: (props: {
+    project: ProjectDefinition;
+    setSelectedTab?: (tabId: string) => void;
+  }) => ReactNode;
   /** Function to check if this action should be displayed in the given project. If not provided the action will be enabled. */
   isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
 }


### PR DESCRIPTION
## Summary

- Extend `ProjectHeaderAction` interface to pass `setSelectedTab` as a prop to header action components
- This gives plugins a type-safe way to switch project detail tabs (e.g. navigating to the Deploy tab after pipeline setup completes)
- Replaces the previous DOM CustomEvent approach with proper React prop-based data flow

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`projectsSlice.ts`** — Added `setSelectedTab?: (tabId: string) => void` to `ProjectHeaderAction.component` props interface
- **`ProjectDetails.tsx`** — Pass `setSelectedTab` when rendering header action components

## Why props over DOM events

- Type-safe: TypeScript enforces the contract between Headlamp and plugins
- Follows React data flow: props flow down through the component tree instead of bypassing React via `window.dispatchEvent`
- Less coupling: plugins call a function they receive as a prop rather than dispatching magic-string events

## Testing

- [x] Unit tests pass
- [x] Manual testing completed

### Test Cases

1. Header action component receives `setSelectedTab` prop
2. Calling `setSelectedTab('deploy')` switches to the Deploy tab
3. Calling with an invalid tab ID updates state (tab rendering handles missing tabs gracefully)

## Related to

- #408