### PR TITLE
frontend: ProjectDetails: Hide project details card when they're empty

### DIFF
--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -330,7 +330,7 @@ function ProjectOverview({
       </Grid>
 
       {projectSections.map(section => (
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12} md={4} sx={{ '&:has(.MuiCardContent-root:empty)': { display: 'none' } }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <section.component


### PR DESCRIPTION
This change hides empty Project details card in pure CSS
So when a card returns null it automatically hides the parent grid item