### PR TITLE
Fix multi-tenant auth by threading tenant ID into kubeconfig exec plugin

### DIFF
--- a/build/az-kubelogin.py
+++ b/build/az-kubelogin.py
@@ -12,11 +12,12 @@ This script is bundled with AKS desktop and automatically uses the
 bundled Azure CLI installation.
 
 Usage:
-    python az-kubelogin.py --server-id <server-id> [--resource <resource>]
+    python az-kubelogin.py --server-id <server-id> [--resource <resource>] [--tenant <tenant-id>]
 
 Arguments:
     --server-id: The Azure AD server ID (default: 6dae42f8-4368-4678-94ff-3960e28e3630)
     --resource: The Kubernetes API server resource (optional)
+    --tenant: The Azure AD tenant ID (optional, ensures correct token in multi-tenant scenarios)
 
 Environment Variables:
     AZ_CLI_PATH: Path to the az CLI command (defaults to 'az' in PATH)
@@ -45,13 +46,14 @@ from datetime import datetime, timezone
 from typing import Dict
 
 
-def get_azure_token(server_id: str, resource: str = None) -> Dict:
+def get_azure_token(server_id: str, resource: str = None, tenant: str = None) -> Dict:
     """
     Get an access token from Azure CLI.
 
     Args:
         server_id: The Azure AD server ID
         resource: Optional Kubernetes API server resource
+        tenant: Optional Azure AD tenant ID to request the token from
 
     Returns:
         Dictionary containing the Azure CLI token response
@@ -68,6 +70,10 @@ def get_azure_token(server_id: str, resource: str = None) -> Dict:
 
     # Build the az command
     cmd = [az_cmd, "account", "get-access-token", "--scope", scope]
+
+    # Add tenant parameter if provided (ensures correct token in multi-tenant scenarios)
+    if tenant:
+        cmd.extend(["--tenant", tenant])
 
     # Add resource parameter if provided
     if resource:
@@ -158,11 +164,16 @@ def main():
         help="Kubernetes API server resource (optional)"
     )
 
+    parser.add_argument(
+        "--tenant",
+        help="Azure AD tenant ID (optional, ensures correct token in multi-tenant scenarios)"
+    )
+
     args = parser.parse_args()
 
     try:
         # Get the token from Azure CLI
-        az_token = get_azure_token(args.server_id, args.resource)
+        az_token = get_azure_token(args.server_id, args.resource, args.tenant)
 
         # Convert to ExecCredential format
         exec_credential = convert_to_exec_credential(az_token)

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
@@ -195,7 +195,9 @@ export default function RegisterAKSClusterDialog({
       const result = await registerAKSCluster(
         selectedSubscription.id,
         selectedCluster.resourceGroup,
-        selectedCluster.name
+        selectedCluster.name,
+        undefined, // managedNamespace
+        selectedSubscription.tenantId
       );
 
       if (!result.success) {

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
@@ -10,9 +10,9 @@ import RegisterAKSClusterDialogPure, {
 const noOp = () => {};
 
 const SAMPLE_SUBSCRIPTIONS = [
-  { id: 'sub-1', name: 'Production Subscription', state: 'Enabled' },
-  { id: 'sub-2', name: 'Development Subscription', state: 'Enabled' },
-  { id: 'sub-3', name: 'Legacy Subscription', state: 'Disabled' },
+  { id: 'sub-1', name: 'Production Subscription', state: 'Enabled', tenantId: 'tenant-1' },
+  { id: 'sub-2', name: 'Development Subscription', state: 'Enabled', tenantId: 'tenant-1' },
+  { id: 'sub-3', name: 'Legacy Subscription', state: 'Disabled', tenantId: 'tenant-2' },
 ];
 
 const SAMPLE_CLUSTERS = [

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
@@ -24,6 +24,7 @@ export interface Subscription {
   id: string;
   name: string;
   state: string;
+  tenantId: string;
 }
 
 export interface AKSCluster {

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -397,6 +397,7 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
             cluster={selectedCluster.name}
             resourceGroup={selectedCluster.resourceGroup}
             subscription={formData.subscription}
+            tenantId={subscriptions.find(s => s.id === formData.subscription)?.tenant}
           />
         )}
 
@@ -500,10 +501,12 @@ function RegisterCluster({
   cluster,
   resourceGroup,
   subscription,
+  tenantId,
 }: {
   cluster: string;
   resourceGroup: string;
   subscription: string;
+  tenantId?: string;
 }) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
@@ -522,7 +525,13 @@ function RegisterCluster({
     try {
       // Register the cluster by running az aks get-credentials and setting up kubeconfig
       if (DEBUG) console.debug('[AKS] Registering cluster...');
-      const result = await registerAKSCluster(subscription, resourceGroup, cluster);
+      const result = await registerAKSCluster(
+        subscription,
+        resourceGroup,
+        cluster,
+        undefined,
+        tenantId
+      );
       if (DEBUG) console.debug('[AKS] Register cluster result:', result.success);
       if (!result.success) {
         setError(result.message);

--- a/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DiscoveredNamespace, useNamespaceDiscovery } from '../../hooks/useNamespaceDiscovery';
 import { useRegisteredClusters } from '../../hooks/useRegisteredClusters';
-import { registerAKSCluster } from '../../utils/azure/aks';
+import { getSubscriptions, registerAKSCluster } from '../../utils/azure/aks';
 import { applyProjectLabels } from '../../utils/kubernetes/namespaceUtils';
 import { getClusterSettings, setClusterSettings } from '../../utils/shared/clusterSettings';
 import AzureAuthGuard from '../AzureAuth/AzureAuthGuard';
@@ -122,6 +122,21 @@ function ImportAKSProjectsContent() {
       message: string;
     }> = [];
 
+    // Build a subscription -> tenant lookup for multi-tenant token support
+    const tenantBySubscription = new Map<string, string>();
+    try {
+      const subsResult = await getSubscriptions();
+      if (subsResult.success && subsResult.subscriptions) {
+        for (const sub of subsResult.subscriptions) {
+          tenantBySubscription.set(sub.id, sub.tenantId);
+        }
+      } else if (!subsResult.success) {
+        console.warn('Failed to fetch subscriptions for tenant lookup:', subsResult.message);
+      }
+    } catch (err) {
+      console.warn('Failed to fetch subscriptions for tenant lookup', err);
+    }
+
     // Build a lookup of cluster -> Azure metadata from ALL discovered namespaces
     // (not just selected). This ensures we have Azure metadata for clusters even
     // when the user only selects namespaces that were discovered via K8s API.
@@ -206,7 +221,9 @@ function ImportAKSProjectsContent() {
           const registerResult = await registerAKSCluster(
             subscriptionId,
             resourceGroup,
-            clusterName
+            clusterName,
+            undefined, // managedNamespace
+            tenantBySubscription.get(subscriptionId)
           );
 
           if (!registerResult.success) {

--- a/plugins/aks-desktop/src/utils/azure/aks.ts
+++ b/plugins/aks-desktop/src/utils/azure/aks.ts
@@ -92,7 +92,8 @@ export async function registerAKSCluster(
   subscriptionId: string,
   resourceGroup: string,
   clusterName: string,
-  managedNamespace?: string
+  managedNamespace?: string,
+  tenantId?: string
 ): Promise<{
   success: boolean;
   message: string;
@@ -120,7 +121,8 @@ export async function registerAKSCluster(
       resourceGroup,
       clusterName,
       false, // isAzureRBACEnabled
-      managedNamespace
+      managedNamespace,
+      tenantId
     );
 
     console.debug('[AKS] Registration result:', result);


### PR DESCRIPTION
## Description

Users with access to multiple Azure tenants lose access to clusters in one tenant after interacting with clusters in another. The Kubernetes API returns 403 Forbidden because `az-kubelogin.py` requests tokens without `--tenant`, using whichever tenant is globally active in Azure CLI.

This PR threads `tenantId` from the subscription through the full registration chain into the kubeconfig exec plugin args, so tokens are always requested for the correct tenant.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #501

## Changes Made

- **`build/az-kubelogin.py`** — Added `--tenant` argument; passes `--tenant <id>` to `az account get-access-token` when provided
- **`headlamp/app/electron/aks-cluster.ts`** — Added `tenantId` parameter to `registerAKSCluster()` and `addAzKubeloginToKubeconfig()`; writes `--tenant` to kubeconfig exec args
- **`headlamp/app/electron/preload.ts`** — Added `tenantId` to IPC bridge
- **`headlamp/app/electron/main.ts`** — Added `tenantId` to IPC handler data type
- **`plugins/aks-desktop/src/utils/azure/aks.ts`** — Added `tenantId` parameter to `registerAKSCluster()`
- **`plugins/aks-desktop/src/components/AKS/`** — Added `tenantId` to `Subscription` interface, pass through on registration
- **`plugins/aks-desktop/src/components/CreateAKSProject/`** — Look up tenant from subscriptions array, pass to register
- **`plugins/aks-desktop/src/components/ImportAKSProjects/`** — Build subscription→tenant map, pass tenantId when registering

All changes are backwards compatible — `tenantId` is optional throughout the chain, so existing kubeconfigs without it continue to work.

## Testing

- [x] Unit tests pass
- [x] Manual testing completed

### Test Cases

1. Register a cluster — inspect `~/.kube/config` and verify exec args include `--tenant <tenantId>`
2. Register clusters from two different tenants, switch between them — both should maintain access
3. Omit tenant (legacy path) — verify existing behavior is unchanged

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Reviewer Notes

The `ImportAKSProjects` flow makes one extra `getSubscriptions()` call at import time to build the subscription→tenant lookup map. This is a lightweight `az account list` call that's already cached by Azure CLI.