### PR TITLE
headlamp: upstreamable: add muialert styling for dark mode to fix dark mode readability for MUI alerts

### DIFF
--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -496,6 +496,17 @@ export function createMuiTheme(currentTheme: AppTheme) {
             underline: 'hover' as 'always' | 'hover' | 'none',
           },
         },
+        MuiAlert: {
+          styleOverrides: {
+            standardWarning: {
+              backgroundColor: 'rgba(255, 152, 0, 0.12)',
+              color: orange[50],
+              '& .MuiAlert-icon': {
+                color: orange[300],
+              },
+            },
+          },
+        },
         MuiSwitch: {
           styleOverrides: {
             root: {


### PR DESCRIPTION
This PR adds `MuiAlert` styling for dark mode that give us properly-contrasting text, background color & icon colors. 

## Screenshots/Videos
Current:
<img width="399" height="294" alt="image" src="https://github.com/user-attachments/assets/044116c6-7899-4217-95b8-00b8c2e1871e" />
Change:
<img width="401" height="300" alt="image" src="https://github.com/user-attachments/assets/dd504ac0-c924-45a7-9db7-f439535d2bd3" />

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published