### PR TITLE
fix: pin kubelogin version, add actions:read, instruct two-job split in agent templates

### DIFF
--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -3241,6 +3241,9 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-arm64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
@@ -3366,6 +3369,9 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
@@ -3421,6 +3427,9 @@
         "openharmony"
       ]
     },
+    "node_modules/@rollup/rollup-win32-arm64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
@@ -3448,6 +3457,9 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rollup/rollup-win32-x64": {
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",

--- a/plugins/aks-desktop/src/components/GitHubPipeline/constants.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/constants.ts
@@ -31,6 +31,9 @@ export const SCHEMA_VERSION = 1;
 /** Version of the containerization-assist-mcp used in agent setup steps. */
 export const CONTAINERIZATION_MCP_VERSION = '1.3.2';
 
+/** Pinned kubelogin version for AAD-enabled AKS clusters. */
+export const KUBELOGIN_VERSION = 'v0.1.6';
+
 /** Default polling interval for GitHub API checks (5 seconds). */
 export const POLLING_INTERVAL_MS = 5_000;
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createContainerConfig, createValidConfig } from '../__fixtures__/pipelineConfig';
+import { KUBELOGIN_VERSION } from '../constants';
 import type { PipelineConfig } from '../types';
 import {
   generateAgentConfig,
@@ -82,6 +83,23 @@ describe('agentTemplates', () => {
       // Subscription ID comes from secrets, not workflow inputs
       expect(result).toContain('secrets.AZURE_SUBSCRIPTION_ID');
       expect(result).not.toContain('Trigger on push to main');
+    });
+
+    it('should instruct agent to pin kubelogin version instead of skip-cache', () => {
+      const result = generateAgentConfig(validConfig);
+      expect(result).toContain(`kubelogin-version: '${KUBELOGIN_VERSION}'`);
+      expect(result).not.toContain('skip-cache: true');
+    });
+
+    it('should instruct agent to include actions: read permission', () => {
+      const result = generateAgentConfig(validConfig);
+      expect(result).toContain('actions: read');
+    });
+
+    it('should instruct agent to split workflow into two jobs', () => {
+      const result = generateAgentConfig(validConfig);
+      expect(result).toContain('buildImage');
+      expect(result).toContain('needs: [buildImage]');
     });
 
     it('should include optional fields when provided', () => {

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.ts
@@ -5,6 +5,7 @@ import { getServiceAccountName } from '../../../utils/kubernetes/serviceAccountN
 import {
   CONTAINERIZATION_MCP_VERSION,
   DEFAULT_IMAGE_TAG,
+  KUBELOGIN_VERSION,
   PIPELINE_WORKFLOW_FILENAME,
 } from '../constants';
 import type { PipelineConfig } from '../types';
@@ -305,7 +306,9 @@ Generate \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\` with the following:
 - Do NOT add a \`push\` trigger — deployment is always triggered explicitly
 - Use \`azure/login@v2\` with OIDC (\`secrets.AZURE_CLIENT_ID\`, \`secrets.AZURE_TENANT_ID\`, \`secrets.AZURE_SUBSCRIPTION_ID\`)
 - Use \`azure/aks-set-context@v4\` with cluster \`\${{ inputs.cluster-name }}\` and resource group \`\${{ inputs.resource-group }}\`
-- Install kubelogin (required for AAD-enabled AKS clusters): \`azure/use-kubelogin@v1\` with \`skip-cache: true\`
+- The deploy job MUST include \`actions: read\` in its permissions block (required for GITHUB_TOKEN access)
+- Split the workflow into two jobs: a \`buildImage\` job (build + push to ACR) and a \`deploy\` job (apply manifests) with \`needs: [buildImage]\`
+- Install kubelogin (required for AAD-enabled AKS clusters): \`azure/use-kubelogin@v1\` with \`kubelogin-version: '${KUBELOGIN_VERSION}'\`
 - Convert kubeconfig to use kubelogin: \`kubelogin convert-kubeconfig -l workloadidentity\`${
     config.acrLoginServer
       ? `\n- Build and push the container image using ACR Tasks: \`az acr build --registry \${{ secrets.AZURE_ACR_NAME }} --image ${config.appName}:\${{ github.sha }} .\`\n- Update the container image reference in manifests to use \`${config.acrLoginServer}/${config.appName}:\${{ github.sha }}\``


### PR DESCRIPTION
## Summary

Fixes three root causes of agent-generated workflow failures (PR 7 — independent, improves existing agent path):

- **Pin kubelogin v0.1.6** — replaces `skip-cache: true` which required an unavailable GITHUB_TOKEN for GitHub API calls
- **Add `actions: read` permission** — was missing from agent instructions, causing kubelogin setup to fail silently
- **Instruct two-job workflow split** — `buildImage` and `deploy` as separate jobs so build failures don't touch the cluster

## Changes Made

- `agentTemplates.ts` — updated agent instruction templates with pinned version, correct permissions, and split-job guidance
- `agentTemplates.test.ts` — tests verifying the templates include all three fixes
- `constants.ts` — added `KUBELOGIN_VERSION` constant

## Related Issues

Part of #557 (Fast Path Pipeline)
Closes #556

## Test Plan

- [x] Agent template includes `kubelogin-version: 'v0.1.6'`
- [x] Agent template includes `actions: read` permission
- [x] Agent template includes two-job split instruction
- [x] Type check passes

