### PR TITLE
feat: deterministic deploy workflow + K8s manifest generators

### DIFF
--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -43,7 +43,7 @@ describe('generateDeployWorkflow', () => {
 
   it('should use Azure/k8s-deploy@v5 for deployment', () => {
     const output = generateDeployWorkflow(baseConfig);
-    expect(output).toContain('Azure/k8s-deploy@v5');
+    expect(output).toContain('Azure/k8s-deploy@c8cfec839dc09896b3b8cc40cd13d04792680771'); // v5.1.0
     expect(output).not.toContain('kubectl apply');
   });
 
@@ -114,11 +114,11 @@ describe('generateDeployWorkflow', () => {
     expect(output).toContain('${{ secrets.AZURE_CLIENT_ID }}');
   });
 
-  it('should include concurrency block to cancel in-progress runs', () => {
+  it('should include concurrency block that queues rather than cancels in-progress runs', () => {
     const output = generateDeployWorkflow(baseConfig);
     const parsed = YAML.parse(output);
     expect(parsed.concurrency.group).toContain('github.workflow');
-    expect(parsed.concurrency['cancel-in-progress']).toBe(true);
+    expect(parsed.concurrency['cancel-in-progress']).toBe(false);
   });
 
   it('should annotate specific deployment, not all deployments in namespace', () => {

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -137,6 +137,24 @@ describe('generateDeployWorkflow', () => {
     const output = generateDeployWorkflow(baseConfig);
     expect(output).toContain('"aks-project/pipeline-repo=${{ github.repository }}"');
   });
+
+  it('should throw when appName contains no alphanumeric characters', () => {
+    expect(() => generateDeployWorkflow({ ...baseConfig, appName: '???' })).toThrow(
+      /no alphanumeric characters/
+    );
+  });
+
+  it('should throw when appName is empty string', () => {
+    expect(() => generateDeployWorkflow({ ...baseConfig, appName: '' })).toThrow(
+      /no alphanumeric characters/
+    );
+  });
+
+  it('should throw when appName contains only special characters', () => {
+    expect(() => generateDeployWorkflow({ ...baseConfig, appName: '___###' })).toThrow(
+      /no alphanumeric characters/
+    );
+  });
 });
 
 const baseManifestConfig = {
@@ -334,6 +352,24 @@ describe('generateDeploymentManifest', () => {
     const container = parsed.spec.template.spec.containers[0];
     expect(container.readinessProbe.successThreshold).toBe(2);
   });
+
+  it('should throw when appName contains no alphanumeric characters', () => {
+    expect(() =>
+      generateDeploymentManifest({ ...baseManifestConfig, appName: '???' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
+  });
+
+  it('should throw when appName is empty string', () => {
+    expect(() =>
+      generateDeploymentManifest({ ...baseManifestConfig, appName: '' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
+  });
+
+  it('should throw when appName contains only special characters', () => {
+    expect(() =>
+      generateDeploymentManifest({ ...baseManifestConfig, appName: '___###' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
+  });
 });
 
 describe('generateServiceManifest', () => {
@@ -370,5 +406,23 @@ describe('generateServiceManifest', () => {
     const parsed = YAML.parse(output);
     expect(parsed.spec.ports[0].port).toBe(3000);
     expect(parsed.spec.ports[0].targetPort).toBe(3000);
+  });
+
+  it('should throw when appName contains no alphanumeric characters', () => {
+    expect(() =>
+      generateServiceManifest({ ...baseManifestConfig, appName: '???' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
+  });
+
+  it('should throw when appName is empty string', () => {
+    expect(() =>
+      generateServiceManifest({ ...baseManifestConfig, appName: '' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
+  });
+
+  it('should throw when appName contains only special characters', () => {
+    expect(() =>
+      generateServiceManifest({ ...baseManifestConfig, appName: '___###' }, baseContainerConfig)
+    ).toThrow(/no alphanumeric characters/);
   });
 });

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+import { createContainerConfig } from '../__fixtures__/pipelineConfig';
+import {
+  generateDeploymentManifest,
+  generateDeployWorkflow,
+  generateServiceManifest,
+} from './fastPathTemplates';
+
+const baseConfig = {
+  appName: 'contoso-air',
+  clusterName: 'aks-prod',
+  resourceGroup: 'rg-prod',
+  namespace: 'demo',
+  acrName: 'acrprod',
+  dockerfilePath: './Dockerfile',
+  buildContextPath: '.',
+  defaultBranch: 'main',
+};
+
+describe('generateDeployWorkflow', () => {
+  it('should produce parseable workflow YAML with two jobs', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+
+    expect(parsed.name).toBe('Deploy to AKS');
+    expect(Object.keys(parsed.jobs)).toContain('buildImage');
+    expect(Object.keys(parsed.jobs)).toContain('deploy');
+    expect(parsed.jobs.deploy.needs).toContain('buildImage');
+  });
+
+  it('should use pinned kubelogin version', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain("kubelogin-version: 'v0.1.6'");
+    expect(output).not.toContain('skip-cache');
+  });
+
+  it('should include actions: read permission', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.jobs.deploy.permissions.actions).toBe('read');
+  });
+
+  it('should use Azure/k8s-deploy@v5 for deployment', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain('Azure/k8s-deploy@v5');
+    expect(output).not.toContain('kubectl apply');
+  });
+
+  it('should include explicit Dockerfile path and build context', () => {
+    const output = generateDeployWorkflow({
+      ...baseConfig,
+      dockerfilePath: './src/web/Dockerfile',
+      buildContextPath: './src/web',
+    });
+    const parsed = YAML.parse(output);
+    expect(parsed.env.DOCKER_FILE).toBe('./src/web/Dockerfile');
+    expect(parsed.env.BUILD_CONTEXT_PATH).toBe('./src/web');
+  });
+
+  it('should set continue-on-error on annotation steps', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain('continue-on-error: true');
+  });
+
+  it('should use use-kubelogin: true in aks-set-context', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain("use-kubelogin: 'true'");
+  });
+
+  it('should parameterize all config values', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.env.AZURE_CONTAINER_REGISTRY).toBe('acrprod');
+    expect(parsed.env.CONTAINER_NAME).toBe('contoso-air');
+    expect(parsed.env.CLUSTER_NAME).toBe('aks-prod');
+    expect(parsed.env.CLUSTER_RESOURCE_GROUP).toBe('rg-prod');
+    expect(parsed.env.NAMESPACE).toBe('demo');
+  });
+
+  it('should trigger on push to default branch and workflow_dispatch', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.on.push.branches).toContain('main');
+    expect(parsed.on.workflow_dispatch).toBeDefined();
+  });
+
+  it('should not include ACR_RESOURCE_GROUP env var', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.env.ACR_RESOURCE_GROUP).toBeUndefined();
+  });
+
+  it('should not pass -g flag to az acr build', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).not.toContain('-g ');
+  });
+
+  it('should escape config values with special characters', () => {
+    const output = generateDeployWorkflow({
+      ...baseConfig,
+      appName: 'my:app#1',
+      namespace: 'ns-with-special',
+    });
+    const parsed = YAML.parse(output);
+    expect(parsed.env.CONTAINER_NAME).toBe('my-app-1');
+    expect(parsed.env.NAMESPACE).toBe('ns-with-special');
+  });
+
+  it('should preserve GitHub Actions expressions (${{ }}) verbatim', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain('${{ env.CLUSTER_NAME }}');
+    expect(output).toContain('${{ github.sha }}');
+    expect(output).toContain('${{ secrets.AZURE_CLIENT_ID }}');
+  });
+
+  it('should include concurrency block to cancel in-progress runs', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.concurrency.group).toContain('github.workflow');
+    expect(parsed.concurrency['cancel-in-progress']).toBe(true);
+  });
+
+  it('should annotate specific deployment, not all deployments in namespace', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain('deployment "${{ env.CONTAINER_NAME }}"');
+    expect(output).not.toContain('deployment --all');
+  });
+
+  it('should normalize appName to DNS-1123 for CONTAINER_NAME', () => {
+    const output = generateDeployWorkflow({ ...baseConfig, appName: 'My_App_v2' });
+    const parsed = YAML.parse(output);
+    expect(parsed.env.CONTAINER_NAME).toBe('my-app-v2');
+  });
+
+  it('should quote pipeline-repo annotation value in namespace annotate step', () => {
+    const output = generateDeployWorkflow(baseConfig);
+    expect(output).toContain('"aks-project/pipeline-repo=${{ github.repository }}"');
+  });
+});
+
+const baseManifestConfig = {
+  appName: 'contoso-air',
+  namespace: 'demo',
+  acrName: 'acrprod',
+  repo: { owner: 'pauldotyu', name: 'contoso-air' },
+};
+
+const baseContainerConfig = createContainerConfig({
+  replicas: 1,
+  targetPort: 3000,
+  servicePort: 80,
+  useCustomServicePort: true,
+  serviceType: 'ClusterIP',
+  enableResources: true,
+  cpuRequest: '100m',
+  cpuLimit: '500m',
+  memoryRequest: '128Mi',
+  memoryLimit: '512Mi',
+  enableLivenessProbe: true,
+  livenessPath: '/',
+  livenessInitialDelay: 15,
+  livenessPeriod: 20,
+  livenessTimeout: 5,
+  livenessFailure: 3,
+  livenessSuccess: 1,
+  enableReadinessProbe: false,
+  enableStartupProbe: false,
+  allowPrivilegeEscalation: false,
+  runAsNonRoot: false,
+  readOnlyRootFilesystem: false,
+  enablePodAntiAffinity: false,
+  enableTopologySpreadConstraints: false,
+});
+
+describe('generateDeploymentManifest', () => {
+  it('should produce parseable YAML with correct structure', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, baseContainerConfig);
+    const parsed = YAML.parse(output);
+
+    expect(parsed.apiVersion).toBe('apps/v1');
+    expect(parsed.kind).toBe('Deployment');
+    expect(parsed.metadata.name).toBe('contoso-air');
+    expect(parsed.metadata.namespace).toBe('demo');
+    expect(parsed.spec.replicas).toBe(1);
+    expect(parsed.spec.template.spec.containers).toHaveLength(1);
+    expect(parsed.spec.template.spec.containers[0].ports).toEqual([{ containerPort: 3000 }]);
+  });
+
+  it('should include pipeline annotations', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, baseContainerConfig);
+    const parsed = YAML.parse(output);
+    expect(parsed.metadata.annotations['aks-project/deployed-by']).toBe('pipeline');
+    expect(parsed.metadata.annotations['aks-project/pipeline-repo']).toBe('pauldotyu/contoso-air');
+  });
+
+  it('should include resource limits when enabled', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, baseContainerConfig);
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.resources.requests.cpu).toBe('100m');
+    expect(container.resources.requests.memory).toBe('128Mi');
+    expect(container.resources.limits.cpu).toBe('500m');
+    expect(container.resources.limits.memory).toBe('512Mi');
+  });
+
+  it('should include liveness probe when enabled', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, baseContainerConfig);
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+
+    expect(container.livenessProbe).toBeDefined();
+    expect(container.livenessProbe.httpGet.path).toBe('/');
+    expect(container.livenessProbe.httpGet.port).toBe(3000);
+    expect(container.livenessProbe.initialDelaySeconds).toBe(15);
+    expect(container.livenessProbe.periodSeconds).toBe(20);
+    expect(container.readinessProbe).toBeUndefined();
+    expect(container.startupProbe).toBeUndefined();
+  });
+
+  it('should omit resources when not enabled', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      enableResources: false,
+    });
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.resources).toBeUndefined();
+  });
+
+  it('should include security context when configured', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      allowPrivilegeEscalation: false,
+      runAsNonRoot: true,
+      readOnlyRootFilesystem: true,
+    });
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.securityContext.allowPrivilegeEscalation).toBe(false);
+    expect(container.securityContext.runAsNonRoot).toBe(true);
+    expect(container.securityContext.readOnlyRootFilesystem).toBe(true);
+  });
+
+  it('should omit allowPrivilegeEscalation from security context when true', () => {
+    // When the user sets allowPrivilegeEscalation: true, we do NOT write it to the manifest
+    // (we never emit `allowPrivilegeEscalation: true`; the field is omitted and K8s defaults apply).
+    const output = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      allowPrivilegeEscalation: true,
+    });
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.securityContext.allowPrivilegeEscalation).toBeUndefined();
+  });
+
+  it('should normalize appName to DNS-1123 for K8s resource names', () => {
+    const output = generateDeploymentManifest(
+      { ...baseManifestConfig, appName: 'My_App_v2' },
+      baseContainerConfig
+    );
+    const parsed = YAML.parse(output);
+    expect(parsed.metadata.name).toBe('my-app-v2');
+    expect(parsed.spec.selector.matchLabels.app).toBe('my-app-v2');
+    expect(parsed.spec.template.spec.containers[0].name).toBe('my-app-v2');
+  });
+
+  it('should include anti-affinity when enabled', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      enablePodAntiAffinity: true,
+    });
+    const parsed = YAML.parse(output);
+    const affinity = parsed.spec.template.spec.affinity;
+    expect(affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution).toHaveLength(
+      1
+    );
+    expect(affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight).toBe(
+      100
+    );
+  });
+
+  it('should include topology spread constraints when enabled', () => {
+    const output = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      enableTopologySpreadConstraints: true,
+    });
+    const parsed = YAML.parse(output);
+    const constraints = parsed.spec.template.spec.topologySpreadConstraints;
+    expect(constraints).toHaveLength(1);
+    expect(constraints[0].maxSkew).toBe(1);
+    expect(constraints[0].whenUnsatisfiable).toBe('ScheduleAnyway');
+  });
+});
+
+describe('generateServiceManifest', () => {
+  it('should produce parseable YAML with correct structure', () => {
+    const output = generateServiceManifest(baseManifestConfig, baseContainerConfig);
+    const parsed = YAML.parse(output);
+
+    expect(parsed.apiVersion).toBe('v1');
+    expect(parsed.kind).toBe('Service');
+    expect(parsed.metadata.name).toBe('contoso-air');
+    expect(parsed.metadata.namespace).toBe('demo');
+    expect(parsed.spec.type).toBe('ClusterIP');
+    expect(parsed.spec.ports).toHaveLength(1);
+    expect(parsed.spec.ports[0].port).toBe(80);
+    expect(parsed.spec.ports[0].targetPort).toBe(3000);
+    expect(parsed.spec.ports[0].protocol).toBe('TCP');
+    expect(parsed.spec.selector.app).toBe('contoso-air');
+  });
+
+  it('should support LoadBalancer service type', () => {
+    const output = generateServiceManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      serviceType: 'LoadBalancer',
+    });
+    const parsed = YAML.parse(output);
+    expect(parsed.spec.type).toBe('LoadBalancer');
+  });
+
+  it('should use targetPort when custom service port is disabled', () => {
+    const output = generateServiceManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      useCustomServicePort: false,
+    });
+    const parsed = YAML.parse(output);
+    expect(parsed.spec.ports[0].port).toBe(3000);
+    expect(parsed.spec.ports[0].targetPort).toBe(3000);
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -291,6 +291,49 @@ describe('generateDeploymentManifest', () => {
     expect(constraints[0].maxSkew).toBe(1);
     expect(constraints[0].whenUnsatisfiable).toBe('ScheduleAnyway');
   });
