### PR TITLE
fix: add missing getSubscriptions mock in ImportAKSProjects test

### DIFF
--- a/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
@@ -70,8 +70,12 @@ vi.mock('../../hooks/useRegisteredClusters', () => ({
 }));
 
 const mockRegisterAKSCluster = vi.fn();
+const mockGetSubscriptions = vi
+  .fn()
+  .mockResolvedValue({ success: true, message: '', subscriptions: [] });
 vi.mock('../../utils/azure/aks', () => ({
   registerAKSCluster: (...args: any[]) => mockRegisterAKSCluster(...args),
+  getSubscriptions: (...args: any[]) => mockGetSubscriptions(...args),
 }));
 
 const mockApplyProjectLabels = vi.fn();
@@ -131,6 +135,9 @@ describe('ImportAKSProjects', () => {
     mockPush.mockReset();
     mockReplace.mockReset();
     mockRegisterAKSCluster.mockReset();
+    mockGetSubscriptions
+      .mockReset()
+      .mockResolvedValue({ success: true, message: '', subscriptions: [] });
     mockApplyProjectLabels.mockReset();
     mockSetClusterSettings.mockReset();
     mockUseRegisteredClusters.mockReturnValue(new Set());


### PR DESCRIPTION
## Description

Commit a5ad9401f added getSubscriptions to the component's imports  
 but did not update the vi.mock for ../../utils/azure/aks, causing
 vitest to throw "No getSubscriptions export is defined on the mock".