### PR TITLE
Enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This change adds a `.gitattributes` file to ensure `.sh` files are always checked out with LF line endings, preventing `core.autocrlf=true` on Windows from converting them to CRLF. This fixes a build failure where bash would reject `set -o pipefail\r` as an invalid option.

Fixes: #520 

### Testing
- [x] Run `npm run plugin:setup` on Windows and ensure it doesn't fail