+
+  it('should omit successThreshold for liveness probe (K8s requires it to be 1, the default)', () => {
+    const output = generateDeploymentManifest(
+      baseManifestConfig,
+      createContainerConfig({
+        ...baseContainerConfig,
+        enableLivenessProbe: true,
+        livenessSuccess: 5, // user set > 1, but K8s forbids this for liveness
+      })
+    );
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    // successThreshold is omitted (K8s defaults to 1); emitting > 1 would be rejected by the API
+    expect(container.livenessProbe.successThreshold).toBeUndefined();
+  });
+
+  it('should omit successThreshold for startup probe (K8s requires it to be 1, the default)', () => {
+    const output = generateDeploymentManifest(
+      baseManifestConfig,
+      createContainerConfig({
+        ...baseContainerConfig,
+        enableStartupProbe: true,
+        startupSuccess: 3,
+      })
+    );
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.startupProbe.successThreshold).toBeUndefined();
+  });
+
+  it('should emit successThreshold for readiness probe when > 1', () => {
+    const output = generateDeploymentManifest(
+      baseManifestConfig,
+      createContainerConfig({
+        ...baseContainerConfig,
+        enableReadinessProbe: true,
+        readinessSuccess: 2,
+      })
+    );
+    const parsed = YAML.parse(output);
+    const container = parsed.spec.template.spec.containers[0];
+    expect(container.readinessProbe.successThreshold).toBe(2);
+  });
 });
 
 describe('generateServiceManifest', () => {

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -184,14 +184,19 @@ export function generateDeploymentManifest(config: ManifestConfig, cc: Container
   }
 
   for (const probe of getProbeConfigs(cc).filter(p => p.enabled)) {
-    container[probeFieldName(probe.name)] = {
+    const probeSpec: Record<string, unknown> = {
       httpGet: { path: probe.path, port: cc.targetPort },
       initialDelaySeconds: probe.initialDelay,
       periodSeconds: probe.period,
       timeoutSeconds: probe.timeout,
       failureThreshold: probe.failure,
-      successThreshold: probe.success,
     };
+    // Kubernetes requires successThreshold === 1 for liveness and startup probes (K8s API constraint).
+    // Only readiness probes may have successThreshold > 1, so we only emit the field for readiness.
+    if (probe.name === 'Readiness') {
+      probeSpec.successThreshold = probe.success;
+    }
+    container[probeFieldName(probe.name)] = probeSpec;
   }
 
   // Security context: always-on hardening defaults (capabilities drop ALL, seccomp RuntimeDefault).

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -44,7 +44,7 @@ on:
 
 concurrency:
   group: \${{ github.workflow }}-\${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   AZURE_CONTAINER_REGISTRY: "${esc(config.acrName)}"
@@ -63,12 +63,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      # Note: using floating major-version tags for maintainability (consistent with agentTemplates.ts).
-      # For higher-security environments, pin to specific commit SHAs.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
         with:
           client-id: \${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: \${{ secrets.AZURE_TENANT_ID }}
@@ -90,24 +88,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [buildImage]
     steps:
-      # Note: using floating major-version tags for maintainability (consistent with agentTemplates.ts).
-      # For higher-security environments, pin to specific commit SHAs.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
         with:
           client-id: \${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: \${{ secrets.AZURE_TENANT_ID }}
           subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Set up kubelogin
-        uses: azure/use-kubelogin@v1
+        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
         with:
           kubelogin-version: 'v0.1.6'
 
       - name: Get K8s context
-        uses: azure/aks-set-context@v4
+        uses: azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4.0.3
         with:
           resource-group: \${{ env.CLUSTER_RESOURCE_GROUP }}
           cluster-name: \${{ env.CLUSTER_NAME }}
@@ -115,7 +111,7 @@ jobs:
           use-kubelogin: 'true'
 
       - name: Deploy application
-        uses: Azure/k8s-deploy@v5
+        uses: Azure/k8s-deploy@c8cfec839dc09896b3b8cc40cd13d04792680771 # v5.1.0
         with:
           action: deploy
           manifests: \${{ env.DEPLOYMENT_MANIFEST_PATH }}
@@ -126,7 +122,7 @@ jobs:
       - name: Annotate namespace
         continue-on-error: true
         run: |
-          kubectl annotate namespace \${{ env.NAMESPACE }} \\
+          kubectl annotate namespace "\${{ env.NAMESPACE }}" \\
             "aks-project/pipeline-repo=\${{ github.repository }}" \\
             --overwrite
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -16,7 +16,12 @@ export interface WorkflowConfig {
   resourceGroup: string;
   /** Kubernetes namespace for deployment and annotation steps. */
   namespace: string;
-  /** Azure Container Registry name (without `.azurecr.io`), written to `AZURE_CONTAINER_REGISTRY`. */
+  /**
+   * Azure Container Registry name (without `.azurecr.io`), written to `AZURE_CONTAINER_REGISTRY`.
+   * **Must match `ManifestConfig.acrName` exactly** — Azure/k8s-deploy substitutes the manifest
+   * image at deploy time by matching on the registry+name prefix. Mismatched values cause
+   * k8s-deploy to silently skip substitution and deploy the `:latest` tag instead.
+   */
   acrName: string;
   /** Path to the Dockerfile, relative to repo root (e.g., `./Dockerfile` or `./src/web/Dockerfile`). */
   dockerfilePath: string;
@@ -35,6 +40,13 @@ export function generateDeployWorkflow(config: WorkflowConfig): string {
   // Normalize to a valid DNS-1123 label so CONTAINER_NAME matches the K8s resource name
   // used in the generated manifests, preventing a silent mismatch during k8s-deploy image substitution.
   const appName = normalizeK8sName(config.appName);
+  // Guard: if the name normalized to the fallback sentinel, reject rather than silently
+  // deploying to a resource named "app".
+  if (!/[a-z0-9]/i.test(config.appName)) {
+    throw new Error(
+      `appName "${config.appName}" contains no alphanumeric characters and cannot produce a valid K8s resource name.`
+    );
+  }
   return `name: Deploy to AKS
 
 on:
@@ -142,7 +154,12 @@ export interface ManifestConfig {
   appName: string;
   /** Kubernetes namespace for the generated Deployment and Service manifests. */
   namespace: string;
-  /** Azure Container Registry name (without `.azurecr.io`) used to construct the container image reference. */
+  /**
+   * Azure Container Registry name (without `.azurecr.io`) used to construct the container image reference.
+   * **Must match `WorkflowConfig.acrName` exactly** — Azure/k8s-deploy substitutes the manifest
+   * image at deploy time by matching on the registry+name prefix. Mismatched values cause
+   * k8s-deploy to silently skip substitution and deploy the `:latest` tag instead.
+   */
   acrName: string;
   /** GitHub repository owner and name, used in the `aks-project/pipeline-repo` annotation. */
   repo: { owner: string; name: string };
@@ -163,11 +180,20 @@ export function generateDeploymentManifest(config: ManifestConfig, cc: Container
   // Normalize to a valid DNS-1123 label so the manifest is accepted by Kubernetes even if
   // the caller passes an app name with uppercase, underscores, or other invalid characters.
   const appName = normalizeK8sName(config.appName);
+  // Guard: if the name normalized to the fallback sentinel, reject rather than silently
+  // deploying to a resource named "app".
+  if (!/[a-z0-9]/i.test(config.appName)) {
+    throw new Error(
+      `appName "${config.appName}" contains no alphanumeric characters and cannot produce a valid K8s resource name.`
+    );
+  }
 
   const container: Record<string, unknown> = {
     name: appName,
-    // Note: Azure/k8s-deploy@v5 substitutes this with the actual built image+SHA at deploy time.
-    // The ':latest' here is a placeholder that will be replaced by the workflow's build SHA.
+    // Note: ':latest' is a placeholder tag. Azure/k8s-deploy substitutes it at deploy time with
+    // the actual image+SHA built by the workflow (e.g., myapp:abc1234). The manifest file on disk
+    // shows ':latest', but the running container always uses the SHA-pinned image.
+    // This substitution requires WorkflowConfig.acrName and ManifestConfig.acrName to match exactly.
     image: `${config.acrName}.azurecr.io/${appName}:latest`,
     ports: [{ containerPort: cc.targetPort }],
   };
@@ -195,7 +221,11 @@ export function generateDeploymentManifest(config: ManifestConfig, cc: Container
     container[probeFieldName(probe.name)] = probeSpec;
   }
 
-  // Security context: always-on hardening defaults (capabilities drop ALL, seccomp RuntimeDefault).
+  // Security context: always-on baseline hardening (capabilities drop ALL, seccomp RuntimeDefault).
+  // These two settings are universally supported and have no functional impact on most workloads.
+  // The three conditional fields below reflect the user's wizard choices (configurable in the
+  // DeployWizard UI) and default to opt-in. Users wanting stricter defaults can enable them
+  // in the wizard: allowPrivilegeEscalation=false, runAsNonRoot=true, readOnlyRootFilesystem=true.
   const securityContext: Record<string, unknown> = {
     capabilities: { drop: ['ALL'] },
     seccompProfile: { type: 'RuntimeDefault' },
@@ -267,6 +297,13 @@ export function generateDeploymentManifest(config: ManifestConfig, cc: Container
 export function generateServiceManifest(config: ManifestConfig, cc: ContainerConfig): string {
   const servicePort = cc.useCustomServicePort ? cc.servicePort : cc.targetPort;
   const appName = normalizeK8sName(config.appName);
+  // Guard: if the name normalized to the fallback sentinel, reject rather than silently
+  // deploying to a resource named "app".
+  if (!/[a-z0-9]/i.test(config.appName)) {
+    throw new Error(
+      `appName "${config.appName}" contains no alphanumeric characters and cannot produce a valid K8s resource name.`
+    );
+  }
 
   const service = {
     apiVersion: 'v1',

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import YAML from 'yaml';
+import YAML, { Scalar } from 'yaml';
 import { normalizeK8sName } from '../../../utils/kubernetes/k8sNames';
 import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
 import { getProbeConfigs, probeFieldName } from './probeHelpers';
-import { escapeYamlValue } from './yamlUtils';
 
 export interface WorkflowConfig {
   /** App name used for the ACR image name and the `CONTAINER_NAME` env var. Must be a valid DNS-1123 label. */
@@ -32,11 +31,20 @@ export interface WorkflowConfig {
 }
 
 /**
+ * Creates a YAML scalar with single-quote style.
+ */
+function singleQuoted(value: string): Scalar {
+  const scalar = new Scalar(value);
+  scalar.type = 'QUOTE_SINGLE';
+  return scalar;
+}
+
+/**
  * Generates a deterministic deploy-to-aks.yml workflow.
+ * Builds a plain JS object and serializes via YAML.stringify.
  * Based on the proven aks-devhub workflow with all known bug fixes applied.
  */
 export function generateDeployWorkflow(config: WorkflowConfig): string {
-  const esc = escapeYamlValue;
   // Normalize to a valid DNS-1123 label so CONTAINER_NAME matches the K8s resource name
   // used in the generated manifests, preventing a silent mismatch during k8s-deploy image substitution.
   const appName = normalizeK8sName(config.appName);
@@ -47,106 +55,120 @@ export function generateDeployWorkflow(config: WorkflowConfig): string {
       `appName "${config.appName}" contains no alphanumeric characters and cannot produce a valid K8s resource name.`
     );
   }
-  return `name: Deploy to AKS
 
-on:
-  push:
-    branches: ["${esc(config.defaultBranch)}"]
-  workflow_dispatch:
+  const workflow: Record<string, unknown> = {
+    name: 'Deploy to AKS',
+    on: {
+      push: {
+        branches: [config.defaultBranch],
+      },
+      workflow_dispatch: null,
+    },
+    concurrency: {
+      group: '${{ github.workflow }}-${{ github.ref }}',
+      'cancel-in-progress': false,
+    },
+    env: {
+      AZURE_CONTAINER_REGISTRY: config.acrName,
+      CONTAINER_NAME: appName,
+      CLUSTER_NAME: config.clusterName,
+      CLUSTER_RESOURCE_GROUP: config.resourceGroup,
+      DEPLOYMENT_MANIFEST_PATH: './deploy/kubernetes',
+      DOCKER_FILE: config.dockerfilePath,
+      BUILD_CONTEXT_PATH: config.buildContextPath,
+      NAMESPACE: config.namespace,
+    },
+    jobs: {
+      buildImage: {
+        permissions: {
+          contents: 'read',
+          'id-token': 'write',
+        },
+        'runs-on': 'ubuntu-latest',
+        steps: [
+          {
+            uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1',
+          },
+          {
+            name: 'Azure login',
+            uses: 'azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0',
+            with: {
+              'client-id': '${{ secrets.AZURE_CLIENT_ID }}',
+              'tenant-id': '${{ secrets.AZURE_TENANT_ID }}',
+              'subscription-id': '${{ secrets.AZURE_SUBSCRIPTION_ID }}',
+            },
+          },
+          {
+            name: 'Build and push image to ACR',
+            run: 'az acr build \\\n  --registry "${{ env.AZURE_CONTAINER_REGISTRY }}" \\\n  -f "${{ env.DOCKER_FILE }}" \\\n  --image "${{ env.CONTAINER_NAME }}:${{ github.sha }}" \\\n  "${{ env.BUILD_CONTEXT_PATH }}"\n',
+          },
+        ],
+      },
+      deploy: {
+        permissions: {
+          actions: 'read',
+          contents: 'read',
+          'id-token': 'write',
+        },
+        'runs-on': 'ubuntu-latest',
+        needs: ['buildImage'],
+        steps: [
+          {
+            uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1',
+          },
+          {
+            name: 'Azure login',
+            uses: 'azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0',
+            with: {
+              'client-id': '${{ secrets.AZURE_CLIENT_ID }}',
+              'tenant-id': '${{ secrets.AZURE_TENANT_ID }}',
+              'subscription-id': '${{ secrets.AZURE_SUBSCRIPTION_ID }}',
+            },
+          },
+          {
+            name: 'Set up kubelogin',
+            uses: 'azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3',
+            with: {
+              'kubelogin-version': singleQuoted('v0.1.6'),
+            },
+          },
+          {
+            name: 'Get K8s context',
+            uses: 'azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4.0.3',
+            with: {
+              'resource-group': '${{ env.CLUSTER_RESOURCE_GROUP }}',
+              'cluster-name': '${{ env.CLUSTER_NAME }}',
+              admin: singleQuoted('false'),
+              'use-kubelogin': singleQuoted('true'),
+            },
+          },
+          {
+            name: 'Deploy application',
+            uses: 'Azure/k8s-deploy@c8cfec839dc09896b3b8cc40cd13d04792680771 # v5.1.0',
+            with: {
+              action: 'deploy',
+              manifests: '${{ env.DEPLOYMENT_MANIFEST_PATH }}',
+              images:
+                '${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}\n',
+              namespace: '${{ env.NAMESPACE }}',
+            },
+          },
+          {
+            name: 'Annotate namespace',
+            'continue-on-error': true,
+            run: 'kubectl annotate namespace "${{ env.NAMESPACE }}" \\\n  "aks-project/pipeline-repo=${{ github.repository }}" \\\n  --overwrite\n',
+          },
+          {
+            name: 'Annotate deployment',
+            'continue-on-error': true,
+            run: 'kubectl annotate deployment "${{ env.CONTAINER_NAME }}" \\\n  -n "${{ env.NAMESPACE }}" \\\n  aks-project/pipeline-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \\\n  "aks-project/pipeline-workflow=${{ github.workflow }}" \\\n  --overwrite\n',
+          },
+        ],
+      },
+    },
+  };
 
-concurrency:
-  group: \${{ github.workflow }}-\${{ github.ref }}
-  cancel-in-progress: false
-
-env:
-  AZURE_CONTAINER_REGISTRY: "${esc(config.acrName)}"
-  CONTAINER_NAME: "${esc(appName)}"
-  CLUSTER_NAME: "${esc(config.clusterName)}"
-  CLUSTER_RESOURCE_GROUP: "${esc(config.resourceGroup)}"
-  DEPLOYMENT_MANIFEST_PATH: ./deploy/kubernetes
-  DOCKER_FILE: "${esc(config.dockerfilePath)}"
-  BUILD_CONTEXT_PATH: "${esc(config.buildContextPath)}"
-  NAMESPACE: "${esc(config.namespace)}"
-
-jobs:
-  buildImage:
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Azure login
-        uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
-        with:
-          client-id: \${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Build and push image to ACR
-        run: |
-          az acr build \\
-            --registry "\${{ env.AZURE_CONTAINER_REGISTRY }}" \\
-            -f "\${{ env.DOCKER_FILE }}" \\
-            --image "\${{ env.CONTAINER_NAME }}:\${{ github.sha }}" \\
-            "\${{ env.BUILD_CONTEXT_PATH }}"
-
-  deploy:
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    needs: [buildImage]
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Azure login
-        uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
-        with:
-          client-id: \${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Set up kubelogin
-        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
-        with:
-          kubelogin-version: 'v0.1.6'
-
-      - name: Get K8s context
-        uses: azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4.0.3
-        with:
-          resource-group: \${{ env.CLUSTER_RESOURCE_GROUP }}
-          cluster-name: \${{ env.CLUSTER_NAME }}
-          admin: 'false'
-          use-kubelogin: 'true'
-
-      - name: Deploy application
-        uses: Azure/k8s-deploy@c8cfec839dc09896b3b8cc40cd13d04792680771 # v5.1.0
-        with:
-          action: deploy
-          manifests: \${{ env.DEPLOYMENT_MANIFEST_PATH }}
-          images: |
-            \${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/\${{ env.CONTAINER_NAME }}:\${{ github.sha }}
-          namespace: \${{ env.NAMESPACE }}
-
-      - name: Annotate namespace
-        continue-on-error: true
-        run: |
-          kubectl annotate namespace "\${{ env.NAMESPACE }}" \\
-            "aks-project/pipeline-repo=\${{ github.repository }}" \\
-            --overwrite
-
-      - name: Annotate deployment
-        continue-on-error: true
-        run: |
-          kubectl annotate deployment "\${{ env.CONTAINER_NAME }}" \\
-            -n "\${{ env.NAMESPACE }}" \\
-            aks-project/pipeline-run-url=\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }} \\
-            "aks-project/pipeline-workflow=\${{ github.workflow }}" \\
-            --overwrite
-`;
+  return YAML.stringify(workflow, { lineWidth: 0 });
 }
 
 export interface ManifestConfig {

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import YAML from 'yaml';
+import { normalizeK8sName } from '../../../utils/kubernetes/k8sNames';
+import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
+import { getProbeConfigs, probeFieldName } from './probeHelpers';
+import { escapeYamlValue } from './yamlUtils';
+
+export interface WorkflowConfig {
+  /** App name used for the ACR image name and the `CONTAINER_NAME` env var. Must be a valid DNS-1123 label. */
+  appName: string;
+  /** AKS cluster name, written to `CLUSTER_NAME` env var. */
+  clusterName: string;
+  /** Resource group containing the AKS cluster, written to `CLUSTER_RESOURCE_GROUP` env var. */
+  resourceGroup: string;
+  /** Kubernetes namespace for deployment and annotation steps. */
+  namespace: string;
+  /** Azure Container Registry name (without `.azurecr.io`), written to `AZURE_CONTAINER_REGISTRY`. */
+  acrName: string;
+  /** Path to the Dockerfile, relative to repo root (e.g., `./Dockerfile` or `./src/web/Dockerfile`). */
+  dockerfilePath: string;
+  /** Build context path passed to `az acr build` (e.g., `.` or `./src/web`). */
+  buildContextPath: string;
+  /** Default branch name used as the push trigger (e.g., `main`). */
+  defaultBranch: string;
+}
+
+/**
+ * Generates a deterministic deploy-to-aks.yml workflow.
+ * Based on the proven aks-devhub workflow with all known bug fixes applied.
+ */
+export function generateDeployWorkflow(config: WorkflowConfig): string {
+  const esc = escapeYamlValue;
+  // Normalize to a valid DNS-1123 label so CONTAINER_NAME matches the K8s resource name
+  // used in the generated manifests, preventing a silent mismatch during k8s-deploy image substitution.
+  const appName = normalizeK8sName(config.appName);
+  return `name: Deploy to AKS
+
+on:
+  push:
+    branches: ["${esc(config.defaultBranch)}"]
+  workflow_dispatch:
+
+concurrency:
+  group: \${{ github.workflow }}-\${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AZURE_CONTAINER_REGISTRY: "${esc(config.acrName)}"
+  CONTAINER_NAME: "${esc(appName)}"
+  CLUSTER_NAME: "${esc(config.clusterName)}"
+  CLUSTER_RESOURCE_GROUP: "${esc(config.resourceGroup)}"
+  DEPLOYMENT_MANIFEST_PATH: ./deploy/kubernetes
+  DOCKER_FILE: "${esc(config.dockerfilePath)}"
+  BUILD_CONTEXT_PATH: "${esc(config.buildContextPath)}"
+  NAMESPACE: "${esc(config.namespace)}"
+
+jobs:
+  buildImage:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      # Note: using floating major-version tags for maintainability (consistent with agentTemplates.ts).
+      # For higher-security environments, pin to specific commit SHAs.
+      - uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: \${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build and push image to ACR
+        run: |
+          az acr build \\
+            --registry "\${{ env.AZURE_CONTAINER_REGISTRY }}" \\
+            -f "\${{ env.DOCKER_FILE }}" \\
+            --image "\${{ env.CONTAINER_NAME }}:\${{ github.sha }}" \\
+            "\${{ env.BUILD_CONTEXT_PATH }}"
+
+  deploy:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [buildImage]
+    steps:
+      # Note: using floating major-version tags for maintainability (consistent with agentTemplates.ts).
+      # For higher-security environments, pin to specific commit SHAs.
+      - uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: \${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up kubelogin
+        uses: azure/use-kubelogin@v1
+        with:
+          kubelogin-version: 'v0.1.6'
+
+      - name: Get K8s context
+        uses: azure/aks-set-context@v4
+        with:
+          resource-group: \${{ env.CLUSTER_RESOURCE_GROUP }}
+          cluster-name: \${{ env.CLUSTER_NAME }}
+          admin: 'false'
+          use-kubelogin: 'true'
+
+      - name: Deploy application
+        uses: Azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: \${{ env.DEPLOYMENT_MANIFEST_PATH }}
+          images: |
+            \${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/\${{ env.CONTAINER_NAME }}:\${{ github.sha }}
+          namespace: \${{ env.NAMESPACE }}
+
+      - name: Annotate namespace
+        continue-on-error: true
+        run: |
+          kubectl annotate namespace \${{ env.NAMESPACE }} \\
+            "aks-project/pipeline-repo=\${{ github.repository }}" \\
+            --overwrite
+
+      - name: Annotate deployment
+        continue-on-error: true
+        run: |
+          kubectl annotate deployment "\${{ env.CONTAINER_NAME }}" \\
+            -n "\${{ env.NAMESPACE }}" \\
+            aks-project/pipeline-run-url=\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }} \\
+            "aks-project/pipeline-workflow=\${{ github.workflow }}" \\
+            --overwrite
+`;
+}
+
+export interface ManifestConfig {
+  /** App name used as the K8s resource name (Deployment, Service, container) and selector label. Must be a valid DNS-1123 label. */
+  appName: string;
+  /** Kubernetes namespace for the generated Deployment and Service manifests. */
+  namespace: string;
+  /** Azure Container Registry name (without `.azurecr.io`) used to construct the container image reference. */
+  acrName: string;
+  /** GitHub repository owner and name, used in the `aks-project/pipeline-repo` annotation. */
+  repo: { owner: string; name: string };
+}
+
+/**
+ * Generates a Kubernetes Deployment manifest from container config.
+ * Builds a plain JS object and serializes via YAML.stringify for correct
+ * indentation and escaping.
+ *
+ * Note: This generator is intentionally separate from `DeployWizard/utils/yamlGenerator.ts`.
+ * The two generators differ in annotation strategy (`deployed-by: pipeline` vs `manual`),
+ * output format (single manifest vs multi-doc with Secret/SA/HPA), and caller context
+ * (pipeline-generated file vs wizard UI). Shared logic (`normalizeK8sName`, `getProbeConfigs`)
+ * is imported from shared utilities rather than duplicated.
+ */
+export function generateDeploymentManifest(config: ManifestConfig, cc: ContainerConfig): string {
+  // Normalize to a valid DNS-1123 label so the manifest is accepted by Kubernetes even if
+  // the caller passes an app name with uppercase, underscores, or other invalid characters.
+  const appName = normalizeK8sName(config.appName);
+
+  const container: Record<string, unknown> = {
+    name: appName,
+    // Note: Azure/k8s-deploy@v5 substitutes this with the actual built image+SHA at deploy time.
+    // The ':latest' here is a placeholder that will be replaced by the workflow's build SHA.
+    image: `${config.acrName}.azurecr.io/${appName}:latest`,
+    ports: [{ containerPort: cc.targetPort }],
+  };
+
+  if (cc.enableResources) {
+    container.resources = {
+      requests: { cpu: cc.cpuRequest, memory: cc.memoryRequest },
+      limits: { cpu: cc.cpuLimit, memory: cc.memoryLimit },
+    };
+  }
+
+  for (const probe of getProbeConfigs(cc).filter(p => p.enabled)) {
+    container[probeFieldName(probe.name)] = {
+      httpGet: { path: probe.path, port: cc.targetPort },
+      initialDelaySeconds: probe.initialDelay,
+      periodSeconds: probe.period,
+      timeoutSeconds: probe.timeout,
+      failureThreshold: probe.failure,
+      successThreshold: probe.success,
+    };
+  }
+
+  // Security context: always-on hardening defaults (capabilities drop ALL, seccomp RuntimeDefault).
+  const securityContext: Record<string, unknown> = {
+    capabilities: { drop: ['ALL'] },
+    seccompProfile: { type: 'RuntimeDefault' },
+  };
+  if (!cc.allowPrivilegeEscalation) securityContext.allowPrivilegeEscalation = false;
+  if (cc.runAsNonRoot) securityContext.runAsNonRoot = true;
+  if (cc.readOnlyRootFilesystem) securityContext.readOnlyRootFilesystem = true;
+  container.securityContext = securityContext;
+
+  const podSpec: Record<string, unknown> = {};
+
+  if (cc.enablePodAntiAffinity) {
+    podSpec.affinity = {
+      podAntiAffinity: {
+        preferredDuringSchedulingIgnoredDuringExecution: [
+          {
+            weight: 100,
+            podAffinityTerm: {
+              labelSelector: { matchLabels: { app: appName } },
+              topologyKey: 'kubernetes.io/hostname',
+            },
+          },
+        ],
+      },
+    };
+  }
+
+  if (cc.enableTopologySpreadConstraints) {
+    podSpec.topologySpreadConstraints = [
+      {
+        maxSkew: 1,
+        topologyKey: 'kubernetes.io/hostname',
+        whenUnsatisfiable: 'ScheduleAnyway',
+        labelSelector: { matchLabels: { app: appName } },
+      },
+    ];
+  }
+
+  podSpec.containers = [container];
+
+  const deployment = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: appName,
+      namespace: config.namespace,
+      annotations: {
+        'aks-project/deployed-by': 'pipeline',
+        'aks-project/pipeline-repo': `${config.repo.owner}/${config.repo.name}`,
+      },
+    },
+    spec: {
+      replicas: cc.replicas,
+      selector: { matchLabels: { app: appName } },
+      template: {
+        metadata: { labels: { app: appName } },
+        spec: podSpec,
+      },
+    },
+  };
+
+  return YAML.stringify(deployment, { lineWidth: 0 });
+}
+
+/**
+ * Generates a Kubernetes Service manifest from container config.
+ * Builds a plain JS object and serializes via YAML.stringify.
+ */
+export function generateServiceManifest(config: ManifestConfig, cc: ContainerConfig): string {
+  const servicePort = cc.useCustomServicePort ? cc.servicePort : cc.targetPort;
+  const appName = normalizeK8sName(config.appName);
+
+  const service = {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: appName,
+      namespace: config.namespace,
+    },
+    spec: {
+      type: cc.serviceType,
+      ports: [
+        {
+          port: servicePort,
+          targetPort: cc.targetPort,
+          protocol: 'TCP',
+        },
+      ],
+      selector: { app: appName },
+    },
+  };
+
+  return YAML.stringify(service, { lineWidth: 0 });
+}

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/probeHelpers.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/probeHelpers.ts
@@ -17,6 +17,14 @@ interface ProbeRenderConfig {
 }
 
 /**
+ * Returns the Kubernetes probe field name for a given probe name.
+ * E.g. 'Liveness' → 'livenessProbe', 'Readiness' → 'readinessProbe'.
+ */
+export function probeFieldName(name: string): string {
+  return name.charAt(0).toLowerCase() + name.slice(1) + 'Probe';
+}
+
+/**
  * Renders a probe as a single Markdown bullet line for the agent config.
  * - Enabled:  `- {name} Probe: enabled (path: {path}, initialDelay: …)`
  * - Disabled: `- {name} Probe: disabled`
@@ -35,7 +43,7 @@ export function renderProbeMarkdown(probe: ProbeRenderConfig): string {
  * the probe is enabled and `showConfigs` is true.
  */
 export function renderProbeYaml(probe: ProbeRenderConfig): string[] {
-  const tag = probe.name.charAt(0).toLowerCase() + probe.name.slice(1) + 'Probe';
+  const tag = probeFieldName(probe.name);
   const lines: string[] = [
     `${tag}:`,
     `  enabled: ${probe.enabled}`,

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/probeHelpers.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/probeHelpers.ts
@@ -4,8 +4,10 @@
 import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
 import { escapeYamlValue } from './yamlUtils';
 
+export type ProbeName = 'Liveness' | 'Readiness' | 'Startup';
+
 interface ProbeRenderConfig {
-  name: string;
+  name: ProbeName;
   enabled: boolean;
   path: string;
   showConfigs: boolean;
@@ -20,7 +22,7 @@ interface ProbeRenderConfig {
  * Returns the Kubernetes probe field name for a given probe name.
  * E.g. 'Liveness' → 'livenessProbe', 'Readiness' → 'readinessProbe'.
  */
-export function probeFieldName(name: string): string {
+export function probeFieldName(name: ProbeName): string {
   return name.charAt(0).toLowerCase() + name.slice(1) + 'Probe';
 }
 


### PR DESCRIPTION
## Summary

Pure-function template generators for the fast path pipeline — produces deploy-to-aks workflow YAML and K8s manifests deterministically from config, replacing non-deterministic agent generation:

- **`generateDeployWorkflow()`** — GitHub Actions workflow with two-job split (build + deploy), pinned kubelogin v0.1.6, `actions: read` permission, explicit Dockerfile path, `Azure/k8s-deploy@v5` for image substitution
- **`generateDeploymentManifest()`** — K8s Deployment with configurable replicas, resource requests/limits, optional probes and security context
- **`generateServiceManifest()`** — K8s Service with configurable type (ClusterIP/LoadBalancer), ports

## Changes Made

- New `fastPathTemplates.ts` — `PipelineConfig` and `ContainerConfig` types + three generator functions
- New `fastPathTemplates.test.ts` — comprehensive tests for parameterization, defaults, edge cases (nested Dockerfile paths, custom build context, probe configuration)

## Related Issues

Part of #557 (Fast Path Pipeline)
Closes #552

## Test Plan

- [x] Workflow includes correct permissions, pinned kubelogin, two-job structure
- [x] Workflow parameterizes Dockerfile path, build context, ACR, cluster, namespace
- [x] Deployment manifest respects replicas, resources, probes, security context
- [x] Service manifest supports ClusterIP and LoadBalancer types
- [x] Nested Dockerfile paths produce correct `DOCKER_FILE` and `BUILD_CONTEXT_PATH`
- [x] Type check passes

