### PR TITLE
SearchableSelect: Announce when no options are found

### DIFF
--- a/plugins/aks-desktop/locales/cs/translation.json
+++ b/plugins/aks-desktop/locales/cs/translation.json
@@ -168,6 +168,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/de/translation.json
+++ b/plugins/aks-desktop/locales/de/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/en/translation.json
+++ b/plugins/aks-desktop/locales/en/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "Access Control ({{count}} assignees)",
   "Not specified": "Not specified",
   "Select an option": "Select an option",
+  "No options": "No options",
   "Starting project creation": "Starting project creation",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.",
   "Initiating managed namespace creation": "Initiating managed namespace creation",

--- a/plugins/aks-desktop/locales/es/translation.json
+++ b/plugins/aks-desktop/locales/es/translation.json
@@ -165,6 +165,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/fr/translation.json
+++ b/plugins/aks-desktop/locales/fr/translation.json
@@ -165,6 +165,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/hu/translation.json
+++ b/plugins/aks-desktop/locales/hu/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/id/translation.json
+++ b/plugins/aks-desktop/locales/id/translation.json
@@ -159,6 +159,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/it/translation.json
+++ b/plugins/aks-desktop/locales/it/translation.json
@@ -165,6 +165,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/ja/translation.json
+++ b/plugins/aks-desktop/locales/ja/translation.json
@@ -159,6 +159,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/ko/translation.json
+++ b/plugins/aks-desktop/locales/ko/translation.json
@@ -159,6 +159,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/nl/translation.json
+++ b/plugins/aks-desktop/locales/nl/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/pl/translation.json
+++ b/plugins/aks-desktop/locales/pl/translation.json
@@ -168,6 +168,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/pt-BR/translation.json
+++ b/plugins/aks-desktop/locales/pt-BR/translation.json
@@ -165,6 +165,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/pt-PT/translation.json
+++ b/plugins/aks-desktop/locales/pt-PT/translation.json
@@ -165,6 +165,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/ru/translation.json
+++ b/plugins/aks-desktop/locales/ru/translation.json
@@ -168,6 +168,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/sv/translation.json
+++ b/plugins/aks-desktop/locales/sv/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/tr/translation.json
+++ b/plugins/aks-desktop/locales/tr/translation.json
@@ -162,6 +162,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/zh-Hans/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hans/translation.json
@@ -159,6 +159,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/locales/zh-Hant/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hant/translation.json
@@ -159,6 +159,7 @@
   "Access Control ({{count}} assignee)_other": "",
   "Not specified": "",
   "Select an option": "",
+  "No options": "",
   "Starting project creation": "",
   "Project creation timed out after 10 minutes. Please check if the namespace was created and try again.": "",
   "Initiating managed namespace creation": "",

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
@@ -4,7 +4,8 @@
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Autocomplete } from '@mui/material';
 import { Box, CircularProgress, TextField, Typography } from '@mui/material';
-import React, { ReactNode, useMemo } from 'react';
+import { visuallyHidden } from '@mui/utils';
+import React, { ReactNode, useMemo, useState } from 'react';
 
 export interface SearchableSelectOption {
   value: string;
@@ -42,9 +43,13 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
   disabled = false,
   placeholder,
   helperText,
+  noResultsText,
 }) => {
   const { t } = useTranslation();
   const resolvedPlaceholder = placeholder ?? `${t('Select an option')}...`;
+  const resolvedNoResults = noResultsText ?? t('No options');
+  const [inputValue, setInputValue] = useState('');
+
   // Sort options alphabetically by label
   const sortedOptions = useMemo(() => {
     return [...options].sort((a, b) =>
@@ -52,58 +57,75 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
     );
   }, [options]);
 
+  // Replicate MUI's default filter to detect zero matches for screen reader announcement
+  const noFilteredResults = useMemo(() => {
+    if (!inputValue) return false;
+    const lower = inputValue.toLowerCase();
+    return !sortedOptions.some(opt => opt.label.toLowerCase().includes(lower));
+  }, [sortedOptions, inputValue]);
+
   return (
-    <Autocomplete
-      options={sortedOptions}
-      disabled={disabled}
-      getOptionKey={it => it.value}
-      value={sortedOptions.find(it => it.value === value) ?? null}
-      renderInput={params => (
-        <TextField
-          {...params}
-          label={label}
-          variant="outlined"
-          helperText={helperText}
-          placeholder={resolvedPlaceholder}
-          error={error}
-          InputProps={{
-            ...params.InputProps,
-            endAdornment: (
-              <>
-                {/* The adornment spinner is decorative; MUI Autocomplete already manages
+    <>
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {noFilteredResults ? resolvedNoResults : ''}
+      </Box>
+      <Autocomplete
+        inputValue={inputValue}
+        onInputChange={(_, newValue) => setInputValue(newValue)}
+        options={sortedOptions}
+        disabled={disabled}
+        getOptionKey={it => it.value}
+        value={sortedOptions.find(it => it.value === value) ?? null}
+        noOptionsText={resolvedNoResults}
+        renderInput={params => (
+          <TextField
+            {...params}
+            label={label}
+            variant="outlined"
+            helperText={helperText}
+            placeholder={resolvedPlaceholder}
+            error={error}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {/* The adornment spinner is decorative; MUI Autocomplete already manages
                     aria-busy on the listbox via the loading prop, so this spinner
                     would cause a duplicate announcement if not hidden.
                     MUI: https://mui.com/material-ui/react-autocomplete/#asynchronous-requests */}
-                {loading ? <CircularProgress color="inherit" size={20} aria-hidden="true" /> : null}
-                {params.InputProps.endAdornment}
-              </>
-            ),
-          }}
-        />
-      )}
-      loading={loading}
-      onChange={(e, newValue) => onChange(newValue?.value)}
-      renderOption={(props, option) => {
-        const { key, ...optionProps } = props;
-        return (
-          <Box component="li" key={key} {...optionProps}>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-start',
-              }}
-            >
-              <Typography variant="body1">{option.label}</Typography>
-              {option.subtitle && (
-                <Typography variant="caption" color="text.secondary">
-                  {option.subtitle}
-                </Typography>
-              )}
+                  {loading ? (
+                    <CircularProgress color="inherit" size={20} aria-hidden="true" />
+                  ) : null}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            }}
+          />
+        )}
+        loading={loading}
+        onChange={(e, newValue) => onChange(newValue?.value)}
+        renderOption={(props, option) => {
+          const { key, ...optionProps } = props;
+          return (
+            <Box component="li" key={key} {...optionProps}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start',
+                }}
+              >
+                <Typography variant="body1">{option.label}</Typography>
+                {option.subtitle && (
+                  <Typography variant="caption" color="text.secondary">
+                    {option.subtitle}
+                  </Typography>
+                )}
+              </Box>
             </Box>
-          </Box>
-        );
-      }}
-    />
+          );
+        }}
+      />
+    </>
   );
 };


### PR DESCRIPTION
Fixes issue from this [ADO ticket ](https://dev.azure.com/msazure/CloudNativeCompute/_queries/edit/36821248/)

Announces when there are no options found.

Here's an example with cluster and subscription selectors

https://github.com/user-attachments/assets/035935de-7e9e-45fa-a9f5-37b6561290ad

To test follow the video above of from the ado ticket

