### PR TITLE
aks-desktop: a11y: Add anouncements for empty state messages

### DIFF
--- a/plugins/aks-desktop/src/components/DeployTab/DeployTab.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/DeployTab.tsx
@@ -3,7 +3,8 @@
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Box, Typography } from '@mui/material';
-import React from 'react';
+import { visuallyHidden } from '@mui/utils';
+import React, { useEffect, useState } from 'react';
 import { usePreviewFeatures } from '../../hooks/usePreviewFeatures';
 import type { ProjectDefinition } from '../../types/project';
 import { ClusterDeployCard } from './components/ClusterDeployCard';
@@ -17,6 +18,12 @@ function DeployTab({ project }: DeployTabProps) {
   const { t } = useTranslation();
   const { githubPipelines } = usePreviewFeatures();
   const { settings } = usePipelineSettings();
+  // Deferred flag: starts false so the live region mounts with empty text,
+  // then flips to true after the first paint so the text change is announced.
+  const [liveReady, setLiveReady] = useState(false);
+  useEffect(() => {
+    setLiveReady(true);
+  }, []);
 
   if (!githubPipelines) {
     return (
@@ -32,6 +39,10 @@ function DeployTab({ project }: DeployTabProps) {
     <Box sx={{ my: 3 }}>
       <Box sx={{ mb: 3 }}>
         <Typography variant="h5">{t('Workloads')}</Typography>
+      </Box>
+
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {liveReady && project.clusters?.length === 0 ? t('No clusters in this project.') : ''}
       </Box>
 
       {project.clusters?.length === 0 && (

--- a/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
@@ -20,6 +20,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import React, { useMemo, useState } from 'react';
 import { useAzureContext } from '../../../hooks/useAzureContext';
 import type { GitHubRepo } from '../../../types/github';
@@ -174,6 +175,12 @@ export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: Clust
             {error}
           </Typography>
         )}
+
+        <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+          {!loading && !error && deployments.length === 0
+            ? t('No deployments found in this namespace.')
+            : ''}
+        </Box>
 
         {!loading && !error && (
           <>

--- a/plugins/aks-desktop/src/components/Deployments/PipelineCard.tsx
+++ b/plugins/aks-desktop/src/components/Deployments/PipelineCard.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import React from 'react';
 import { usePreviewFeatures } from '../../hooks/usePreviewFeatures';
 import type { ProjectDefinition } from '../../types/project';
@@ -134,6 +135,10 @@ function PipelineCard({ project }: PipelineCardProps) {
               {error}
             </Typography>
           )}
+
+          <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+            {!loading && !error && runs.length === 0 ? t('No pipeline runs yet.') : ''}
+          </Box>
 
           {!loading && !error && runs.length === 0 && (
             <Typography variant="body2" color="text.secondary">

--- a/plugins/aks-desktop/src/components/GitHubPipeline/components/RepoSelector.tsx
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/components/RepoSelector.tsx
@@ -12,6 +12,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import type { Octokit } from '@octokit/rest';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { GitHubRepo } from '../../../types/github';
@@ -86,6 +87,14 @@ export function RepoSelector({ octokit, selectedRepo, onRepoSelect }: RepoSelect
           {error}
         </Alert>
       )}
+
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {!loading && !error && filtered.length === 0
+          ? filter
+            ? t('No repositories match your filter')
+            : t('No repositories found')
+          : ''}
+      </Box>
 
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>

--- a/plugins/aks-desktop/src/components/LogsTab/LogsTab.tsx
+++ b/plugins/aks-desktop/src/components/LogsTab/LogsTab.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { LogsViewer } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { type KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
 import { Box, Card, MenuItem, TextField, Typography } from '@mui/material';
-import React, { useMemo, useState } from 'react';
+import { visuallyHidden } from '@mui/utils';
+import React, { useEffect, useMemo, useState } from 'react';
 
 interface LogsTabProps {
   projectResources: KubeObject[];
@@ -20,6 +21,12 @@ const LogsTab = ({ projectResources }: LogsTabProps) => {
     [projectResources]
   );
   const [deploymentId, setDeploymentId] = useState<string>('');
+  // Deferred flag: starts false so the live region mounts with empty text,
+  // then flips to true after the first paint so the text change is announced.
+  const [liveReady, setLiveReady] = useState(false);
+  useEffect(() => {
+    setLiveReady(true);
+  }, []);
 
   if (!deploymentId && deployments.length > 0) {
     setDeploymentId(deployments[0].jsonData.metadata.uid as string);
@@ -30,55 +37,61 @@ const LogsTab = ({ projectResources }: LogsTabProps) => {
     [deployments, deploymentId]
   );
 
-  if (!deployments.length)
-    return (
-      <Card sx={{ p: 4, textAlign: 'center', mt: 2 }}>
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          justifyContent="center"
-          sx={{ color: 'text.secondary' }}
-        >
-          <Icon
-            icon="mdi:chart-box-outline"
-            style={{ marginBottom: 16, fontSize: 64, color: 'currentColor' }}
-          />
-          <Typography variant="h6" color="textSecondary" gutterBottom>
-            {t('No Deployments Found')}
-          </Typography>
-          <Typography color="textSecondary" variant="body2">
-            {t('There are no deployments in this project namespace yet.')}
-          </Typography>
-          <Typography color="textSecondary" variant="body2">
-            {t('Deploy an application to view logs.')}
-          </Typography>
-        </Box>
-      </Card>
-    );
-
   return (
     <>
-      {deployments.length > 1 && (
-        <Box sx={{ p: 2, px: 1 }}>
-          <TextField
-            select
-            size="small"
-            variant="outlined"
-            onChange={e => setDeploymentId(e.target.value)}
-            value={deploymentId}
-            label={t('Deployment')}
+      {/* Always-mounted live region for empty-state announcement */}
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {liveReady && deployments.length === 0 ? t('No Deployments Found') : ''}
+      </Box>
+
+      {!deployments.length ? (
+        <Card sx={{ p: 4, textAlign: 'center', mt: 2 }}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            sx={{ color: 'text.secondary' }}
           >
-            {deployments.map(d => (
-              <MenuItem key={d.jsonData.metadata.uid} value={d.jsonData.metadata.uid}>
-                {d.jsonData.metadata.name}
-              </MenuItem>
-            ))}
-          </TextField>
-        </Box>
-      )}
-      {selectedDeployment && (
-        <LogsViewer item={selectedDeployment} key={selectedDeployment.jsonData.metadata.uid} />
+            <Icon
+              icon="mdi:chart-box-outline"
+              style={{ marginBottom: 16, fontSize: 64, color: 'currentColor' }}
+            />
+            <Typography variant="h6" color="textSecondary" gutterBottom>
+              {t('No Deployments Found')}
+            </Typography>
+            <Typography color="textSecondary" variant="body2">
+              {t('There are no deployments in this project namespace yet.')}
+            </Typography>
+            <Typography color="textSecondary" variant="body2">
+              {t('Deploy an application to view logs.')}
+            </Typography>
+          </Box>
+        </Card>
+      ) : (
+        <>
+          {deployments.length > 1 && (
+            <Box sx={{ p: 2, px: 1 }}>
+              <TextField
+                select
+                size="small"
+                variant="outlined"
+                onChange={e => setDeploymentId(e.target.value)}
+                value={deploymentId}
+                label={t('Deployment')}
+              >
+                {deployments.map(d => (
+                  <MenuItem key={d.jsonData.metadata.uid} value={d.jsonData.metadata.uid}>
+                    {d.jsonData.metadata.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Box>
+          )}
+          {selectedDeployment && (
+            <LogsViewer item={selectedDeployment} key={selectedDeployment.jsonData.metadata.uid} />
+          )}
+        </>
       )}
     </>
   );

--- a/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
+++ b/plugins/aks-desktop/src/components/MetricsTab/MetricsTab.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   CartesianGrid,
@@ -129,6 +130,7 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
   const [pods, setPods] = useState<PodInfo[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [metricsLoading, setMetricsLoading] = useState<boolean>(false);
+  const [hasFetchedMetrics, setHasFetchedMetrics] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [memoryUnit, setMemoryUnit] = useState<MemoryUnit>('MB');
 
@@ -559,6 +561,7 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
       setError(errorMessage);
     } finally {
       setMetricsLoading(false);
+      setHasFetchedMetrics(true);
     }
   }, [namespace, cluster, selectedDeployment, subscription, resourceGroupLabel]);
 
@@ -617,6 +620,22 @@ const MetricsTab: React.FC<MetricsTabProps> = ({ project }) => {
           onDeploymentChange={setSelectedDeployment}
           sx={{ minWidth: 300 }}
         />
+      </Box>
+
+      {/* Always-mounted consolidated live region for empty chart announcements */}
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {selectedDeployment && !metricsLoading && hasFetchedMetrics
+          ? [
+              requestErrorData.length === 0 &&
+                `${t('Request & error rate')}: ${t('No data available')}`,
+              responseTimeData.length === 0 && `${t('Response Time')}: ${t('No data available')}`,
+              cpuData.length === 0 && `${t('CPU Usage')}: ${t('No data available')}`,
+              memoryData.length === 0 && `${t('Memory utilization')}: ${t('No data available')}`,
+              networkData.length === 0 && `${t('Network I/O')}: ${t('No data available')}`,
+            ]
+              .filter(Boolean)
+              .join('. ')
+          : ''}
       </Box>
 
       {deployments.length === 0 ? (

--- a/plugins/aks-desktop/src/components/Scaling/ScalingCard.tsx
+++ b/plugins/aks-desktop/src/components/Scaling/ScalingCard.tsx
@@ -98,6 +98,7 @@ function ScalingCard({ project }: ScalingCardProps) {
           deployments={deployments}
           loading={loading}
           onDeploymentChange={setSelectedDeployment}
+          suppressLiveRegion
         />
       </Box>
 

--- a/plugins/aks-desktop/src/components/Scaling/components/ScalingChart.tsx
+++ b/plugins/aks-desktop/src/components/Scaling/components/ScalingChart.tsx
@@ -4,7 +4,8 @@
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Alert, AlertTitle, Box, CircularProgress, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React from 'react';
+import { visuallyHidden } from '@mui/utils';
+import React, { useEffect, useState } from 'react';
 import {
   CartesianGrid,
   Legend,
@@ -54,106 +55,127 @@ interface ScalingChartProps {
 export const ScalingChart: React.FC<ScalingChartProps> = ({ chartData, loading, error }) => {
   const { t } = useTranslation();
   const theme = useTheme();
+  // Deferred flag: starts false so the live region mounts with empty text,
+  // then flips to true after the first paint so the text change is announced.
+  const [liveReady, setLiveReady] = useState(false);
+  useEffect(() => {
+    if (!loading) {
+      setLiveReady(true);
+    }
+  }, [loading]);
 
-  if (loading) {
-    return (
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        height="100%"
-      >
-        <CircularProgress size={32} sx={{ mb: 1 }} />
-        <Typography variant="body2" color="text.secondary">
-          {t('Loading scaling metrics from Prometheus')}...
-        </Typography>
-      </Box>
-    );
-  }
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          height="100%"
+        >
+          <CircularProgress size={32} sx={{ mb: 1 }} />
+          <Typography variant="body2" color="text.secondary">
+            {t('Loading scaling metrics from Prometheus')}...
+          </Typography>
+        </Box>
+      );
+    }
 
-  if (error) {
-    return (
-      <Box display="flex" alignItems="center" justifyContent="center" height="100%" p={2}>
-        <Alert severity="warning" sx={{ maxWidth: 600 }}>
-          <AlertTitle>{t('Scaling Chart Unavailable')}</AlertTitle>
-          {error}
-        </Alert>
-      </Box>
-    );
-  }
+    if (error) {
+      return (
+        <Box display="flex" alignItems="center" justifyContent="center" height="100%" p={2}>
+          <Alert severity="warning" sx={{ maxWidth: 600 }}>
+            <AlertTitle>{t('Scaling Chart Unavailable')}</AlertTitle>
+            {error}
+          </Alert>
+        </Box>
+      );
+    }
 
-  if (chartData.length === 0) {
+    if (chartData.length === 0) {
+      return (
+        <Box display="flex" alignItems="center" justifyContent="center" height="100%">
+          <Typography color="textSecondary" variant="body2">
+            {t('No scaling data available')}
+          </Typography>
+        </Box>
+      );
+    }
+
     return (
-      <Box display="flex" alignItems="center" justifyContent="center" height="100%">
-        <Typography color="textSecondary" variant="body2">
-          {t('No scaling data available')}
-        </Typography>
-      </Box>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={chartData}
+          margin={{
+            top: 10,
+            right: 30,
+            left: 20,
+            bottom: 30,
+          }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
+          <XAxis
+            dataKey="time"
+            stroke={theme.palette.text.secondary}
+            fontSize={10}
+            tick={
+              <AngledTick fill={theme.palette.text.secondary} x={0} y={0} payload={{ value: '' }} />
+            }
+            tickLine={{ stroke: theme.palette.divider }}
+            interval={0} // Show all ticks (12 labels over 24 hours)
+            height={50}
+          />
+          <YAxis
+            stroke={theme.palette.text.secondary}
+            fontSize={10}
+            tick={{ fontSize: 10 }}
+            tickLine={{ stroke: theme.palette.divider }}
+            domain={[0, 'dataMax + 1']}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: '6px',
+              fontSize: '11px',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+              color: theme.palette.text.primary,
+            }}
+            labelStyle={{ color: theme.palette.text.secondary }}
+          />
+          <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '5px' }} />
+          <Line
+            type="monotone"
+            dataKey="Replicas"
+            name={t('Replicas')}
+            stroke="#66BB6A"
+            strokeWidth={2}
+            dot={{ fill: '#66BB6A', strokeWidth: 0, r: 2 }}
+            activeDot={{ r: 4, stroke: '#66BB6A', strokeWidth: 0, fill: '#66BB6A' }}
+          />
+          <Line
+            type="monotone"
+            dataKey="CPU"
+            name={t('CPU')}
+            stroke="#42A5F5"
+            strokeWidth={2}
+            dot={{ fill: '#42A5F5', strokeWidth: 0, r: 2 }}
+            activeDot={{ r: 4, stroke: '#42A5F5', strokeWidth: 0, fill: '#42A5F5' }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
     );
-  }
+  };
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <LineChart
-        data={chartData}
-        margin={{
-          top: 10,
-          right: 30,
-          left: 20,
-          bottom: 30,
-        }}
-      >
-        <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
-        <XAxis
-          dataKey="time"
-          stroke={theme.palette.text.secondary}
-          fontSize={10}
-          tick={
-            <AngledTick fill={theme.palette.text.secondary} x={0} y={0} payload={{ value: '' }} />
-          }
-          tickLine={{ stroke: theme.palette.divider }}
-          interval={0} // Show all ticks (12 labels over 24 hours)
-          height={50}
-        />
-        <YAxis
-          stroke={theme.palette.text.secondary}
-          fontSize={10}
-          tick={{ fontSize: 10 }}
-          tickLine={{ stroke: theme.palette.divider }}
-          domain={[0, 'dataMax + 1']}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: theme.palette.background.paper,
-            border: `1px solid ${theme.palette.divider}`,
-            borderRadius: '6px',
-            fontSize: '11px',
-            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-            color: theme.palette.text.primary,
-          }}
-          labelStyle={{ color: theme.palette.text.secondary }}
-        />
-        <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '5px' }} />
-        <Line
-          type="monotone"
-          dataKey="Replicas"
-          name={t('Replicas')}
-          stroke="#66BB6A"
-          strokeWidth={2}
-          dot={{ fill: '#66BB6A', strokeWidth: 0, r: 2 }}
-          activeDot={{ r: 4, stroke: '#66BB6A', strokeWidth: 0, fill: '#66BB6A' }}
-        />
-        <Line
-          type="monotone"
-          dataKey="CPU"
-          name={t('CPU')}
-          stroke="#42A5F5"
-          strokeWidth={2}
-          dot={{ fill: '#42A5F5', strokeWidth: 0, r: 2 }}
-          activeDot={{ r: 4, stroke: '#42A5F5', strokeWidth: 0, fill: '#42A5F5' }}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <>
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {liveReady && !loading && !error && chartData.length === 0
+          ? t('No scaling data available')
+          : ''}
+      </Box>
+      {renderContent()}
+    </>
   );
 };

--- a/plugins/aks-desktop/src/components/shared/DeploymentSelector.tsx
+++ b/plugins/aks-desktop/src/components/shared/DeploymentSelector.tsx
@@ -2,8 +2,9 @@
 // Licensed under the Apache 2.0.
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { CircularProgress, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import { Box, CircularProgress, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { visuallyHidden } from '@mui/utils';
 import React from 'react';
 
 interface DeploymentSelectorProps {
@@ -12,6 +13,9 @@ interface DeploymentSelectorProps {
   loading?: boolean;
   onDeploymentChange: (deploymentName: string) => void;
   sx?: SxProps<Theme>;
+  /** When true, suppress the visually-hidden live region to avoid duplicate announcements
+   *  when multiple DeploymentSelector instances appear on the same page. */
+  suppressLiveRegion?: boolean;
 }
 
 /**
@@ -23,37 +27,50 @@ export const DeploymentSelector: React.FC<DeploymentSelectorProps> = ({
   loading = false,
   onDeploymentChange,
   sx,
+  suppressLiveRegion = false,
 }) => {
   const { t } = useTranslation();
+  const id = React.useId();
+  const labelId = `${id}-deployment-selector-label`;
+  const selectId = `${id}-deployment-selector`;
 
   return (
-    <FormControl
-      sx={[{ minWidth: 200 }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
-      size="small"
-      variant="outlined"
-    >
-      <InputLabel>{t('Select Deployment')}</InputLabel>
-      <Select
-        value={selectedDeployment || ''}
-        onChange={e => onDeploymentChange(e.target.value as string)}
-        label={t('Select Deployment')}
-        disabled={loading || deployments.length === 0}
+    <>
+      {!suppressLiveRegion && (
+        <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+          {!loading && deployments.length === 0 ? t('No deployments found') : ''}
+        </Box>
+      )}
+      <FormControl
+        sx={[{ minWidth: 200 }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
+        size="small"
+        variant="outlined"
       >
-        {loading ? (
-          <MenuItem disabled>
-            <CircularProgress size={16} style={{ marginRight: 8 }} />
-            {t('Loading deployments')}...
-          </MenuItem>
-        ) : deployments.length === 0 ? (
-          <MenuItem disabled>{t('No deployments found')}</MenuItem>
-        ) : (
-          deployments.map(deployment => (
-            <MenuItem key={deployment.name} value={deployment.name}>
-              {deployment.name}
+        <InputLabel id={labelId}>{t('Select Deployment')}</InputLabel>
+        <Select
+          id={selectId}
+          labelId={labelId}
+          value={selectedDeployment || ''}
+          onChange={e => onDeploymentChange(e.target.value as string)}
+          label={t('Select Deployment')}
+          disabled={loading || deployments.length === 0}
+        >
+          {loading ? (
+            <MenuItem disabled>
+              <CircularProgress size={16} style={{ marginRight: 8 }} />
+              {t('Loading deployments')}...
             </MenuItem>
-          ))
-        )}
-      </Select>
-    </FormControl>
+          ) : deployments.length === 0 ? (
+            <MenuItem disabled>{t('No deployments found')}</MenuItem>
+          ) : (
+            deployments.map(deployment => (
+              <MenuItem key={deployment.name} value={deployment.name}>
+                {deployment.name}
+              </MenuItem>
+            ))
+          )}
+        </Select>
+      </FormControl>
+    </>
   );
 };


### PR DESCRIPTION
## Description

Screen readers (Narrator/NVDA) don't announce empty state messages ("No data available", "No deployments found", etc.) because the elements lack ARIA live region attributes. The existing `EmptyContent.tsx` used by `Table`/`SimpleTable` already has these attributes, but many plugin components render their own status messages with plain `Typography` elements.

Additionally, ARIA live regions only announce **changes** to their content — elements mounted with content already present are not announced. All live regions in this PR use the always-mounted pattern: mount a visually-hidden `<Box>` with empty text, then toggle the text when the empty state is detected, ensuring screen readers reliably pick up the change.

For components that derive data synchronously from props with no loading state (e.g. `LogsTab`, `DeployTab`), a deferred `liveReady` flag (`useState(false)` + `useEffect(() => setLiveReady(true), [])`) ensures the text transitions from `''` → message after the first paint, since ARIA live regions ignore content already present at mount. Components with async loading gates (`!loading`, `!metricsLoading`) naturally create this transition when loading settles.

For components where async loading state initializes to `false` and flips to `true` in a post-render effect (e.g. `ScalingChart` via `useChartData`, `MetricsTab` via `metricsLoading`), additional guards prevent premature announcements: `ScalingChart` uses a deferred `liveReady` flag that only flips `true` after the first load completes, and `MetricsTab` uses a `hasFetchedMetrics` flag that flips after the first fetch settles.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

## Changes Made

Added always-mounted visually-hidden `<Box role="status" aria-live="polite" aria-atomic="true">` live regions with toggled text content to all empty state messages missing live region attributes. The visible `Typography` elements remain for sighted users but no longer carry ARIA live region attributes (since they are conditionally rendered and would not be announced).

- **MetricsTab.tsx** — Single consolidated always-mounted visually-hidden live region with `aria-atomic="true"` that summarizes all empty chart states by composing existing translated fragments at runtime (e.g. `` `${t('Request & error rate')}: ${t('No data available')}` ``), avoiding new untranslated i18n keys. The region is gated on `!metricsLoading`, `selectedDeployment`, and a `hasFetchedMetrics` flag that only flips `true` after `fetchMetrics()` completes, preventing premature announcements when `metricsLoading` starts as `false`. The "No Deployments Found" Card relies on `DeploymentSelector`'s own hidden live region to avoid duplicate announcements.
- **ClusterDeployCard.tsx** — Always-mounted hidden Box for "No deployments found in this namespace". Gated on `!loading` which naturally creates the text transition.
- **DeployTab.tsx** — Always-mounted hidden Box for "No clusters in this project". Uses deferred `liveReady` flag since data is derived synchronously from props with no loading state.
- **PipelineCard.tsx** — Always-mounted hidden Box for "No pipeline runs yet". Gated on `!loading` which naturally creates the text transition.
- **RepoSelector.tsx** — Always-mounted hidden Box for "No repositories match your filter" / "No repositories found". Gated on `!loading` and `!error` to avoid contradictory announcements when an error Alert is displayed.
- **ScalingChart.tsx** — Refactored early returns to single return with persistent always-mounted live region for "No scaling data available". Uses a deferred `liveReady` flag that flips `true` only after `loading` finishes, since `useChartData` initializes `loading` to `false` and the live region would otherwise mount with content already present.
- **LogsTab.tsx** — Always-mounted hidden Box for "No Deployments Found". Refactored from early-return style to single return so the live region Box persists across all states. Uses deferred `liveReady` flag since deployments are derived synchronously from props with no loading state.
- **DeploymentSelector.tsx** — Always-mounted visually-hidden live region announcing "No deployments found" (matching the visible disabled `MenuItem` text). Disabled `MenuItem` elements are ignored by screen readers, so ARIA attributes on them don't work. Added `React.useId()`-derived per-instance `id`/`labelId` association between `InputLabel` and `Select` for proper programmatic labeling, ensuring unique IDs when multiple `DeploymentSelector` instances render on the same page (e.g. MetricsCard + ScalingCard). Added `suppressLiveRegion` prop so parents can prevent duplicate announcements when multiple instances are on the same page; `ScalingCard` passes this prop to its instance.

## Testing

Make sure to try nvda



## Screenshots/Videos


<img width="1918" height="1222" alt="Screenshot 2026-03-18 153333" src="https://github.com/user-attachments/assets/1e5db839-4290-42f4-8a3f-1489e596bb70" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Breaking Changes

N/A

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why this is acceptable)

## Documentation Updates

- [ ] README.md updated
- [ ] API documentation updated
- [ ] Code comments updated
- [ ] User guide updated
- [x] No documentation updates needed
