### PR TITLE
upstreamable: resourceMap: group unscheduled pods in node view

### DIFF
--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -16,7 +16,7 @@
 
 import { KubeMetadata } from '../../../lib/k8s/KubeMetadata';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
-import { getMainNode, groupGraph } from './graphGrouping';
+import { getMainNode, groupGraph, UNSCHEDULED_GROUP } from './graphGrouping';
 import { GraphEdge, GraphNode } from './graphModel';
 
 describe('getMainNode', () => {
@@ -115,11 +115,22 @@ describe('groupGraph', () => {
     });
     const nodeNames = groupedGraph.nodes?.map(node => node.id);
 
-    // Node 2 is grouped into Node-node1 group
-    // Nodes 1, 3 and 4 don't have a node and are not grouped
-    // After sorting by weight (descending) and ID (stable sort),
-    // individual nodes come first, then group because no edges are present
-    expect(nodeNames).toEqual(['1', '3', '4', 'Node-node1']);
+    // Pods 1, 3 and 4 have no nodeName and are grouped into Node-Unscheduled
+    // Pod 2 has nodeName 'node1' and is grouped into Node-node1
+    expect(nodeNames).toHaveLength(2);
+    expect(nodeNames).toEqual(expect.arrayContaining(['Node-Unscheduled', 'Node-node1']));
+  });
+
+  it('does not link a kubeObject to the Unscheduled group', () => {
+    const groupedGraph = groupGraph(nodes, edges, {
+      groupBy: 'node',
+      namespaces: [],
+      k8sNodes: [],
+    });
+    const unscheduledGroup = groupedGraph.nodes?.find(n => n.label === UNSCHEDULED_GROUP);
+    expect(unscheduledGroup).toBeDefined();
+    expect(unscheduledGroup?.kubeObject).toBeUndefined();
+    expect(unscheduledGroup?.nodes?.length).toBe(3);
   });
 
   it('groups nodes by instance', () => {

--- a/frontend/src/components/resourceMap/graph/graphGrouping.tsx
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.tsx
@@ -23,6 +23,8 @@ import { forEachNode, getNodeWeight, GraphEdge, GraphNode } from './graphModel';
 
 export type GroupBy = 'node' | 'namespace' | 'instance';
 
+export const UNSCHEDULED_GROUP = 'Unscheduled';
+
 /**
  * Returns the amount of nodes in the graph
  */
@@ -256,25 +258,32 @@ export function groupGraph(
   }
 
   if (groupBy === 'node') {
-    // Create groups based on the Kube resource node
+    // Create groups based on the Kube resource node.
+    // Pods without a nodeName (e.g. pending due to quota or scheduling failures)
+    // are grouped under an "Unscheduled" sentinel so they remain visible.
     components = groupByProperty(
       components,
       component => {
+        let pod: Pod | undefined;
         if (component.nodes) {
-          return (component.nodes.find(node => node.kubeObject?.kind === 'Pod')?.kubeObject as Pod)
-            ?.spec?.nodeName;
+          pod = component.nodes.find(node => node.kubeObject?.kind === 'Pod')?.kubeObject as
+            | Pod
+            | undefined;
+        } else if (component.kubeObject?.kind === 'Pod') {
+          pod = component.kubeObject as Pod;
         }
-
-        return (component.kubeObject as Pod)?.spec?.nodeName;
+        if (pod) {
+          return pod.spec?.nodeName ?? UNSCHEDULED_GROUP;
+        }
+        // Non-Pod resources without a Pod in their component: leave ungrouped
+        return undefined;
       },
       { label: 'Node', allowSingleMemberGroup: true }
     );
 
     components.forEach(component => {
-      if (!component.kubeObject) {
-        component.kubeObject = k8sNodes.find(
-          namespace => namespace.metadata.name === component.label
-        );
+      if (!component.kubeObject && component.label !== UNSCHEDULED_GROUP) {
+        component.kubeObject = k8sNodes.find(node => node.metadata.name === component.label);
         if (component.kubeObject) {
           component.id = component.kubeObject.metadata.uid;
         }


### PR DESCRIPTION
## Summary

Pods without a `spec.nodeName` (e.g. pending due to quota or scheduling failures) were silently ungrouped in the Map tab's "Group by Node" view. This made it impossible to see or troubleshoot unscheduled pods from the Map.

- Return an `"Unscheduled"` sentinel instead of `undefined` for pods without `nodeName`, so they appear in a visible group
- Skip K8s Node object linking for the Unscheduled group (no real node to link)
- Updated existing test + added new test for the Unscheduled group

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #492 (partially — Map tab fix only; quota warning is in #494)

## Changes Made

| File | Change |
|------|--------|
| `graphGrouping.tsx` | Node grouping accessor returns `'Unscheduled'` for pods without `nodeName`; guard added to skip Node object linking for the Unscheduled group |
| `graphGrouping.test.ts` | Updated "groups nodes by node" expectations; added test verifying Unscheduled group has no linked kubeObject |

## Testing

- [x] Unit tests pass (`npx vitest run graphGrouping`)
- [x] 10/10 grouping tests pass including 2 updated/new tests

### Test Cases

1. Pods without `nodeName` are grouped into `Node-Unscheduled` (updated existing test)
2. Unscheduled group has label `'Unscheduled'`, no linked `kubeObject`, and correct member count (new test)
3. Pods with `nodeName` continue to group correctly under their node (existing, unchanged)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes