### PR TITLE
refactor: extract constants and parameterize extension functions

### DIFF
--- a/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.tsx
@@ -15,6 +15,11 @@ import {
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { getLoginStatus, initiateLogin } from '../../utils/azure/az-auth';
+import {
+  LOGIN_POLL_INTERVAL_MS,
+  LOGIN_REDIRECT_DELAY_MS,
+  LOGIN_TIMEOUT_MS,
+} from '../../utils/constants/timing';
 
 interface AzureLoginPageProps {
   redirectTo?: string;
@@ -86,7 +91,7 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
 
       // Start polling for login completion
       let pollCount = 0;
-      const maxPolls = 60; // 5 minutes max (60 * 5 seconds)
+      const maxPolls = Math.ceil(LOGIN_TIMEOUT_MS / LOGIN_POLL_INTERVAL_MS);
 
       const interval = setInterval(async () => {
         pollCount++;
@@ -105,13 +110,13 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
             setTimeout(() => {
               const target = getRedirectTarget();
               history.push(target);
-            }, 1000);
+            }, LOGIN_REDIRECT_DELAY_MS);
           } else if (pollCount >= maxPolls) {
             clearInterval(interval);
             setErrorMessage(t('Login timeout. Please try again.'));
             setLoading(false);
           } else {
-            const remaining = ((maxPolls - pollCount) * 5) / 60;
+            const remaining = ((maxPolls - pollCount) * LOGIN_POLL_INTERVAL_MS) / 60_000;
             setStatusMessage(
               t('Waiting for login completion... ({{minutes}} minutes remaining)', {
                 minutes: remaining.toFixed(1),
@@ -121,7 +126,7 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
         } catch (error) {
           console.error('Error polling login status:', error);
         }
-      }, 5000); // Poll every 5 seconds
+      }, LOGIN_POLL_INTERVAL_MS);
 
       setPollingInterval(interval);
     } catch (error) {

--- a/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
@@ -16,6 +16,7 @@ import { useTheme } from '@mui/material/styles';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAzureAuth } from '../../hooks/useAzureAuth';
+import { PROFILE_REDIRECT_DELAY_MS } from '../../utils/constants/timing';
 
 export default function AzureProfilePage() {
   const history = useHistory();
@@ -51,7 +52,7 @@ export default function AzureProfilePage() {
       // Redirect to login page after logout
       setTimeout(() => {
         history.push('/azure/login');
-      }, 500);
+      }, PROFILE_REDIRECT_DELAY_MS);
     } catch (error) {
       console.error('Error logging out:', error);
       setLoggingOut(false);

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useExtensionCheck.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useExtensionCheck.ts
@@ -3,8 +3,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import {
-  installAksPreviewExtension,
-  isAksPreviewExtensionInstalled,
+  installExtension as installAzExtension,
+  isExtensionInstalled,
 } from '../../../utils/azure/az-extensions';
 import type { ExtensionStatus } from '../types';
 
@@ -21,7 +21,7 @@ export const useExtensionCheck = () => {
 
   const checkExtension = useCallback(async () => {
     try {
-      const result = await isAksPreviewExtensionInstalled();
+      const result = await isExtensionInstalled('aks-preview');
       setStatus(prev => ({
         ...prev,
         installed: result.installed,
@@ -40,7 +40,7 @@ export const useExtensionCheck = () => {
   const installExtension = useCallback(async () => {
     try {
       setStatus(prev => ({ ...prev, installing: true, error: null }));
-      const result = await installAksPreviewExtension();
+      const result = await installAzExtension('aks-preview');
 
       if (result.success) {
         setStatus(prev => ({

--- a/plugins/aks-desktop/src/components/Metrics/MetricsCard.tsx
+++ b/plugins/aks-desktop/src/components/Metrics/MetricsCard.tsx
@@ -8,6 +8,11 @@ import { Box, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 import { getClusterResourceIdAndGroup } from '../../utils/azure/az-clusters';
 import { RESOURCE_GROUP_LABEL, SUBSCRIPTION_LABEL } from '../../utils/constants/projectLabels';
+import {
+  METRICS_REFRESH_INTERVAL_MS,
+  PROMETHEUS_QUERY_RANGE_SECONDS,
+  PROMETHEUS_STEP_SECONDS,
+} from '../../utils/constants/timing';
 import { getPrometheusEndpoint } from '../MetricsTab/getPrometheusEndpoint';
 import { queryPrometheus } from '../MetricsTab/queryPrometheus';
 import { DeploymentSelector } from '../shared/DeploymentSelector';
@@ -146,8 +151,8 @@ function MetricsCard({ project }: MetricsCardProps) {
       const promEndpoint = await getPrometheusEndpoint(resourceGroup, cluster, subscription);
 
       const end = Math.floor(Date.now() / 1000);
-      const start = end - 300; // Last 5 minutes
-      const step = 60;
+      const start = end - PROMETHEUS_QUERY_RANGE_SECONDS;
+      const step = PROMETHEUS_STEP_SECONDS;
 
       // Query CPU usage
       const cpuQuery = `sum by (namespace) (rate(container_cpu_usage_seconds_total{namespace="${namespace}", container!=""}[5m]))`;
@@ -265,8 +270,7 @@ function MetricsCard({ project }: MetricsCardProps) {
   useEffect(() => {
     fetchMetrics();
 
-    // Refresh metrics every 30 seconds
-    const interval = setInterval(fetchMetrics, 30000);
+    const interval = setInterval(fetchMetrics, METRICS_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [selectedDeployment, subscription, fetchMetrics]);
 

--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -43,6 +43,7 @@ import ScalingCard from './components/Scaling/ScalingCard';
 import ScalingTab from './components/Scaling/ScalingTab';
 import type { ProjectDefinition } from './types/project';
 import { getLoginStatus } from './utils/azure/az-auth';
+import { AZURE_ACCOUNT_POLL_INTERVAL_MS } from './utils/constants/timing';
 import { isAksProject } from './utils/shared/isAksProject';
 import { azureTheme } from './utils/shared/theme';
 
@@ -177,7 +178,7 @@ if (Headlamp.isRunningAsApp()) {
   });
 
   // Fallback: Check periodically with a longer interval (30 seconds) as a safety net
-  setInterval(updateAzureAccountLabel, 30000); // Check every 30 seconds
+  setInterval(updateAzureAccountLabel, AZURE_ACCOUNT_POLL_INTERVAL_MS);
 
   // Register Azure authentication routes
   registerRoute({

--- a/plugins/aks-desktop/src/utils/azure/az-auth.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-auth.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
+import { LOGIN_POLL_INTERVAL_MS, LOGIN_TIMEOUT_MS } from '../constants/timing';
 import {
   debugLog,
   getErrorMessage,
@@ -131,7 +132,7 @@ export async function initiateLogin(): Promise<{ success: boolean; message: stri
 
 export function monitorLoginStatus(
   onStatusChange: (status: { isLoggedIn: boolean; message: string }) => void,
-  intervalMs = 5000
+  intervalMs = LOGIN_POLL_INTERVAL_MS
 ): () => void {
   let isPolling = true;
   let pollCount = 0;
@@ -173,7 +174,7 @@ export function monitorLoginStatus(
   };
 }
 
-export async function login(timeoutMs = 300000): Promise<boolean> {
+export async function login(timeoutMs = LOGIN_TIMEOUT_MS): Promise<boolean> {
   if (await isAzCliLoggedIn()) return true;
   const init = await initiateLogin();
   if (!init.success) return false;
@@ -183,7 +184,7 @@ export async function login(timeoutMs = 300000): Promise<boolean> {
     const poll = async () => {
       if (await isAzCliLoggedIn()) return resolve(true);
       if (Date.now() - start > timeoutMs) return resolve(false);
-      setTimeout(poll, 5000);
+      setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
     };
     poll();
   });

--- a/plugins/aks-desktop/src/utils/azure/az-extensions.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-extensions.ts
@@ -3,7 +3,7 @@
 
 import { debugLog, getErrorMessage, isAzError, needsRelogin, runCommandAsync } from './az-cli-core';
 
-async function isExtensionInstalled(
+export async function isExtensionInstalled(
   extensionName: string
 ): Promise<{ installed: boolean; error?: string }> {
   try {
@@ -46,7 +46,7 @@ async function isExtensionInstalled(
   }
 }
 
-async function installExtension(
+export async function installExtension(
   extensionName: string,
   options?: { allowPreview?: boolean }
 ): Promise<{ success: boolean; stdout: string; stderr: string; error?: string }> {
@@ -84,22 +84,6 @@ async function installExtension(
       error: `Failed to install ${extensionName} extension: ${errorMessage}`,
     };
   }
-}
-
-export function isAksPreviewExtensionInstalled() {
-  return isExtensionInstalled('aks-preview');
-}
-
-export function installAksPreviewExtension() {
-  return installExtension('aks-preview');
-}
-
-export function isAlertsManagementExtensionInstalled() {
-  return isExtensionInstalled('alertsmanagement');
-}
-
-export function installAlertsManagementExtension() {
-  return installExtension('alertsmanagement', { allowPreview: true });
 }
 
 export async function configureAzureCliExtensions(): Promise<{

--- a/plugins/aks-desktop/src/utils/constants/timing.ts
+++ b/plugins/aks-desktop/src/utils/constants/timing.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+/** How often to poll for Azure account label changes (ms). */
+export const AZURE_ACCOUNT_POLL_INTERVAL_MS = 30_000;
+
+/** How often to refresh Prometheus metrics (ms). */
+export const METRICS_REFRESH_INTERVAL_MS = 30_000;
+
+/** Default Prometheus query range (seconds). */
+export const PROMETHEUS_QUERY_RANGE_SECONDS = 300;
+
+/** Default Prometheus query step (seconds). */
+export const PROMETHEUS_STEP_SECONDS = 60;
+
+/** How often to poll for login completion (ms). */
+export const LOGIN_POLL_INTERVAL_MS = 5_000;
+
+/** Delay before redirecting after successful login (ms). */
+export const LOGIN_REDIRECT_DELAY_MS = 1_000;
+
+/** Delay before redirecting after profile load (ms). */
+export const PROFILE_REDIRECT_DELAY_MS = 500;
+
+/** Default timeout for Azure CLI login flow (ms). */
+export const LOGIN_TIMEOUT_MS = 300_000;


### PR DESCRIPTION
## Summary

- Extract magic numbers (polling intervals, timeouts, delays) into named constants in a new `timing.ts` module
- Export the generic `isExtensionInstalled` and `installExtension` functions directly, removing four trivial wrapper functions (two of which were unused)

Closes #529

## Type of Change

- [x] Code refactoring

## Changes Made

**Part A: Timing constants**
- Created `src/utils/constants/timing.ts` with 8 named constants
- Replaced magic numbers in `index.tsx`, `MetricsCard.tsx`, `AzureLoginPage.tsx`, `AzureProfilePage.tsx`, `az-auth.ts`

**Part B: Extension functions**
- Exported existing generic `isExtensionInstalled()` and `installExtension()` from `az-extensions.ts`
- Removed 4 wrapper functions: `isAksPreviewExtensionInstalled`, `installAksPreviewExtension`, `isAlertsManagementExtensionInstalled` (unused), `installAlertsManagementExtension` (unused)
- Updated the one caller (`useExtensionCheck.ts`) to use generic functions directly

## Testing

- [x] TypeScript type checking passes (`npm run tsc`)
- [x] ESLint passes (`npm run lint`)
- [x] Prettier formatting passes (`npm run format -- --check`)
- [x] No test regressions (same 52 passed / 13 failed baseline as main)
- [x] No performance impact — pure refactor, no behavioral changes

