### PR TITLE
RegisterAKSClusterDialog: Fix a11y issues, add tests

### DIFF
--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { Icon } from '@iconify/react';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import {
-  Alert,
-  Autocomplete,
-  Box,
-  Button,
-  CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  TextField,
-  Typography,
-} from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAzureAuth } from '../../hooks/useAzureAuth';
 import type { ClusterCapabilities } from '../../types/ClusterCapabilities';
 import { getAKSClusters, getSubscriptions, registerAKSCluster } from '../../utils/azure/aks';
 import { getClusterCapabilities } from '../../utils/azure/az-cli';
-import { ClusterConfigurePanel } from '../CreateAKSProject/components/ClusterConfigurePanel';
+import type { AKSCluster, Subscription } from './RegisterAKSClusterDialogPure';
+import RegisterAKSClusterDialogPure from './RegisterAKSClusterDialogPure';
 
 interface RegisterAKSClusterDialogProps {
   open: boolean;
   onClose: () => void;
   onClusterRegistered?: () => void;
-}
-
-interface Subscription {
-  id: string;
-  name: string;
-  state: string;
-}
-
-interface AKSCluster {
-  name: string;
-  resourceGroup: string;
-  location: string;
-  kubernetesVersion: string;
-  provisioningState: string;
 }
 
 export default function RegisterAKSClusterDialog({
@@ -212,249 +185,52 @@ export default function RegisterAKSClusterDialog({
     }
   };
 
+  const handleDone = () => {
+    onClose();
+    history.replace('/');
+    window.location.reload();
+  };
+
+  const handleConfigured = () => {
+    if (selectedSubscription && selectedCluster) {
+      getClusterCapabilities({
+        subscriptionId: selectedSubscription.id,
+        resourceGroup: selectedCluster.resourceGroup,
+        clusterName: selectedCluster.name,
+      })
+        .then(caps => {
+          if (isMountedRef.current) {
+            setCapabilities(caps);
+          }
+        })
+        .catch(() => {});
+    }
+  };
+
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle component="h1">
-        <Box display="flex" alignItems="center" gap={1}>
-          <Icon icon="logos:microsoft-azure" style={{ fontSize: '24px' }} />
-          <Typography variant="h6" component="span">
-            {t('Register AKS Cluster')}
-          </Typography>
-        </Box>
-      </DialogTitle>
-
-      <DialogContent>
-        <Box display="flex" flexDirection="column" gap={2} pt={1}>
-          {error && (
-            <Alert severity="error" onClose={() => setError('')}>
-              {error}
-            </Alert>
-          )}
-
-          {success && (
-            <Alert severity="success" onClose={() => setSuccess('')}>
-              {success}
-            </Alert>
-          )}
-
-          {capabilitiesLoading && (
-            <Box display="flex" alignItems="center" gap={1}>
-              <CircularProgress size={16} />
-              <Typography variant="body2" color="textSecondary">
-                Checking cluster capabilities...
-              </Typography>
-            </Box>
-          )}
-
-          {capabilities && capabilities.azureRbacEnabled !== true && (
-            <Alert severity="error" sx={{ mb: 1 }}>
-              Azure RBAC for Kubernetes is not enabled. Project role assignments (Admin, Writer,
-              Reader) will not work. This must be set at cluster creation.
-            </Alert>
-          )}
-
-          {capabilities &&
-            (!capabilities.networkPolicy || capabilities.networkPolicy === 'none') && (
-              <Alert severity="warning" sx={{ mb: 1 }}>
-                No network policy engine configured. Network policies will not be enforced. This
-                must be set at cluster creation.
-              </Alert>
-            )}
-
-          {capabilities &&
-            (capabilities.prometheusEnabled !== true ||
-              capabilities.kedaEnabled !== true ||
-              capabilities.vpaEnabled !== true) &&
-            selectedSubscription &&
-            selectedCluster && (
-              <ClusterConfigurePanel
-                capabilities={capabilities}
-                subscriptionId={selectedSubscription.id}
-                resourceGroup={selectedCluster.resourceGroup}
-                clusterName={selectedCluster.name}
-                onConfigured={() => {
-                  if (selectedSubscription && selectedCluster) {
-                    getClusterCapabilities({
-                      subscriptionId: selectedSubscription.id,
-                      resourceGroup: selectedCluster.resourceGroup,
-                      clusterName: selectedCluster.name,
-                    })
-                      .then(caps => {
-                        if (isMountedRef.current) {
-                          setCapabilities(caps);
-                        }
-                      })
-                      .catch(() => {});
-                  }
-                }}
-              />
-            )}
-
-          {capabilities &&
-            capabilities.azureRbacEnabled === true &&
-            capabilities.prometheusEnabled === true &&
-            capabilities.kedaEnabled === true &&
-            capabilities.vpaEnabled === true &&
-            capabilities.networkPolicy &&
-            capabilities.networkPolicy !== 'none' && (
-              <Alert severity="success">All recommended cluster configurations are in place.</Alert>
-            )}
-
-          {!authStatus.isLoggedIn && (
-            <Alert severity="warning">
-              {t('You need to be logged in to Azure to register AKS clusters.')}
-            </Alert>
-          )}
-
-          {authStatus.isLoggedIn && (
-            <>
-              <Autocomplete
-                fullWidth
-                options={subscriptions}
-                value={selectedSubscription}
-                onChange={handleSubscriptionChange}
-                getOptionLabel={option =>
-                  `${option.name}${option.state !== 'Enabled' ? ` (${option.state})` : ''}`
-                }
-                isOptionEqualToValue={(option, value) => option.id === value.id}
-                disabled={loadingSubscriptions}
-                loading={loadingSubscriptions}
-                renderInput={params => (
-                  <TextField
-                    {...params}
-                    label={t('Subscription')}
-                    placeholder={t('Select an Azure subscription')}
-                    InputProps={{
-                      ...params.InputProps,
-                      endAdornment: (
-                        <>
-                          {loadingSubscriptions ? (
-                            <CircularProgress color="inherit" size={20} />
-                          ) : null}
-                          {params.InputProps.endAdornment}
-                        </>
-                      ),
-                    }}
-                  />
-                )}
-                renderOption={(props, option) => (
-                  <li {...props} key={option.id}>
-                    <Box>
-                      <Typography variant="body1">{option.name}</Typography>
-                      {option.state !== 'Enabled' && (
-                        <Typography variant="caption" color="textSecondary">
-                          {option.state}
-                        </Typography>
-                      )}
-                    </Box>
-                  </li>
-                )}
-              />
-
-              {loadingSubscriptions && (
-                <Box display="flex" alignItems="center" gap={1}>
-                  <CircularProgress size={20} />
-                  <Typography variant="body2" color="textSecondary">
-                    {t('Loading subscriptions')}...
-                  </Typography>
-                </Box>
-              )}
-
-              {loadingClusters && (
-                <Box display="flex" alignItems="center" gap={1}>
-                  <CircularProgress size={20} />
-                  <Typography variant="body2" color="textSecondary">
-                    {t('Loading AKS clusters')}...
-                  </Typography>
-                </Box>
-              )}
-
-              {!loadingClusters && selectedSubscription && clusters.length === 0 && (
-                <Alert severity="info">{t('No AKS clusters found in this subscription.')}</Alert>
-              )}
-
-              {!loadingClusters && selectedSubscription && clusters.length > 0 && (
-                <Autocomplete
-                  fullWidth
-                  options={clusters}
-                  value={selectedCluster}
-                  onChange={handleClusterChange}
-                  getOptionLabel={option => option.name}
-                  isOptionEqualToValue={(option, value) => option.name === value.name}
-                  renderInput={params => (
-                    <TextField
-                      {...params}
-                      label={t('AKS Cluster')}
-                      placeholder={t('Select an AKS cluster')}
-                    />
-                  )}
-                  renderOption={(props, option) => (
-                    <li {...props} key={option.name}>
-                      <Box width="100%">
-                        <Typography variant="body1">{option.name}</Typography>
-                        <Typography variant="caption" color="textSecondary">
-                          {option.location} • v{option.kubernetesVersion} •{' '}
-                          {option.provisioningState}
-                        </Typography>
-                      </Box>
-                    </li>
-                  )}
-                />
-              )}
-
-              {selectedCluster && !success && (
-                <Box p={2} bgcolor="action.hover" borderRadius={1}>
-                  <Typography variant="subtitle2" gutterBottom>
-                    {t('Selected Cluster Details')}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('Name')}:</strong> {selectedCluster.name}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('Resource Group')}:</strong> {selectedCluster.resourceGroup}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('Location')}:</strong> {selectedCluster.location}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('Kubernetes Version')}:</strong> {selectedCluster.kubernetesVersion}
-                  </Typography>
-                </Box>
-              )}
-            </>
-          )}
-        </Box>
-      </DialogContent>
-
-      <DialogActions>
-        {success ? (
-          <Button
-            onClick={() => {
-              onClose();
-              history.replace('/');
-              window.location.reload();
-            }}
-            variant="contained"
-          >
-            {t('Done')}
-          </Button>
-        ) : (
-          <>
-            <Button onClick={handleClose} disabled={loading}>
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={handleRegister}
-              variant="contained"
-              color="primary"
-              disabled={!selectedCluster || loading || !authStatus.isLoggedIn}
-              startIcon={loading ? <CircularProgress size={20} /> : <Icon icon="mdi:cloud-check" />}
-            >
-              {loading ? `${t('Registering')}...` : t('Register Cluster')}
-            </Button>
-          </>
-        )}
-      </DialogActions>
-    </Dialog>
+    <RegisterAKSClusterDialogPure
+      open={open}
+      isChecking={authStatus.isChecking}
+      isLoggedIn={authStatus.isLoggedIn}
+      loading={loading}
+      loadingSubscriptions={loadingSubscriptions}
+      loadingClusters={loadingClusters}
+      capabilitiesLoading={capabilitiesLoading}
+      error={error}
+      success={success}
+      subscriptions={subscriptions}
+      selectedSubscription={selectedSubscription}
+      clusters={clusters}
+      selectedCluster={selectedCluster}
+      capabilities={capabilities}
+      onClose={handleClose}
+      onSubscriptionChange={handleSubscriptionChange}
+      onClusterChange={handleClusterChange}
+      onRegister={handleRegister}
+      onDone={handleDone}
+      onDismissError={() => setError('')}
+      onDismissSuccess={() => setSuccess('')}
+      onConfigured={handleConfigured}
+    />
   );
 }

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.guidepup.test.tsx
@@ -1,0 +1,434 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+/**
+ * Virtual screen-reader tests for {@link RegisterAKSClusterDialogPure}.
+ *
+ * Each test renders the component using the args from the corresponding
+ * Storybook story so that the stories act as a single source of truth for
+ * both the visual catalogue and the screen-reader announcement matrix.
+ *
+ * Uses `@guidepup/virtual-screen-reader` to walk the accessibility tree and
+ * assert on the spoken phrases that a screen reader would announce.
+ *
+ * Also uses axe-core to validate WCAG compliance for each story state.
+ *
+ * Coverage:
+ *  RegisterAKSClusterDialogPure
+ *  ├── Default            — dialog landmark; heading; Subscription combobox; Cancel/Register buttons
+ *  ├── NotLoggedIn        — warning alert; Register button disabled
+ *  ├── CheckingAuth       — spinner + "Checking authentication status"; no combobox; no warning
+ *  ├── LoadingSubscriptions — disabled combobox; loading status region
+ *  ├── LoadingClusters    — loading status region with cluster loading text
+ *  ├── NoClusters         — info alert "No AKS clusters found"
+ *  ├── WithClusters       — Subscription + AKS Cluster comboboxes
+ *  ├── ClusterSelected    — cluster details region; Register button enabled
+ *  ├── Registering        — Register button busy + disabled; "Registering..."
+ *  ├── Success            — success alert; Done button replaces Cancel/Register
+ *  ├── Error              — error alert with message
+ *  ├── CheckingCapabilities — loading status for capabilities
+ *  ├── AllCapabilitiesEnabled — success alert for capabilities
+ *  ├── RbacNotEnabled     — error alert for RBAC
+ *  └── NoNetworkPolicy    — warning alert for network policy
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { virtual } from '@guidepup/virtual-screen-reader';
+import { cleanup, render } from '@testing-library/react';
+import axe from 'axe-core';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon, ...props }: any) => <span data-icon={icon} {...props} />,
+}));
+
+vi.mock('../CreateAKSProject/components/ClusterConfigurePanel', () => ({
+  ClusterConfigurePanel: () => <div data-testid="cluster-configure-panel">Configure Panel</div>,
+}));
+
+import type { RegisterAKSClusterDialogPureProps } from './RegisterAKSClusterDialogPure';
+import RegisterAKSClusterDialogPure from './RegisterAKSClusterDialogPure';
+import {
+  AllCapabilitiesEnabled,
+  CheckingAuth,
+  CheckingCapabilities,
+  ClusterSelected,
+  Default,
+  Error as ErrorStory,
+  LoadingClusters,
+  LoadingSubscriptions,
+  NoClusters,
+  NoNetworkPolicy,
+  NotLoggedIn,
+  RbacNotEnabled,
+  Registering,
+  Success,
+  WithClusters,
+} from './RegisterAKSClusterDialogPure.stories';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+afterEach(async () => {
+  await virtual.stop();
+  cleanup();
+});
+
+/**
+ * Mount the dialog and start the virtual screen reader on document.body.
+ * We use document.body because MUI Dialog renders into a portal.
+ */
+async function mount(overrides: Partial<RegisterAKSClusterDialogPureProps> = {}) {
+  const args = { ...(Default.args as RegisterAKSClusterDialogPureProps), ...overrides };
+  render(<RegisterAKSClusterDialogPure {...args} />);
+  await virtual.start({ container: document.body });
+}
+
+/** Render story args without starting the screen reader (for axe tests). */
+function renderStory(storyArgs: RegisterAKSClusterDialogPureProps) {
+  render(<RegisterAKSClusterDialogPure {...storyArgs} />);
+}
+
+/** Collect all spoken phrases to "end of document". */
+async function phrases(maxSteps = 300): Promise<string[]> {
+  const log: string[] = [];
+  for (let i = 0; i < maxSteps; i++) {
+    const p = await virtual.lastSpokenPhrase();
+    log.push(p);
+    if (p === 'end of document') break;
+    await virtual.next();
+  }
+  return log;
+}
+
+/** Run axe-core on the rendered document and return violations. */
+async function runAxe() {
+  const results = await axe.run(document.body, {
+    rules: {
+      // MUI Dialog uses aria-hidden on the backdrop; region rule can conflict with portals
+      region: { enabled: false },
+    },
+  });
+  return results.violations;
+}
+
+describe('Axe: RegisterAKSClusterDialogPure', () => {
+  it('Default has no axe violations', async () => {
+    renderStory(Default.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('NotLoggedIn has no axe violations', async () => {
+    renderStory(NotLoggedIn.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('LoadingSubscriptions has no axe violations', async () => {
+    renderStory(LoadingSubscriptions.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('ClusterSelected has no axe violations', async () => {
+    renderStory(ClusterSelected.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('Registering has no axe violations', async () => {
+    renderStory(Registering.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('Success has no axe violations', async () => {
+    renderStory(Success.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('Error has no axe violations', async () => {
+    renderStory(ErrorStory.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('AllCapabilitiesEnabled has no axe violations', async () => {
+    renderStory(AllCapabilitiesEnabled.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('RbacNotEnabled has no axe violations', async () => {
+    renderStory(RbacNotEnabled.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('NoNetworkPolicy has no axe violations', async () => {
+    renderStory(NoNetworkPolicy.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+
+  it('CheckingAuth has no axe violations', async () => {
+    renderStory(CheckingAuth.args as RegisterAKSClusterDialogPureProps);
+    const violations = await runAxe();
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('SR: Default — dialog structure', () => {
+  it('announces the dialog landmark', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('dialog') && p.includes('Register AKS Cluster'))).toBe(true);
+  });
+
+  it('announces the dialog heading "Register AKS Cluster"', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('heading') && p.includes('Register AKS Cluster'))).toBe(true);
+  });
+
+  it('announces the Subscription combobox', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('combobox') && p.includes('Subscription'))).toBe(true);
+  });
+
+  it('announces Cancel and Register Cluster buttons', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('button') && p.includes('Cancel'))).toBe(true);
+    expect(ps.some(p => p.includes('button') && p.includes('Register Cluster'))).toBe(true);
+  });
+
+  it('announces Register Cluster button as disabled (no cluster selected)', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Register Cluster') && p.includes('disabled'))).toBe(true);
+  });
+
+  it('announces a polite status region', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => p === 'status')).toBe(true);
+  });
+
+  it('does NOT announce decorative icons', async () => {
+    await mount();
+    const ps = await phrases();
+    expect(ps.some(p => /logos:microsoft-azure|mdi:cloud-check/.test(p))).toBe(false);
+  });
+});
+
+describe('SR: NotLoggedIn — warning alert', () => {
+  it('announces an alert region', async () => {
+    await mount(NotLoggedIn.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps).toContain('end of alert');
+  });
+
+  it('announces the Azure login warning text', async () => {
+    await mount(NotLoggedIn.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('logged in to Azure'))).toBe(true);
+  });
+
+  it('does not announce the Subscription combobox', async () => {
+    await mount(NotLoggedIn.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('combobox') && p.includes('Subscription'))).toBe(false);
+  });
+});
+
+describe('SR: CheckingAuth — checking authentication', () => {
+  it('announces the status region with checking auth text', async () => {
+    await mount(CheckingAuth.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Checking authentication status'))).toBe(true);
+  });
+
+  it('does not announce the not-logged-in warning', async () => {
+    await mount(CheckingAuth.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('logged in to Azure'))).toBe(false);
+  });
+
+  it('does not announce the Subscription combobox', async () => {
+    await mount(CheckingAuth.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('combobox') && p.includes('Subscription'))).toBe(false);
+  });
+});
+
+describe('SR: LoadingSubscriptions — loading status', () => {
+  it('announces the status region with loading subscriptions text', async () => {
+    await mount(LoadingSubscriptions.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Loading subscriptions'))).toBe(true);
+  });
+
+  it('announces the Subscription combobox as disabled', async () => {
+    await mount(LoadingSubscriptions.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(
+      ps.some(p => p.includes('combobox') && p.includes('Subscription') && p.includes('disabled'))
+    ).toBe(true);
+  });
+});
+
+describe('SR: LoadingClusters — loading status', () => {
+  it('announces the status region with loading clusters text', async () => {
+    await mount(LoadingClusters.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Loading AKS clusters'))).toBe(true);
+  });
+});
+
+describe('SR: NoClusters — info alert', () => {
+  it('announces an alert region for no clusters found', async () => {
+    await mount(NoClusters.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('No AKS clusters found'))).toBe(true);
+  });
+});
+
+describe('SR: WithClusters — both comboboxes', () => {
+  it('announces both Subscription and AKS Cluster comboboxes', async () => {
+    await mount(WithClusters.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('combobox') && p.includes('Subscription'))).toBe(true);
+    expect(ps.some(p => p.includes('combobox') && p.includes('AKS Cluster'))).toBe(true);
+  });
+});
+
+describe('SR: ClusterSelected — cluster details region', () => {
+  it('announces the Selected Cluster Details region', async () => {
+    await mount(ClusterSelected.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('region') && p.includes('Selected Cluster Details'))).toBe(true);
+  });
+
+  it('announces cluster name within the details', async () => {
+    await mount(ClusterSelected.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('prod-aks-cluster'))).toBe(true);
+  });
+
+  it('announces Register Cluster button as enabled', async () => {
+    await mount(ClusterSelected.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    const registerBtn = ps.find(p => p.includes('Register Cluster') && p.includes('button'));
+    expect(registerBtn).toBeDefined();
+    expect(registerBtn).not.toMatch(/disabled/);
+  });
+});
+
+describe('SR: Registering — busy register button', () => {
+  it('announces the register button as busy and disabled', async () => {
+    await mount(Registering.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Registering') && p.includes('busy'))).toBe(true);
+  });
+
+  it('announces "Registering..." text on the button', async () => {
+    await mount(Registering.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Registering...'))).toBe(true);
+  });
+
+  it('announces Cancel button as disabled during registration', async () => {
+    await mount(Registering.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Cancel') && p.includes('disabled'))).toBe(true);
+  });
+});
+
+describe('SR: Success — success state', () => {
+  it('announces an alert region with the success message', async () => {
+    await mount(Success.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('successfully merged'))).toBe(true);
+  });
+
+  it('announces the Done button', async () => {
+    await mount(Success.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('button') && p.includes('Done'))).toBe(true);
+  });
+
+  it('does NOT announce Cancel or Register buttons in success state', async () => {
+    await mount(Success.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('button') && p.includes('Cancel'))).toBe(false);
+    expect(ps.some(p => p.includes('button') && p.includes('Register Cluster'))).toBe(false);
+  });
+});
+
+describe('SR: Error — error alert', () => {
+  it('announces an alert region with the error message', async () => {
+    await mount(ErrorStory.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('ECONNREFUSED'))).toBe(true);
+  });
+});
+
+describe('SR: CheckingCapabilities — loading status', () => {
+  it('announces the status region with capabilities loading text', async () => {
+    await mount(CheckingCapabilities.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps.some(p => p.includes('Checking cluster capabilities'))).toBe(true);
+  });
+});
+
+describe('SR: AllCapabilitiesEnabled — success alert', () => {
+  it('announces an alert with cluster configurations message', async () => {
+    await mount(AllCapabilitiesEnabled.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('All recommended cluster configurations'))).toBe(true);
+  });
+});
+
+describe('SR: RbacNotEnabled — error alert', () => {
+  it('announces an alert with Azure RBAC warning text', async () => {
+    await mount(RbacNotEnabled.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('Azure RBAC'))).toBe(true);
+  });
+});
+
+describe('SR: NoNetworkPolicy — warning alert', () => {
+  it('announces an alert with network policy warning text', async () => {
+    await mount(NoNetworkPolicy.args as Partial<RegisterAKSClusterDialogPureProps>);
+    const ps = await phrases();
+    expect(ps).toContain('alert');
+    expect(ps.some(p => p.includes('No network policy engine'))).toBe(true);
+  });
+});

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import RegisterAKSClusterDialogPure, {
+  RegisterAKSClusterDialogPureProps,
+} from './RegisterAKSClusterDialogPure';
+
+const noOp = () => {};
+
+const SAMPLE_SUBSCRIPTIONS = [
+  { id: 'sub-1', name: 'Production Subscription', state: 'Enabled' },
+  { id: 'sub-2', name: 'Development Subscription', state: 'Enabled' },
+  { id: 'sub-3', name: 'Legacy Subscription', state: 'Disabled' },
+];
+
+const SAMPLE_CLUSTERS = [
+  {
+    name: 'prod-aks-cluster',
+    resourceGroup: 'prod-rg',
+    location: 'eastus',
+    kubernetesVersion: '1.28.5',
+    provisioningState: 'Succeeded',
+  },
+  {
+    name: 'dev-aks-cluster',
+    resourceGroup: 'dev-rg',
+    location: 'westus2',
+    kubernetesVersion: '1.29.0',
+    provisioningState: 'Succeeded',
+  },
+];
+
+const baseArgs: RegisterAKSClusterDialogPureProps = {
+  open: true,
+  isChecking: false,
+  isLoggedIn: true,
+  loading: false,
+  loadingSubscriptions: false,
+  loadingClusters: false,
+  capabilitiesLoading: false,
+  error: '',
+  success: '',
+  subscriptions: SAMPLE_SUBSCRIPTIONS,
+  selectedSubscription: null,
+  clusters: [],
+  selectedCluster: null,
+  capabilities: null,
+  onClose: noOp,
+  onSubscriptionChange: noOp as any,
+  onClusterChange: noOp as any,
+  onRegister: noOp,
+  onDone: noOp,
+  onDismissError: noOp,
+  onDismissSuccess: noOp,
+  onConfigured: noOp,
+};
+
+export default {
+  title: 'AKS/RegisterAKSClusterDialogPure',
+  component: RegisterAKSClusterDialogPure,
+} as Meta;
+
+const Template: StoryFn<RegisterAKSClusterDialogPureProps> = args => (
+  <RegisterAKSClusterDialogPure {...args} />
+);
+
+/** Default state: logged in with subscriptions loaded, nothing selected. */
+export const Default = Template.bind({});
+Default.args = { ...baseArgs };
+
+/** Not logged in to Azure — shows a warning alert. */
+export const NotLoggedIn = Template.bind({});
+NotLoggedIn.args = {
+  ...baseArgs,
+  isLoggedIn: false,
+  subscriptions: [],
+};
+
+/** Checking authentication status — spinner shown while verifying Azure login. */
+export const CheckingAuth = Template.bind({});
+CheckingAuth.args = {
+  ...baseArgs,
+  isChecking: true,
+  isLoggedIn: false,
+  subscriptions: [],
+};
+
+/** Loading subscriptions — Autocomplete is disabled with a spinner. */
+export const LoadingSubscriptions = Template.bind({});
+LoadingSubscriptions.args = {
+  ...baseArgs,
+  loadingSubscriptions: true,
+  subscriptions: [],
+};
+
+/** Subscription selected, loading clusters. */
+export const LoadingClusters = Template.bind({});
+LoadingClusters.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  loadingClusters: true,
+};
+
+/** Subscription selected, no clusters found. */
+export const NoClusters = Template.bind({});
+NoClusters.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: [],
+};
+
+/** Subscription selected and clusters loaded — cluster picker visible. */
+export const WithClusters = Template.bind({});
+WithClusters.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+};
+
+/** Cluster selected — shows cluster details and enabled Register button. */
+export const ClusterSelected = Template.bind({});
+ClusterSelected.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+};
+
+/** Registration in progress — Register button shows spinner and "Registering...". */
+export const Registering = Template.bind({});
+Registering.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  loading: true,
+};
+
+/** Registration succeeded — success alert and Done button. */
+export const Success = Template.bind({});
+Success.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
+};
+
+/** Registration failed — error alert displayed. */
+export const Error = Template.bind({});
+Error.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  error: 'Failed to register cluster: ECONNREFUSED — Could not reach the Kubernetes API server.',
+};
+
+/** Checking cluster capabilities after registration. */
+export const CheckingCapabilities = Template.bind({});
+CheckingCapabilities.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
+  capabilitiesLoading: true,
+};
+
+/** All capabilities enabled — green success alert. */
+export const AllCapabilitiesEnabled = Template.bind({});
+AllCapabilitiesEnabled.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
+  capabilities: {
+    azureRbacEnabled: true,
+    prometheusEnabled: true,
+    kedaEnabled: true,
+    vpaEnabled: true,
+    networkPolicy: 'cilium',
+  },
+};
+
+/** Azure RBAC not enabled — error alert for RBAC. */
+export const RbacNotEnabled = Template.bind({});
+RbacNotEnabled.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
+  capabilities: {
+    azureRbacEnabled: false,
+    prometheusEnabled: true,
+    kedaEnabled: true,
+    vpaEnabled: true,
+    networkPolicy: 'cilium',
+  },
+};
+
+/** Network policy not configured — warning alert. */
+export const NoNetworkPolicy = Template.bind({});
+NoNetworkPolicy.args = {
+  ...baseArgs,
+  selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
+  clusters: SAMPLE_CLUSTERS,
+  selectedCluster: SAMPLE_CLUSTERS[0],
+  success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
+  capabilities: {
+    azureRbacEnabled: true,
+    prometheusEnabled: true,
+    kedaEnabled: true,
+    vpaEnabled: true,
+    networkPolicy: 'none',
+  },
+};

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
@@ -1,0 +1,371 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import type { ClusterCapabilities } from '../../types/ClusterCapabilities';
+import { ClusterConfigurePanel } from '../CreateAKSProject/components/ClusterConfigurePanel';
+
+export interface Subscription {
+  id: string;
+  name: string;
+  state: string;
+}
+
+export interface AKSCluster {
+  name: string;
+  resourceGroup: string;
+  location: string;
+  kubernetesVersion: string;
+  provisioningState: string;
+}
+
+export interface RegisterAKSClusterDialogPureProps {
+  open: boolean;
+  isChecking: boolean;
+  isLoggedIn: boolean;
+  loading: boolean;
+  loadingSubscriptions: boolean;
+  loadingClusters: boolean;
+  capabilitiesLoading: boolean;
+  error: string;
+  success: string;
+  subscriptions: Subscription[];
+  selectedSubscription: Subscription | null;
+  clusters: AKSCluster[];
+  selectedCluster: AKSCluster | null;
+  capabilities: ClusterCapabilities | null;
+  onClose: () => void;
+  onSubscriptionChange: (event: React.SyntheticEvent, value: Subscription | null) => void;
+  onClusterChange: (event: React.SyntheticEvent, value: AKSCluster | null) => void;
+  onRegister: () => void;
+  onDone: () => void;
+  onDismissError: () => void;
+  onDismissSuccess: () => void;
+  onConfigured?: () => void;
+}
+
+export default function RegisterAKSClusterDialogPure({
+  open,
+  isChecking,
+  isLoggedIn,
+  loading,
+  loadingSubscriptions,
+  loadingClusters,
+  capabilitiesLoading,
+  error,
+  success,
+  subscriptions,
+  selectedSubscription,
+  clusters,
+  selectedCluster,
+  capabilities,
+  onClose,
+  onSubscriptionChange,
+  onClusterChange,
+  onRegister,
+  onDone,
+  onDismissError,
+  onDismissSuccess,
+  onConfigured,
+}: RegisterAKSClusterDialogPureProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="register-aks-dialog-title"
+    >
+      <DialogTitle id="register-aks-dialog-title" component="h1">
+        <Box display="flex" alignItems="center" gap={1}>
+          <Icon icon="logos:microsoft-azure" style={{ fontSize: '24px' }} aria-hidden="true" />
+          <Typography variant="h6" component="span">
+            {t('Register AKS Cluster')}
+          </Typography>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        <Box display="flex" flexDirection="column" gap={2} pt={1}>
+          {error && (
+            <Alert severity="error" onClose={onDismissError}>
+              {error}
+            </Alert>
+          )}
+
+          {success && (
+            <Alert severity="success" onClose={onDismissSuccess}>
+              {success}
+            </Alert>
+          )}
+
+          {capabilitiesLoading && (
+            <Box display="flex" alignItems="center" gap={1}>
+              <CircularProgress size={16} aria-hidden="true" />
+              <Typography variant="body2" color="textSecondary">
+                Checking cluster capabilities...
+              </Typography>
+            </Box>
+          )}
+
+          {capabilities && capabilities.azureRbacEnabled !== true && (
+            <Alert severity="error" sx={{ mb: 1 }}>
+              Azure RBAC for Kubernetes is not enabled. Project role assignments (Admin, Writer,
+              Reader) will not work. This must be set at cluster creation.
+            </Alert>
+          )}
+
+          {capabilities &&
+            (!capabilities.networkPolicy || capabilities.networkPolicy === 'none') && (
+              <Alert severity="warning" sx={{ mb: 1 }}>
+                No network policy engine configured. Network policies will not be enforced. This
+                must be set at cluster creation.
+              </Alert>
+            )}
+
+          {capabilities &&
+            (capabilities.prometheusEnabled !== true ||
+              capabilities.kedaEnabled !== true ||
+              capabilities.vpaEnabled !== true) &&
+            selectedSubscription &&
+            selectedCluster && (
+              <ClusterConfigurePanel
+                capabilities={capabilities}
+                subscriptionId={selectedSubscription.id}
+                resourceGroup={selectedCluster.resourceGroup}
+                clusterName={selectedCluster.name}
+                onConfigured={onConfigured ?? (() => {})}
+              />
+            )}
+
+          {capabilities &&
+            capabilities.azureRbacEnabled === true &&
+            capabilities.prometheusEnabled === true &&
+            capabilities.kedaEnabled === true &&
+            capabilities.vpaEnabled === true &&
+            capabilities.networkPolicy &&
+            capabilities.networkPolicy !== 'none' && (
+              <Alert severity="success">All recommended cluster configurations are in place.</Alert>
+            )}
+
+          {isChecking && (
+            <Box display="flex" alignItems="center" gap={1}>
+              <CircularProgress size={20} aria-hidden="true" />
+              <Typography variant="body2" color="textSecondary">
+                {t('Checking authentication status')}...
+              </Typography>
+            </Box>
+          )}
+
+          {!isChecking && !isLoggedIn && (
+            <Alert severity="warning">
+              {t('You need to be logged in to Azure to register AKS clusters.')}
+            </Alert>
+          )}
+
+          {!isChecking && isLoggedIn && (
+            <>
+              <Autocomplete
+                fullWidth
+                options={subscriptions}
+                value={selectedSubscription}
+                onChange={onSubscriptionChange}
+                getOptionLabel={option =>
+                  `${option.name}${option.state !== 'Enabled' ? ` (${option.state})` : ''}`
+                }
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                disabled={loadingSubscriptions}
+                loading={loadingSubscriptions}
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    label={t('Subscription')}
+                    placeholder={t('Select an Azure subscription')}
+                    InputProps={{
+                      ...params.InputProps,
+                      endAdornment: (
+                        <>
+                          {loadingSubscriptions ? (
+                            <CircularProgress color="inherit" size={20} aria-hidden="true" />
+                          ) : null}
+                          {params.InputProps.endAdornment}
+                        </>
+                      ),
+                    }}
+                  />
+                )}
+                renderOption={(props, option) => (
+                  <li {...props} key={option.id}>
+                    <Box>
+                      <Typography variant="body1">{option.name}</Typography>
+                      {option.state !== 'Enabled' && (
+                        <Typography variant="caption" color="textSecondary">
+                          {option.state}
+                        </Typography>
+                      )}
+                    </Box>
+                  </li>
+                )}
+              />
+
+              {loadingSubscriptions && (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <CircularProgress size={20} aria-hidden="true" />
+                  <Typography variant="body2" color="textSecondary">
+                    {t('Loading subscriptions')}...
+                  </Typography>
+                </Box>
+              )}
+
+              {loadingClusters && (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <CircularProgress size={20} aria-hidden="true" />
+                  <Typography variant="body2" color="textSecondary">
+                    {t('Loading AKS clusters')}...
+                  </Typography>
+                </Box>
+              )}
+
+              {!loadingClusters && selectedSubscription && clusters.length === 0 && (
+                <Alert severity="info">{t('No AKS clusters found in this subscription.')}</Alert>
+              )}
+
+              {!loadingClusters && selectedSubscription && clusters.length > 0 && (
+                <Autocomplete
+                  fullWidth
+                  options={clusters}
+                  value={selectedCluster}
+                  onChange={onClusterChange}
+                  getOptionLabel={option => option.name}
+                  isOptionEqualToValue={(option, value) =>
+                    option.name === value.name && option.resourceGroup === value.resourceGroup
+                  }
+                  renderInput={params => (
+                    <TextField
+                      {...params}
+                      label={t('AKS Cluster')}
+                      placeholder={t('Select an AKS cluster')}
+                    />
+                  )}
+                  renderOption={(props, option) => (
+                    <li {...props} key={`${option.resourceGroup}/${option.name}`}>
+                      <Box width="100%">
+                        <Typography variant="body1">{option.name}</Typography>
+                        <Typography variant="caption" color="textSecondary">
+                          {option.location} • v{option.kubernetesVersion} •{' '}
+                          {option.provisioningState}
+                        </Typography>
+                      </Box>
+                    </li>
+                  )}
+                />
+              )}
+
+              {selectedCluster && !success && (
+                <Box
+                  p={2}
+                  bgcolor="action.hover"
+                  borderRadius={1}
+                  role="region"
+                  aria-label={t('Selected Cluster Details')}
+                >
+                  <Typography variant="subtitle2" component="p" gutterBottom>
+                    {t('Selected Cluster Details')}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>{t('Name')}:</strong> {selectedCluster.name}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>{t('Resource Group')}:</strong> {selectedCluster.resourceGroup}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>{t('Location')}:</strong> {selectedCluster.location}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>{t('Kubernetes Version')}:</strong> {selectedCluster.kubernetesVersion}
+                  </Typography>
+                </Box>
+              )}
+            </>
+          )}
+          {/* Persistent live region for loading status announcements.
+              Stays in the DOM at all times so screen readers register the region
+              before content changes. */}
+          <Box
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            sx={{
+              position: 'absolute',
+              width: '1px',
+              height: '1px',
+              padding: 0,
+              margin: '-1px',
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+            }}
+          >
+            {isChecking
+              ? `${t('Checking authentication status')}...`
+              : loadingSubscriptions
+              ? `${t('Loading subscriptions')}...`
+              : loadingClusters
+              ? `${t('Loading AKS clusters')}...`
+              : capabilitiesLoading
+              ? 'Checking cluster capabilities...'
+              : ''}
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        {success ? (
+          <Button onClick={onDone} variant="contained">
+            {t('Done')}
+          </Button>
+        ) : (
+          <>
+            <Button onClick={onClose} disabled={loading}>
+              {t('Cancel')}
+            </Button>
+            <Button
+              onClick={onRegister}
+              variant="contained"
+              color="primary"
+              disabled={!selectedCluster || loading || !isLoggedIn || isChecking}
+              startIcon={
+                loading ? (
+                  <CircularProgress size={20} aria-hidden="true" />
+                ) : (
+                  <Icon icon="mdi:cloud-check" aria-hidden="true" />
+                )
+              }
+              aria-busy={loading || undefined}
+            >
+              {loading ? `${t('Registering')}...` : t('Register Cluster')}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Description

Screen reader users couldn't properly navigate the Register AKS Cluster dialog — the dialog lacked landmark association, decorative elements were announced, loading states were silent,

For [ADO](https://dev.azure.com/msazure/CloudNativeCompute/_queries/edit/36821127/) item 
This part of the flow mentioned:
> "Register AKS Cluster" dialog will open. Verify all the elements of these dialogs are accessible and MAS compliant.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

## Changes Made

**A11y fixes (`RegisterAKSClusterDialogPure.tsx`)**
- `aria-labelledby="register-aks-dialog-title"` on Dialog → DialogTitle `id`
- `aria-hidden="true"` on all decorative icons (Azure logo, cloud-check) and loading spinners
- Persistent `role="status"` + `aria-live="polite"` region for loading state announcements
- `role="region"` + `aria-label` on Selected Cluster Details
- `aria-busy` on Register button during async operation
- `subtitle2` renders as `<p>` (not `<h6>`) to fix axe `heading-order` rule

**Fix user told they are not logged in issue when they could be logged in.** Added isChecking from useAzureAuth. When isChecking is true, the dialog shows a spinner with "Checking authentication status..." — the not-logged-in warning and subscription form are hidden until the check completes. Register button is also disabled during checking.

**Architecture**
- Extracted `RegisterAKSClusterDialogPure` (props-only, `useTranslation` only) from `RegisterAKSClusterDialog` (hooks/effects wrapper), following established Pure component pattern (`DeployPure`, `CreateAKSProjectPure`)

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [x] Accessibility tested (if applicable)

### Test Cases

1. **10 axe-core WCAG checks** — one per story state (Default, NotLoggedIn, LoadingSubscriptions, ClusterSelected, Registering, Success, Error, AllCapabilitiesEnabled, RbacNotEnabled, NoNetworkPolicy)
2. **29 guidepup virtual screen reader tests** — dialog landmark announced with title, comboboxes labeled, buttons report disabled/busy states, alerts announced with content, status region announces loading text, decorative icons hidden, cluster details region labeled
3. **14 Storybook stories** — visual catalogue for all dialog states
4. Full suite: 981 tests pass

## Screenshots/Videos

N/A — accessibility changes are structural, verified via axe + guidepup virtual screen reader.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why this is acceptable)

## Documentation Updates

- [ ] README.md updated
- [ ] API documentation updated
- [x] Code comments updated
- [ ] User guide updated
- [x] No documentation updates needed

## Reviewer Notes

- The `RegisterAKSClusterDialog` → `RegisterAKSClusterDialogPure` split is the same pattern used by `DeployPure` and `CreateAKSProjectPure`. The wrapper keeps all hooks; the Pure component is props-only and testable.
- axe `heading-order` required changing `subtitle2` from implicit `<h6>` to explicit `component="p"` — the visual styling is unchanged.
