### PR TITLE
aks-desktop: ImportAKSProjects: Fix Go To Projects button

### DIFF
--- a/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
@@ -456,4 +456,43 @@ describe('ImportAKSProjects', () => {
 
     expect(screen.getByText(/Failed to convert namespace/)).toBeInTheDocument();
   });
+
+  test('Go To Projects button navigates via history.replace and reloads', async () => {
+    const reloadMock = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload: reloadMock });
+
+    try {
+      const ns = makeDiscoveredNamespace({
+        name: 'ns-ok',
+        clusterName: 'cluster-a',
+        resourceGroup: 'rg-a',
+        subscriptionId: 'sub-a',
+        isAksProject: true,
+        category: 'needs-import',
+      });
+      mockUseNamespaceDiscovery.mockReturnValue(defaultDiscoveryReturn([ns]));
+      mockRegisterAKSCluster.mockResolvedValue({ success: true });
+
+      render(<ImportAKSProjects />);
+
+      // Select the namespace
+      const row = screen.getByTestId('row-ns-ok');
+      const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      fireEvent.click(checkbox);
+
+      // Click Import Selected (already a project, no conversion dialog)
+      fireEvent.click(screen.getByText('Import Selected Projects'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Go To Projects')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Go To Projects'));
+
+      expect(mockReplace).toHaveBeenCalledWith('/');
+      expect(reloadMock).toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.tsx
@@ -537,7 +537,8 @@ function ImportAKSProjectsContent() {
                       // Navigate to root and force a full reload because Headlamp's cluster
                       // config is loaded at startup and does not reactively update when
                       // kubeconfig/localStorage changes.
-                      window.location.href = '/';
+                      history.replace('/');
+                      window.location.reload();
                     }}
                     startIcon={<Icon icon="mdi:folder-open" />}
                   >


### PR DESCRIPTION
## Description

`window.location.href = '/'` in the Electron desktop app on macOS is interpreted as a filesystem path, opening Finder at `/` instead of navigating within the app. Replaced with `history.replace('/'); window.location.reload()` to match the existing pattern in `RegisterAKSClusterDialog`.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Fixes #456
- https://github.com/Azure/aks-desktop/issues/456


## Changes Made

- **`ImportAKSProjects.tsx`**: Replace `window.location.href = '/'` with `history.replace('/'); window.location.reload()` — React Router replaces the current history entry (avoiding stale back-navigation), then reload picks up kubeconfig/localStorage cluster config changes
- **`ImportAKSProjects.test.tsx`**: Add test asserting the button calls `history.replace('/')` and `window.location.reload()`, using `vi.stubGlobal` with `vi.unstubAllGlobals()` in a `try/finally` block to safely mock the non-configurable `window.location` in JSDOM without global side effects

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

1. All 14 ImportAKSProjects tests pass, including new test verifying `history.replace('/')` and `reload()` are both called when clicking "Go To Projects"

The steps to reproduce are something like this: Home -> Projects -> [Create Project] button -> Use existing namespaces option ->  create the project -> Press [Go to projects] button. It should go to projects, not open finder. Santhosh Nagaraj that correct?



## Screenshots/Videos


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why this is acceptable)

## Documentation Updates

- [ ] README.md updated
- [ ] API documentation updated
- [ ] Code comments updated
- [ ] User guide updated
- [x] No documentation updates needed

## Reviewer Notes

The reload is intentional and matches `RegisterAKSClusterDialog.handleDone` — Headlamp's cluster config is loaded at startup and doesn't reactively update when kubeconfig/localStorage changes after import. Uses `history.replace` (not `push`) to avoid polluting navigation history with a stale import results page. The test uses `vi.stubGlobal`/`vi.unstubAllGlobals()` because JSDOM marks `window.location` properties as non-configurable, which causes both `Object.defineProperty` and `vi.spyOn` to throw.
