### PR TITLE
aksd: derive deep link protocol scheme from package.json

### DIFF
--- a/app/electron/github-oauth.test.ts
+++ b/app/electron/github-oauth.test.ts
@@ -67,6 +67,8 @@ function restoreFetch() {
   global.fetch = originalFetch;
 }
 
+const TEST_REDIRECT_URI = 'test-app://oauth/callback';
+
 describe('handleOAuthCallback', () => {
   let mockMainWindow: ReturnType<typeof createMockMainWindow>;
 
@@ -86,8 +88,8 @@ describe('handleOAuthCallback', () => {
   it('rejects mismatched CSRF state', async () => {
     setPendingState('expected-state');
 
-    const url = new URL('headlamp://oauth/callback?code=test-code&state=wrong-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=test-code&state=wrong-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(GITHUB_OAUTH_CALLBACK, {
       success: false,
@@ -99,8 +101,8 @@ describe('handleOAuthCallback', () => {
   it('rejects missing code parameter', async () => {
     setPendingState('some-state');
 
-    const url = new URL('headlamp://oauth/callback?state=some-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?state=some-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(GITHUB_OAUTH_CALLBACK, {
       success: false,
@@ -111,8 +113,8 @@ describe('handleOAuthCallback', () => {
 
   it('rejects when no pending flow exists', async () => {
     // pendingState is null by default
-    const url = new URL('headlamp://oauth/callback?code=test-code&state=some-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=test-code&state=some-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(GITHUB_OAUTH_CALLBACK, {
       success: false,
@@ -130,8 +132,8 @@ describe('handleOAuthCallback', () => {
       expires_in: 28800,
     });
 
-    const url = new URL('headlamp://oauth/callback?code=auth-code-123&state=valid-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=auth-code-123&state=valid-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     const sendCall = mockMainWindow.webContents.send.mock.calls[0];
     expect(sendCall[0]).toBe(GITHUB_OAUTH_CALLBACK);
@@ -154,8 +156,8 @@ describe('handleOAuthCallback', () => {
       expires_in: 3600,
     });
 
-    const url = new URL('headlamp://oauth/callback?code=code-456&state=valid-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=code-456&state=valid-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(handleSecureStorageSave).toHaveBeenCalledWith(
       expect.stringContaining('secure-storage.json'),
@@ -172,8 +174,8 @@ describe('handleOAuthCallback', () => {
       error_description: 'The code passed is incorrect or expired.',
     });
 
-    const url = new URL('headlamp://oauth/callback?code=expired-code&state=valid-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=expired-code&state=valid-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(GITHUB_OAUTH_CALLBACK, {
       success: false,
@@ -186,8 +188,8 @@ describe('handleOAuthCallback', () => {
 
     mockFetchResponse({}, false, 502);
 
-    const url = new URL('headlamp://oauth/callback?code=code-789&state=valid-state');
-    await handleOAuthCallback(url, mockMainWindow);
+    const url = new URL('test-app://oauth/callback?code=code-789&state=valid-state');
+    await handleOAuthCallback(url, mockMainWindow, TEST_REDIRECT_URI);
 
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(GITHUB_OAUTH_CALLBACK, {
       success: false,

--- a/app/electron/github-oauth.ts
+++ b/app/electron/github-oauth.ts
@@ -19,7 +19,8 @@
 // aksd: GitHub OAuth web flow — handles auth start, deep-link callback, and token refresh
 // entirely in the Electron main process to avoid CORS issues and eliminate the backend proxy.
 //
-// In production the callback arrives via the `headlamp://oauth/callback` custom URL scheme.
+// In production the callback arrives via the app's custom URL scheme (e.g. `aks-desktop://oauth/callback`).
+// The scheme is passed in from the main process via setupGitHubOAuthHandlers({ protocolScheme }).
 // In dev mode (ELECTRON_DEV) we spin up a temporary localhost HTTP server instead, because
 // custom URL schemes are not registered during development (especially under WSL2).
 
@@ -38,7 +39,6 @@ export const CLIENT_ID = 'Iv23liWWbvrfIrA6WWj5';
 // native apps SHOULD NOT be treated as confidential. Security relies on the registered redirect
 // URI, not the secret. GitHub Desktop, VS Code, and other Electron apps follow this pattern.
 export const CLIENT_SECRET = '5a066cc6ca8d2c6f201c45f24f2f4e62905b5d95';
-export const REDIRECT_URI = 'headlamp://oauth/callback';
 export const DEV_CALLBACK_PORT = 48321;
 export const DEV_REDIRECT_URI = `http://localhost:${DEV_CALLBACK_PORT}/oauth/callback`;
 export const STORAGE_KEY = 'aks-desktop:github-auth';
@@ -154,10 +154,12 @@ function startDevCallbackServer(getMainWindow: () => BrowserWindow | null): void
 export function setupGitHubOAuthHandlers(options?: {
   isDev?: boolean;
   getMainWindow?: () => BrowserWindow | null;
+  protocolScheme?: string;
 }): void {
   const isDev = options?.isDev ?? false;
   const getMainWindow = options?.getMainWindow ?? (() => null);
-  const redirectUri = isDev ? DEV_REDIRECT_URI : REDIRECT_URI;
+  const prodRedirectUri = `${options?.protocolScheme ?? 'headlamp'}://oauth/callback`;
+  const redirectUri = isDev ? DEV_REDIRECT_URI : prodRedirectUri;
 
   ipcMain.handle(GITHUB_OAUTH_START, async () => {
     try {
@@ -249,7 +251,7 @@ export function setupGitHubOAuthHandlers(options?: {
 export async function handleOAuthCallback(
   url: URL,
   mainWindow: BrowserWindow,
-  redirectUri: string = REDIRECT_URI
+  redirectUri: string
 ): Promise<void> {
   const code = url.searchParams.get('code');
   const state = url.searchParams.get('state');

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -57,6 +57,26 @@ import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers }
 import { setupSecureStorageHandlers } from './secure-storage';
 import windowSize from './windowSize';
 
+/**
+ * Reads the custom URL protocol scheme from package.json's build.protocols.schemes.
+ * Falls back to the app name (lowercased, spaces replaced with hyphens), then 'headlamp'.
+ */
+function getProtocolScheme(): string {
+  try {
+    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    const schemes: string[] | undefined = pkg?.build?.protocols?.schemes;
+    if (schemes && schemes.length > 0) {
+      return schemes[0];
+    }
+  } catch {
+    // Fall through to fallback
+  }
+  return app.name?.toLowerCase().replace(/\s+/g, '-') || 'headlamp';
+}
+
+const protocolScheme = getProtocolScheme();
+
 let isRunningScript = false;
 if (process.env.HEADLAMP_RUN_SCRIPT) {
   isRunningScript = true;
@@ -1675,7 +1695,7 @@ async function startElectron() {
       // aksd: On Windows/Linux cold start, deep link URLs arrive via process.argv
       // (not via second-instance). Check initial argv after the window is ready.
       if (process.platform !== 'darwin') {
-        const deepLink = process.argv.find(arg => arg.startsWith('headlamp://'));
+        const deepLink = process.argv.find(arg => arg.startsWith(`${protocolScheme}://`));
         if (deepLink) {
           handleDeepLink(deepLink, mainWindow);
         }
@@ -1710,16 +1730,16 @@ async function startElectron() {
       }
     });
 
-    /** Routes headlamp:// deep links to the appropriate handler. Returns true if handled. */
+    /** Routes deep links matching the app's registered protocol scheme to the appropriate handler. */
     function handleDeepLink(urlString: string, targetWindow: BrowserWindow | null): boolean {
       if (!targetWindow) return false;
       try {
         const urlObj = new URL(urlString);
-        if (urlObj.protocol !== 'headlamp:') {
+        if (urlObj.protocol !== `${protocolScheme}:`) {
           return false;
         }
         if (urlObj.hostname === 'oauth' && urlObj.pathname === '/callback') {
-          handleOAuthCallback(urlObj, targetWindow);
+          handleOAuthCallback(urlObj, targetWindow, `${protocolScheme}://oauth/callback`);
           return true;
         }
       } catch {
@@ -1739,7 +1759,7 @@ async function startElectron() {
         }
 
         // aksd: On Windows/Linux, deep link URLs arrive as the last argv element
-        const deepLink = argv.find(arg => arg.startsWith('headlamp://'));
+        const deepLink = argv.find(arg => arg.startsWith(`${protocolScheme}://`));
         if (deepLink) {
           handleDeepLink(deepLink, mainWindow);
         }
@@ -1877,7 +1897,7 @@ async function startElectron() {
 
     // aksd: GitHub OAuth web flow (start, callback, refresh) via main process
     // In dev mode, uses a localhost HTTP callback server instead of the custom URL scheme.
-    setupGitHubOAuthHandlers({ isDev, getMainWindow: () => mainWindow });
+    setupGitHubOAuthHandlers({ isDev, getMainWindow: () => mainWindow, protocolScheme });
 
     // Handle AKS cluster registration
     ipcMain.handle(

--- a/app/package.json
+++ b/app/package.json
@@ -34,9 +34,9 @@
     "asar": false,
     "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
     "protocols": {
-      "name": "headlamp-protocol",
+      "name": "aks-desktop-protocol",
       "schemes": [
-        "headlamp"
+        "aks-desktop"
       ]
     },
     "nsis": {


### PR DESCRIPTION
## Summary

- Deep link protocol was hardcoded as `headlamp://`, causing OAuth callbacks to open Headlamp instead of AKS Desktop when both are installed
- Protocol scheme is now read dynamically from `build.protocols.schemes` in `package.json` at startup, so each Headlamp-based app automatically uses its own registered scheme
- AKS Desktop's scheme updated from `headlamp` to `aks-desktop`

Fixes #458

## Changes

- **`app/package.json`** — Protocol scheme changed from `headlamp` to `aks-desktop`
- **`app/electron/main.ts`** — Added `getProtocolScheme()` that reads the scheme from `package.json` at runtime; all deep link handling uses the dynamic value
- **`app/electron/github-oauth.ts`** — Removed hardcoded `REDIRECT_URI`; `setupGitHubOAuthHandlers` accepts `protocolScheme` option and builds the redirect URI dynamically
- **`app/electron/github-oauth.test.ts`** — Tests updated to use a generic `test-app://` scheme and pass redirect URI explicitly

## Github App Changes

The GitHub OAuth App (client ID `Iv23liWWbvrfIrA6WWj5`) had its callback URL updated to include `aks-desktop://oauth/callback` in the GitHub App settings, and was transferred to the Azure Org

## Testing

- [x] `npm run tsc` — type check passes
- [x] `npm test` — all 73 tests pass
- [x] No remaining hardcoded `headlamp://` references in `app/electron/`
- [ ] End-to-end: build app, trigger "Connect GitHub", confirm callback opens AKS Desktop