### PR TITLE
aksd: InfoTab: Only enable this tab for aks projects

### DIFF
--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -339,6 +339,7 @@ registerProjectDetailsTab({
   id: 'info',
   label: 'Info',
   icon: 'mdi:information',
+  isEnabled: isAksProject,
   component: ({ project }) => <InfoTab project={project} />,
 });
 


### PR DESCRIPTION
this PR will hide the info tab from projects that are not aks projects
