### PR TITLE
Fix: Fix Project deletion for non-ARM managed projects

### DIFF
--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -44,7 +44,7 @@ import ScalingTab from './components/Scaling/ScalingTab';
 import type { ProjectDefinition } from './types/project';
 import { getLoginStatus } from './utils/azure/az-auth';
 import { AZURE_ACCOUNT_POLL_INTERVAL_MS } from './utils/constants/timing';
-import { isAksProject } from './utils/shared/isAksProject';
+import { isAksProject, isArmManagedProject } from './utils/shared/isAksProject';
 import { azureTheme } from './utils/shared/theme';
 
 Headlamp.setAppMenu(menus => {
@@ -404,8 +404,8 @@ registerProjectHeaderAction({
   ),
 });
 
-// Register custom delete button for AKS projects only
+// Register custom delete button for AKS Desktop + ARM-managed projects only
 registerProjectDeleteButton({
-  isEnabled: isAksProject,
+  isEnabled: isArmManagedProject,
   component: ({ project }) => <AKSProjectDeleteButton project={project} />,
 });

--- a/plugins/aks-desktop/src/utils/constants/projectLabels.ts
+++ b/plugins/aks-desktop/src/utils/constants/projectLabels.ts
@@ -15,3 +15,6 @@ export const SUBSCRIPTION_LABEL = 'aks-desktop/project-subscription';
 
 /** Kubernetes label key: the Azure resource group associated with the project. */
 export const RESOURCE_GROUP_LABEL = 'aks-desktop/project-resource-group';
+
+/** Kubernetes label key: whether the namespace is managed by ARM. */
+export const MANAGED_BY_ARM_LABEL = 'kubernetes.azure.com/managedByArm';

--- a/plugins/aks-desktop/src/utils/shared/isAksProject.ts
+++ b/plugins/aks-desktop/src/utils/shared/isAksProject.ts
@@ -4,9 +4,13 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import type { ApiClient } from '@kinvolk/headlamp-plugin/lib/lib/k8s/api/v1/factories';
 import type { KubeNamespace } from '@kinvolk/headlamp-plugin/lib/lib/k8s/namespace';
-import { PROJECT_MANAGED_BY_LABEL, PROJECT_MANAGED_BY_VALUE } from '../constants/projectLabels';
+import {
+  MANAGED_BY_ARM_LABEL,
+  PROJECT_MANAGED_BY_LABEL,
+  PROJECT_MANAGED_BY_VALUE,
+} from '../constants/projectLabels';
 
-/** Checks if the given project is an AKS desktop managed namespace project  */
+/** Checks if the given project is an AKS Desktop project (managed-by: aks-desktop). */
 export const isAksProject = ({
   project,
 }: {
@@ -17,6 +21,31 @@ export const isAksProject = ({
       project.namespaces[0],
       ns => {
         resolve(ns.metadata?.labels?.[PROJECT_MANAGED_BY_LABEL] === PROJECT_MANAGED_BY_VALUE);
+        cancelFn.then(it => it());
+      },
+      () => {
+        cancelFn.then(it => it());
+        resolve(false);
+      },
+      {},
+      project.clusters[0]
+    );
+  });
+
+/** Checks if the given project is an AKS Desktop + ARM-managed namespace. */
+export const isArmManagedProject = ({
+  project,
+}: {
+  project: { namespaces: string[]; clusters: string[] };
+}): Promise<boolean> =>
+  new Promise<boolean>(resolve => {
+    const cancelFn = (K8s.ResourceClasses.Namespace.apiEndpoint as ApiClient<KubeNamespace>).get(
+      project.namespaces[0],
+      ns => {
+        resolve(
+          ns.metadata?.labels?.[PROJECT_MANAGED_BY_LABEL] === PROJECT_MANAGED_BY_VALUE &&
+            ns.metadata?.labels?.[MANAGED_BY_ARM_LABEL] === 'true'
+        );
         cancelFn.then(it => it());
       },
       () => {


### PR DESCRIPTION
## Description

The `AKSProjectDeleteButton` previously would render for any project with the managed-by: aks-desktop label. This worked when the aks-desktop namespaces were exclusively managed, but with both regular & managed namespaces sharing the managed-by:aks-desktop label now (vs. regular namespace previously having `managed-by:headlamp`), the distinction isn't recognized, leading to the managed namespace delete button rendering for both scenarios. This propagates into an error when trying to delete a normal namespace.

This PR introduces `isArmManagedProject` which checks for the `kubernetes.azure.com/managedByArm: true` to identify & use conditionally for registering the correct delete button. This distinction could be used in the future as well for any managed namespace specific operations/logic attached the project.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #[issue number]
Related to #[issue number]

## Changes Made

- Added `isArmManagedproject` to distinguish between regular ASKD projects & managed ones. 

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

1. Create a non-managed project.
2. Click the delete button
3. You should observe the proper delete button dialogue appear (non- managed deletion)

Note: This was a regression from previous changes, so the deletion logic itself is sound & the same, it just has to scoped differently now.

This also overlaps with some changes in #511, since the managed by ARM distinction is used there as well for conditional access tab registration.