### PR TITLE
SearchableSelect: Announce no options when opening the dropdown

### DIFF
--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
@@ -49,6 +49,7 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
   const resolvedPlaceholder = placeholder ?? `${t('Select an option')}...`;
   const resolvedNoResults = noResultsText ?? t('No options');
   const [inputValue, setInputValue] = useState('');
+  const [open, setOpen] = useState(false);
 
   // Sort options alphabetically by label
   const sortedOptions = useMemo(() => {
@@ -59,7 +60,7 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
 
   // Replicate MUI's default filter to detect zero matches for screen reader announcement
   const noFilteredResults = useMemo(() => {
-    if (!inputValue) return false;
+    if (inputValue === '' && sortedOptions.length === 0) return true;
     const lower = inputValue.toLowerCase();
     return !sortedOptions.some(opt => opt.label.toLowerCase().includes(lower));
   }, [sortedOptions, inputValue]);
@@ -67,9 +68,12 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
   return (
     <>
       <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
-        {noFilteredResults ? resolvedNoResults : ''}
+        {open && noFilteredResults ? resolvedNoResults : ''}
       </Box>
       <Autocomplete
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
         inputValue={inputValue}
         onInputChange={(_, newValue) => setInputValue(newValue)}
         options={sortedOptions}


### PR DESCRIPTION
This PR handles screen reader narration when select dropdown was opened.
Previously it would only read out the message after user typed something in and there were no results.

Attaching videos with NVDA and Windows Narrator, first opening the dropdown with "arrow down" key to show the new fix, then typing in something to show that the previous behavior also still works

NVDA:

https://github.com/user-attachments/assets/d05529b2-fdcb-430f-9bdc-e597474e739c

Windows Narrator:

https://github.com/user-attachments/assets/d7925531-5bec-4359-bbda-2792f997ead9


