### PR TITLE
aksd: RegisterAKSClusterDialogue: Improve cluster & subscription search for proper prefix matching & fix duplicate cluster name bug

### DIFF
--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
@@ -34,9 +34,32 @@ export default function RegisterAKSClusterDialog({
   const [selectedSubscription, setSelectedSubscription] = useState<Subscription | null>(null);
   const [clusters, setClusters] = useState<AKSCluster[]>([]);
   const [selectedCluster, setSelectedCluster] = useState<AKSCluster | null>(null);
+  const [subscriptionInputValue, setSubscriptionInputValue] = useState('');
+  const [clusterInputValue, setClusterInputValue] = useState('');
   const [capabilities, setCapabilities] = useState<ClusterCapabilities | null>(null);
   const [capabilitiesLoading, setCapabilitiesLoading] = useState(false);
   const isMountedRef = useRef(true);
+
+  /** Helper function to filter options by name substring match, ranking prefix matches first. */
+  function rankNameMatches<T extends { name: string }>(options: T[], inputValue: string): T[] {
+    const query = inputValue.trim().toLowerCase();
+    if (!query) return options;
+    return options
+      .filter(o => o.name.toLowerCase().includes(query))
+      .sort((a, b) => {
+        const ai = a.name.toLowerCase().indexOf(query);
+        const bi = b.name.toLowerCase().indexOf(query);
+        return ai !== bi ? ai - bi : a.name.localeCompare(b.name);
+      });
+  }
+
+  const resetClusterState = () => {
+    setClusters([]);
+    setSelectedCluster(null);
+    setClusterInputValue('');
+    setCapabilities(null);
+    setCapabilitiesLoading(false);
+  };
 
   useEffect(() => {
     return () => {
@@ -75,7 +98,9 @@ export default function RegisterAKSClusterDialog({
 
       // Auto-select if only one subscription
       if (result.subscriptions && result.subscriptions.length === 1) {
-        setSelectedSubscription(result.subscriptions[0]);
+        const sub = result.subscriptions[0];
+        setSelectedSubscription(sub);
+        setSubscriptionInputValue(`${sub.name}${sub.state !== 'Enabled' ? ` (${sub.state})` : ''}`);
       }
     } catch (err) {
       console.error('Error loading subscriptions:', err);
@@ -90,6 +115,7 @@ export default function RegisterAKSClusterDialog({
     setError('');
     setClusters([]);
     setSelectedCluster(null);
+    setClusterInputValue('');
 
     try {
       const result = await getAKSClusters(subscriptionId);
@@ -108,12 +134,51 @@ export default function RegisterAKSClusterDialog({
     }
   };
 
+  const filteredSubscriptions = React.useMemo(() => {
+    return selectedSubscription
+      ? subscriptions
+      : rankNameMatches(subscriptions, subscriptionInputValue);
+  }, [subscriptions, subscriptionInputValue, selectedSubscription]);
+
+  const filteredClusters = React.useMemo(() => {
+    return rankNameMatches(clusters, clusterInputValue);
+  }, [clusters, clusterInputValue]);
+
   const handleSubscriptionChange = (event: React.SyntheticEvent, value: Subscription | null) => {
     setSelectedSubscription(value);
+    setSubscriptionInputValue(
+      value ? `${value.name}${value.state !== 'Enabled' ? ` (${value.state})` : ''}` : ''
+    );
+    resetClusterState();
   };
 
-  const handleClusterChange = (event: React.SyntheticEvent, value: AKSCluster | null) => {
+  const handleSubscriptionInputChange = (
+    _event: React.SyntheticEvent,
+    value: string,
+    reason: string
+  ) => {
+    if (reason === 'input' || reason === 'clear') {
+      setSubscriptionInputValue(value);
+      setSelectedSubscription(null);
+      resetClusterState();
+    }
+  };
+
+  const handleClusterChange = (_event: React.SyntheticEvent, value: AKSCluster | null) => {
     setSelectedCluster(value);
+    setClusterInputValue(value ? value.name : '');
+  };
+
+  const handleClusterInputChange = (
+    _event: React.SyntheticEvent,
+    value: string,
+    reason: string
+  ) => {
+    if (reason === 'input' || reason === 'clear') {
+      setClusterInputValue(value);
+      setSelectedCluster(null);
+      setCapabilities(null);
+    }
   };
 
   const handleRegister = async () => {
@@ -218,14 +283,19 @@ export default function RegisterAKSClusterDialog({
       capabilitiesLoading={capabilitiesLoading}
       error={error}
       success={success}
-      subscriptions={subscriptions}
+      subscriptions={filteredSubscriptions}
       selectedSubscription={selectedSubscription}
+      subscriptionInputValue={subscriptionInputValue}
       clusters={clusters}
+      filteredClusters={filteredClusters}
       selectedCluster={selectedCluster}
+      clusterInputValue={clusterInputValue}
       capabilities={capabilities}
       onClose={handleClose}
       onSubscriptionChange={handleSubscriptionChange}
+      onSubscriptionInputChange={handleSubscriptionInputChange}
       onClusterChange={handleClusterChange}
+      onClusterInputChange={handleClusterInputChange}
       onRegister={handleRegister}
       onDone={handleDone}
       onDismissError={() => setError('')}

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
@@ -44,12 +44,17 @@ const baseArgs: RegisterAKSClusterDialogPureProps = {
   success: '',
   subscriptions: SAMPLE_SUBSCRIPTIONS,
   selectedSubscription: null,
+  subscriptionInputValue: '',
   clusters: [],
+  filteredClusters: [],
+  clusterInputValue: '',
   selectedCluster: null,
   capabilities: null,
   onClose: noOp,
   onSubscriptionChange: noOp as any,
+  onSubscriptionInputChange: noOp as any,
   onClusterChange: noOp as any,
+  onClusterInputChange: noOp as any,
   onRegister: noOp,
   onDone: noOp,
   onDismissError: noOp,
@@ -117,6 +122,7 @@ WithClusters.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
 };
 
 /** Cluster selected — shows cluster details and enabled Register button. */
@@ -125,7 +131,9 @@ ClusterSelected.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
 };
 
 /** Registration in progress — Register button shows spinner and "Registering...". */
@@ -134,7 +142,9 @@ Registering.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   loading: true,
 };
 
@@ -144,7 +154,9 @@ Success.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
 };
 
@@ -154,7 +166,9 @@ Error.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   error: 'Failed to register cluster: ECONNREFUSED — Could not reach the Kubernetes API server.',
 };
 
@@ -164,7 +178,9 @@ CheckingCapabilities.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
   capabilitiesLoading: true,
 };
@@ -175,7 +191,9 @@ AllCapabilitiesEnabled.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
   capabilities: {
     azureRbacEnabled: true,
@@ -192,7 +210,9 @@ RbacNotEnabled.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
   capabilities: {
     azureRbacEnabled: false,
@@ -209,7 +229,9 @@ NoNetworkPolicy.args = {
   ...baseArgs,
   selectedSubscription: SAMPLE_SUBSCRIPTIONS[0],
   clusters: SAMPLE_CLUSTERS,
+  filteredClusters: SAMPLE_CLUSTERS,
   selectedCluster: SAMPLE_CLUSTERS[0],
+  clusterInputValue: SAMPLE_CLUSTERS[0].name,
   success: "Cluster 'prod-aks-cluster' successfully merged in kubeconfig",
   capabilities: {
     azureRbacEnabled: true,

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
@@ -46,12 +46,17 @@ export interface RegisterAKSClusterDialogPureProps {
   success: string;
   subscriptions: Subscription[];
   selectedSubscription: Subscription | null;
+  subscriptionInputValue: string;
   clusters: AKSCluster[];
+  filteredClusters: AKSCluster[];
+  clusterInputValue: string;
   selectedCluster: AKSCluster | null;
   capabilities: ClusterCapabilities | null;
   onClose: () => void;
   onSubscriptionChange: (event: React.SyntheticEvent, value: Subscription | null) => void;
+  onSubscriptionInputChange: (event: React.SyntheticEvent, value: string, reason: string) => void;
   onClusterChange: (event: React.SyntheticEvent, value: AKSCluster | null) => void;
+  onClusterInputChange: (event: React.SyntheticEvent, value: string, reason: string) => void;
   onRegister: () => void;
   onDone: () => void;
   onDismissError: () => void;
@@ -71,12 +76,17 @@ export default function RegisterAKSClusterDialogPure({
   success,
   subscriptions,
   selectedSubscription,
+  subscriptionInputValue,
   clusters,
+  filteredClusters,
   selectedCluster,
+  clusterInputValue,
   capabilities,
   onClose,
   onSubscriptionChange,
+  onSubscriptionInputChange,
   onClusterChange,
+  onClusterInputChange,
   onRegister,
   onDone,
   onDismissError,
@@ -145,7 +155,8 @@ export default function RegisterAKSClusterDialogPure({
               capabilities.kedaEnabled !== true ||
               capabilities.vpaEnabled !== true) &&
             selectedSubscription &&
-            selectedCluster && (
+            selectedCluster &&
+            clusterInputValue === selectedCluster.name && (
               <ClusterConfigurePanel
                 capabilities={capabilities}
                 subscriptionId={selectedSubscription.id}
@@ -187,6 +198,10 @@ export default function RegisterAKSClusterDialogPure({
                 options={subscriptions}
                 value={selectedSubscription}
                 onChange={onSubscriptionChange}
+                inputValue={subscriptionInputValue}
+                onInputChange={onSubscriptionInputChange}
+                filterOptions={x => x}
+                getOptionKey={option => option.id}
                 getOptionLabel={option =>
                   `${option.name}${option.state !== 'Enabled' ? ` (${option.state})` : ''}`
                 }
@@ -250,9 +265,13 @@ export default function RegisterAKSClusterDialogPure({
               {!loadingClusters && selectedSubscription && clusters.length > 0 && (
                 <Autocomplete
                   fullWidth
-                  options={clusters}
+                  options={filteredClusters}
                   value={selectedCluster}
                   onChange={onClusterChange}
+                  inputValue={clusterInputValue}
+                  onInputChange={onClusterInputChange}
+                  filterOptions={x => x}
+                  getOptionKey={option => `${option.resourceGroup}/${option.name}`}
                   getOptionLabel={option => option.name}
                   isOptionEqualToValue={(option, value) =>
                     option.name === value.name && option.resourceGroup === value.resourceGroup
@@ -278,7 +297,7 @@ export default function RegisterAKSClusterDialogPure({
                 />
               )}
 
-              {selectedCluster && !success && (
+              {selectedCluster && clusterInputValue === selectedCluster.name && !success && (
                 <Box
                   p={2}
                   bgcolor="action.hover"


### PR DESCRIPTION
## Description

Currently when searching for clusters in the Register AKS Cluster dialog, results were'nt ranked by relevance. All clusters with the typed input as a substring anywhere in the name would appear first, which would leave a better match far below. (Ex: 'akslatest' would appear before 'testcluster' if you typed in 'test'. Additionally clusters with duplicate names would persist in the dropdown after 'filtering' occured as well, leaving search results with clusters that don't match the query. These are both more observable in large subscriptions.

This PR introduces a ranking function that makes us prioritize prefix matching vs. agnostic substring matching. Additionally, the issue with duplicate clusters is fixed by using the resource group as an additional identifier.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

Observed issue: 
(First, showing matching issue, secondly showing duplicate cluster issue)



https://github.com/user-attachments/assets/a4d7ed48-da9e-4bbf-9b59-a5b3a63014c3

Post-fix:




https://github.com/user-attachments/assets/57c34fa5-3863-400a-8313-46fd699ce5eb

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
