### PR TITLE
frontend:Resource: Fix ConditionsTable truncation on resize

### DIFF
--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -379,7 +379,6 @@ export default function SimpleTable(props: SimpleTableProps) {
             [theme.breakpoints.down('sm')]: {
               padding: '15px 24px 15px 16px',
             },
-            overflow: 'hidden',
             width: '100%',
             wordWrap: 'break-word',
           },

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -13,7 +13,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -21,7 +21,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -13,7 +13,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -13,7 +13,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <tbody
             class="MuiTableBody-root css-apqrd9-MuiTableBody-root"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -31,7 +31,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-r7i92b-MuiTable-root"
+            class="MuiTable-root css-1f5u0uu-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
@@ -5,7 +5,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
@@ -5,7 +5,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-r7i92b-MuiTable-root"
+        class="MuiTable-root css-1f5u0uu-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
@@ -152,7 +152,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-bv8t57-MuiTable-root"
+        class="MuiTable-root css-14jq1ex-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
@@ -22,7 +22,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
@@ -22,7 +22,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
@@ -114,7 +114,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -262,7 +262,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -367,7 +367,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -235,7 +235,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -247,7 +247,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -350,7 +350,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -220,7 +220,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -252,7 +252,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -335,7 +335,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-d21jum-MuiTable-root"
+                      class="MuiTable-root css-4d0x9t-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -384,7 +384,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-1t02l4h-MuiTable-root"
+                      class="MuiTable-root css-15jmevm-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -514,7 +514,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -232,7 +232,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                        class="MuiTable-root css-1ok7ihs-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -366,7 +366,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -264,7 +264,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -272,7 +272,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -215,7 +215,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-bv8t57-MuiTable-root"
+                        class="MuiTable-root css-14jq1ex-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -284,7 +284,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -385,7 +385,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                  class="MuiTable-root css-1ok7ihs-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -481,7 +481,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -284,7 +284,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -624,7 +624,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -360,7 +360,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -274,7 +274,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -427,7 +427,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -545,7 +545,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -461,7 +461,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -458,7 +458,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -447,7 +447,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -444,7 +444,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"


### PR DESCRIPTION
## Description

This PR fixes an issue pointed out by the accessibility team audit where the `Conditions` section under the `Deployment` details view was truncated and did not have scrollable nav for accessibility.

These fixes now allow users to scroll on the `Conditions` section when viewing the details in a window mode, or on resizing from fullscreen view.

## How to test
- Go to Projects tab and enter any project
- Click on the `Map` section 
- Click on a deployment node
- Scroll to `Conditions` section
- Note that it is no longer truncated and horizontal scrolling is enabled (resize if you want to take a look on fullscreen)


### Images
(Default view, note the scroll wheel)
<img width="777" height="700" alt="image" src="https://github.com/user-attachments/assets/74a95814-0156-4587-a1fe-ed806fd66cb5" />


(Fullscreen resize view)
<img width="732" height="285" alt="image" src="https://github.com/user-attachments/assets/b11c8538-a658-44d3-9dfb-d0ca478d2052" />

