### PR TITLE
Fix: Newly created project hides visible managed projects

### DIFF
--- a/plugins/aks-desktop/src/components/CreateNamespace/CreateNamespace.tsx
+++ b/plugins/aks-desktop/src/components/CreateNamespace/CreateNamespace.tsx
@@ -118,12 +118,14 @@ function CreateNamespaceContent() {
       await createNamespaceAsProject(namespaceName, selectedCluster);
 
       setCreationProgress(`${t('Updating local settings')}...`);
+      // Only append to allowedNamespaces if it's already configured. Appending
+      // from scratch can potentially hide pre-existing projects a user can see.
       const settings = getClusterSettings(selectedCluster);
-      settings.allowedNamespaces ??= [];
-      if (!settings.allowedNamespaces.includes(namespaceName)) {
-        settings.allowedNamespaces.push(namespaceName);
+      const existing = settings.allowedNamespaces;
+      if (Array.isArray(existing) && existing.length > 0 && !existing.includes(namespaceName)) {
+        settings.allowedNamespaces = [...existing, namespaceName];
+        setClusterSettings(selectedCluster, settings);
       }
-      setClusterSettings(selectedCluster, settings);
 
       setCreationProgress(t('Namespace created successfully!'));
       setTimeout(() => {


### PR DESCRIPTION
## Description

When a project is created via a regular (non-managed) namespace, all previously visible managed projects would disappear from view. This is because in CreateNamespace, the namespace is unconditionally added to `allowedNamespaces`, which makes headlamp only look only for namespaces in the list, vs. the default agnostic lookup based on labels cluster wide, which excludes other namespaces that aren't explicitly allowed.  

This PR adds a guard so that we only append the namespace if the `allowedNamespaces` is already configured (>=1 namespace).

This issue is similar to that observed in #487, thus a similar fix. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #[issue number]
Related to #[489]

## Changes Made

- Added guard to append namespace to allowedNamesapces only if it's pre-configured.

## Testing

- [x] Manual testing completed

### Test Cases

Steps to reproduce: 

1. Create at least 1 AKS managed namespace project.
2. Create a regular project via 'Create New Namespace'
3. Observe the managed project (s) disappear. 

## Screenshots/Videos

(Here we start with `first-test-proj` & then upon creating `testnamesapce2`, `first-test-proj` disappears.

https://github.com/user-attachments/assets/795f90cf-9e00-42b2-bd97-86fe8256a45f


## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published