### PR TITLE
frontend: Disable i18n check in ci for submodule

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,9 +78,9 @@ jobs:
         run: |
           make frontend-test
 
-      - name: Run frontend-i18n-check
-        run: |
-          make frontend-i18n-check
+      # - name: Run frontend-i18n-check
+      #   run: |
+      #     make frontend-i18n-check
 
   build:
     name: build


### PR DESCRIPTION
we have a ci check in the main branch and this one is not valid