### PR TITLE
aksd: fix: AKS project overview cards disappear when plugin config is not initialized.

### DIFF
--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -322,7 +322,7 @@ registerProjectOverviewSection({
   id: 'pipeline-overview',
   // @ts-expect-error isEnabled exists at runtime but is missing from ProjectOverviewSection types
   isEnabled: props =>
-    previewFeaturesStore.get().githubPipelines ? isAksProject(props) : Promise.resolve(false),
+    previewFeaturesStore.get()?.githubPipelines ? isAksProject(props) : Promise.resolve(false),
   // GitHubAuthProvider is duplicated across three registrations (here, DeployTab, and
   // ConfigurePipelineButton) because Headlamp renders each registered component in an
   // independent React tree — there is no shared ancestor to hoist the provider into.


### PR DESCRIPTION
Noticed when testing latest builds that the overview cards weren't rendering (Scaling, Metrics, Cluster Capabilities). I traced it to the 'Enable Github Pipelines' plugin setting. If you've never toggled it, the plugin config is uninitialized, which propagates in an error when registering the project since `isEnabled` ends up receiving an undefined value. 

To fix this, added the `?` operator for a graceful fallback to false if undefined, so we can still view AKS Overview cards if plugin settings haven't been set yet. 

How it looks: 
<img width="1341" height="681" alt="image" src="https://github.com/user-attachments/assets/101cf3d0-2aad-4fce-bf26-f7bc801390f7" />

To test- you can manually remove your plugin config with `localStorage.removeItem('pluginConfigs')` & then attempt to view an AKS project. You should see the AKS overview cards appear as intended.