### PR TITLE
Breadcrumb: wrap steps at high text zoom for a11y compliance

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.stories.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.stories.tsx
@@ -32,3 +32,10 @@ export const MiddleStep: StoryFn<BreadcrumbProps> = () => (
 export const LastStep: StoryFn<BreadcrumbProps> = () => (
   <Breadcrumb {...BASE_PROPS} activeStep={4} />
 );
+
+/** Narrow container — verifies wrap behavior at constrained widths (e.g., 200% zoom). */
+export const NarrowContainer: StoryFn<BreadcrumbProps> = () => (
+  <div style={{ width: 500, border: '1px dashed #ccc' }}>
+    <Breadcrumb {...BASE_PROPS} activeStep={4} />
+  </div>
+);

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/Breadcrumb.tsx
@@ -27,12 +27,10 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ steps, activeStep, onSte
         alignItems: 'center',
         // @ts-ignore todo: fix this
         backgroundColor: theme.palette.background.muted,
+        flexWrap: 'wrap',
+        gap: 1,
         px: 3,
         py: 2,
-        overflowX: 'auto',
-        [theme.breakpoints.down('md')]: {
-          flexDirection: 'column',
-        },
       })}
     >
       {steps.map((label, index) => (
@@ -100,13 +98,17 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ steps, activeStep, onSte
             >
               {label}
             </Typography>
-          </Box>
 
-          {index < steps.length - 1 && (
-            <Typography variant="body1" sx={{ mx: 2, color: 'text.secondary' }}>
-              &gt;
-            </Typography>
-          )}
+            {index < steps.length - 1 && (
+              <Typography
+                variant="body1"
+                sx={{ ml: 1, color: 'text.secondary' }}
+                aria-hidden="true"
+              >
+                &gt;
+              </Typography>
+            )}
+          </Box>
         </React.Fragment>
       ))}
     </Box>


### PR DESCRIPTION
## Description

At 200% text resize on 1280x768, the Create Project breadcrumb stepper clips the last steps ("Access", "Review") behind a horizontal scrollbar, violating MAS 1.4.4 (Resize Text).

This replaces the horizontal scroll overflow with `flexWrap: 'wrap'` so steps flow to the next line instead of being hidden.

<img width="169" height="435" alt="image" src="https://github.com/user-attachments/assets/7705c87e-641d-4006-94da-5df7a2762e8c" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #469

## Changes Made

- **Breadcrumb container**: replaced `overflowX: 'auto'` with `flexWrap: 'wrap'` and `gap: 1` so steps wrap instead of scrolling
- **Breadcrumb container**: removed `flexDirection: 'column'` at `md` breakpoint — `flexWrap` handles narrow widths
- **Separators**: moved `>` inside each step button so it wraps as a unit with its label
- **Separators**: added `aria-hidden="true"` so screen readers skip the decorative `>` character
- **Storybook**: added `NarrowContainer` story (fixed 500px width with border) to verify wrapped layout

## Testing

- [x] Unit tests pass
- [x] Accessibility tested (if applicable)

### Test Cases

1. Storybook `NarrowContainer` story shows all 5 steps wrapping correctly
2. At 1280x768 / 200% text size, all stepper steps are fully visible on the Create Project page
3. At normal (100%) text size, breadcrumb displays in a single row as before
4. Next/Back footer buttons navigate between steps correctly
5. Clicking a breadcrumb step navigates to that step
6. Screen reader does not announce `>` separators

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact