### PR TITLE
feat: fast path state machine + orchestration hook

### DIFF
--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -3241,6 +3241,9 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-arm64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
@@ -3366,6 +3369,9 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
@@ -3421,6 +3427,9 @@
         "openharmony"
       ]
     },
+    "node_modules/@rollup/rollup-win32-arm64": {
+      "optional": true
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
@@ -3448,6 +3457,9 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rollup/rollup-win32-x64": {
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWorkloadIdentity.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWorkloadIdentity.ts
@@ -16,6 +16,7 @@ type DeployWorkloadIdentityStatus =
   | 'checking'
   | 'creating-identity'
   | 'assigning-roles'
+  | 'warning-kubelet-acr-pull'
   | 'fetching-issuer'
   | 'creating-credential'
   | 'done'

--- a/plugins/aks-desktop/src/components/GitHubPipeline/components/DockerfileConfirmation.tsx
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/components/DockerfileConfirmation.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Alert, Box, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import React from 'react';
+import type { DockerfileSelection } from '../hooks/useDockerfileDiscovery';
+
+interface DockerfileConfirmationProps {
+  dockerfilePaths: string[];
+  selection: DockerfileSelection | null;
+  onSelect: (path: string) => void;
+  onBuildContextChange: (buildContext: string) => void;
+}
+
+export function DockerfileConfirmation({
+  dockerfilePaths,
+  selection,
+  onSelect,
+  onBuildContextChange,
+}: DockerfileConfirmationProps) {
+  if (dockerfilePaths.length === 0) return null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Alert severity="success" variant="outlined">
+        {dockerfilePaths.length === 1
+          ? `Dockerfile found at ${dockerfilePaths[0]}`
+          : `${dockerfilePaths.length} Dockerfiles found — select one below`}
+      </Alert>
+
+      {dockerfilePaths.length > 1 && (
+        <FormControl fullWidth size="small">
+          <InputLabel>Dockerfile</InputLabel>
+          <Select
+            value={selection?.path ?? ''}
+            label="Dockerfile"
+            onChange={e => onSelect(e.target.value)}
+            displayEmpty
+          >
+            <MenuItem value="" disabled>
+              <em>Select a Dockerfile</em>
+            </MenuItem>
+            {dockerfilePaths.map(path => (
+              <MenuItem key={path} value={path}>
+                {path}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      {selection && (
+        <TextField
+          label="Build context"
+          size="small"
+          value={selection.buildContext}
+          onChange={e => onBuildContextChange(e.target.value)}
+          helperText="Directory used as the Docker build context"
+        />
+      )}
+    </Box>
+  );
+}

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.test.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { describe, expect, it } from 'vitest';
+import { deriveBuildContext } from './useDockerfileDiscovery';
+
+describe('deriveBuildContext', () => {
+  it('should return . for root Dockerfile', () => {
+    expect(deriveBuildContext('Dockerfile')).toBe('.');
+  });
+
+  it('should return parent directory for nested Dockerfile', () => {
+    expect(deriveBuildContext('src/web/Dockerfile')).toBe('./src/web');
+  });
+
+  it('should handle single-level nesting', () => {
+    expect(deriveBuildContext('app/Dockerfile')).toBe('./app');
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.test.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
+// @vitest-environment jsdom
 
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { deriveBuildContext } from './useDockerfileDiscovery';
+import { deriveBuildContext, useDockerfileDiscovery } from './useDockerfileDiscovery';
 
 describe('deriveBuildContext', () => {
   it('should return . for root Dockerfile', () => {
@@ -15,5 +17,99 @@ describe('deriveBuildContext', () => {
 
   it('should handle single-level nesting', () => {
     expect(deriveBuildContext('app/Dockerfile')).toBe('./app');
+  });
+});
+
+describe('useDockerfileDiscovery', () => {
+  it('should auto-select when exactly one Dockerfile is provided', () => {
+    const { result } = renderHook(() => useDockerfileDiscovery(['Dockerfile']));
+    expect(result.current.selection).toEqual({
+      path: 'Dockerfile',
+      buildContext: '.',
+    });
+  });
+
+  it('should not auto-select when multiple Dockerfiles are provided', () => {
+    const { result } = renderHook(() => useDockerfileDiscovery(['Dockerfile', 'src/Dockerfile']));
+    expect(result.current.selection).toBeNull();
+  });
+
+  it('should not auto-select when no Dockerfiles are provided', () => {
+    const { result } = renderHook(() => useDockerfileDiscovery([]));
+    expect(result.current.selection).toBeNull();
+  });
+
+  it('should auto-select when dockerfilePaths changes from empty to single', () => {
+    const { result, rerender } = renderHook((paths: string[]) => useDockerfileDiscovery(paths), {
+      initialProps: [],
+    });
+    expect(result.current.selection).toBeNull();
+
+    rerender(['src/web/Dockerfile']);
+    expect(result.current.selection).toEqual({
+      path: 'src/web/Dockerfile',
+      buildContext: './src/web',
+    });
+  });
+
+  it('should clear stale selection when dockerfilePaths changes', () => {
+    const { result, rerender } = renderHook((paths: string[]) => useDockerfileDiscovery(paths), {
+      initialProps: ['Dockerfile'],
+    });
+    expect(result.current.selection?.path).toBe('Dockerfile');
+
+    rerender(['src/api/Dockerfile']);
+    expect(result.current.selection).toEqual({
+      path: 'src/api/Dockerfile',
+      buildContext: './src/api',
+    });
+  });
+
+  it('should preserve selection when path is still in the list', () => {
+    const { result, rerender } = renderHook((paths: string[]) => useDockerfileDiscovery(paths), {
+      initialProps: ['Dockerfile', 'src/Dockerfile'],
+    });
+    act(() => result.current.select('src/Dockerfile'));
+    expect(result.current.selection?.path).toBe('src/Dockerfile');
+
+    rerender(['Dockerfile', 'src/Dockerfile', 'app/Dockerfile']);
+    expect(result.current.selection?.path).toBe('src/Dockerfile');
+  });
+
+  it('should select a Dockerfile by path', () => {
+    const { result } = renderHook(() =>
+      useDockerfileDiscovery(['Dockerfile', 'src/web/Dockerfile'])
+    );
+
+    act(() => result.current.select('src/web/Dockerfile'));
+    expect(result.current.selection).toEqual({
+      path: 'src/web/Dockerfile',
+      buildContext: './src/web',
+    });
+  });
+
+  it('should ignore select calls with paths not in the list', () => {
+    const { result } = renderHook(() => useDockerfileDiscovery(['Dockerfile']));
+
+    act(() => result.current.select('nonexistent/Dockerfile'));
+    // Auto-selected 'Dockerfile' should remain unchanged
+    expect(result.current.selection?.path).toBe('Dockerfile');
+  });
+
+  it('should override build context', () => {
+    const { result } = renderHook(() => useDockerfileDiscovery(['src/web/Dockerfile']));
+    expect(result.current.selection?.buildContext).toBe('./src/web');
+
+    act(() => result.current.setBuildContext('.'));
+    expect(result.current.selection).toEqual({
+      path: 'src/web/Dockerfile',
+      buildContext: '.',
+    });
+  });
+
+  it('should pass through dockerfilePaths in return value', () => {
+    const paths = ['Dockerfile', 'src/Dockerfile'];
+    const { result } = renderHook(() => useDockerfileDiscovery(paths));
+    expect(result.current.dockerfilePaths).toBe(paths);
   });
 });

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useCallback, useState } from 'react';
+
+export interface DockerfileSelection {
+  /** Full path in the repo, e.g. "src/web/Dockerfile" */
+  path: string;
+  /** Derived build context, e.g. "./src/web" */
+  buildContext: string;
+}
+
+/**
+ * Derives the build context directory from a Dockerfile path.
+ * "Dockerfile" -> ".", "src/web/Dockerfile" -> "./src/web"
+ */
+export function deriveBuildContext(dockerfilePath: string): string {
+  const parts = dockerfilePath.split('/');
+  if (parts.length <= 1) return '.';
+  return './' + parts.slice(0, -1).join('/');
+}
+
+export interface UseDockerfileDiscoveryReturn {
+  /** All Dockerfile paths found in the repo. */
+  dockerfilePaths: string[];
+  /** The user's selected Dockerfile (null if not yet selected). */
+  selection: DockerfileSelection | null;
+  /** Select a Dockerfile by path. */
+  select: (path: string) => void;
+  /** Override the build context for the selected Dockerfile. */
+  setBuildContext: (buildContext: string) => void;
+}
+
+/**
+ * Manages Dockerfile selection state after discovery.
+ * Auto-selects if exactly one Dockerfile is found.
+ */
+export function useDockerfileDiscovery(dockerfilePaths: string[]): UseDockerfileDiscoveryReturn {
+  const [selection, setSelection] = useState<DockerfileSelection | null>(() => {
+    if (dockerfilePaths.length === 1) {
+      return {
+        path: dockerfilePaths[0],
+        buildContext: deriveBuildContext(dockerfilePaths[0]),
+      };
+    }
+    return null;
+  });
+
+  const select = useCallback((path: string) => {
+    setSelection({ path, buildContext: deriveBuildContext(path) });
+  }, []);
+
+  const setBuildContext = useCallback((buildContext: string) => {
+    setSelection(prev => (prev ? { ...prev, buildContext } : null));
+  }, []);
+
+  return { dockerfilePaths, selection, select, setBuildContext };
+}

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useDockerfileDiscovery.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface DockerfileSelection {
   /** Full path in the repo, e.g. "src/web/Dockerfile" */
@@ -36,19 +36,30 @@ export interface UseDockerfileDiscoveryReturn {
  * Auto-selects if exactly one Dockerfile is found.
  */
 export function useDockerfileDiscovery(dockerfilePaths: string[]): UseDockerfileDiscoveryReturn {
-  const [selection, setSelection] = useState<DockerfileSelection | null>(() => {
-    if (dockerfilePaths.length === 1) {
-      return {
-        path: dockerfilePaths[0],
-        buildContext: deriveBuildContext(dockerfilePaths[0]),
-      };
-    }
-    return null;
-  });
+  const [selection, setSelection] = useState<DockerfileSelection | null>(null);
 
-  const select = useCallback((path: string) => {
-    setSelection({ path, buildContext: deriveBuildContext(path) });
-  }, []);
+  // Sync selection when dockerfilePaths changes (e.g. after async API fetch).
+  // Auto-selects when exactly one Dockerfile is found; clears stale selections.
+  useEffect(() => {
+    setSelection(prev => {
+      if (prev && dockerfilePaths.includes(prev.path)) return prev;
+      if (dockerfilePaths.length === 1) {
+        return {
+          path: dockerfilePaths[0],
+          buildContext: deriveBuildContext(dockerfilePaths[0]),
+        };
+      }
+      return null;
+    });
+  }, [dockerfilePaths]);
+
+  const select = useCallback(
+    (path: string) => {
+      if (!dockerfilePaths.includes(path)) return;
+      setSelection({ path, buildContext: deriveBuildContext(path) });
+    },
+    [dockerfilePaths]
+  );
 
   const setBuildContext = useCallback((buildContext: string) => {
     setSelection(prev => (prev ? { ...prev, buildContext } : null));

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.test.ts
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createContainerConfig } from '../__fixtures__/pipelineConfig';
+
+// --- Mock sub-hooks and utilities ---
+
+const mockOctokit = { request: vi.fn() } as never;
+
+vi.mock('../GitHubAuthContext', () => ({
+  useGitHubAuthContext: () => ({
+    octokit: mockOctokit,
+    authState: { isAuthenticated: true, isRestoring: false },
+  }),
+}));
+
+const mockCreatePipelineSecrets = vi.fn().mockResolvedValue(undefined);
+vi.mock('../utils/pipelineOrchestration', () => ({
+  createPipelineSecrets: (...args: unknown[]) => mockCreatePipelineSecrets(...args),
+}));
+
+const mockCreateFastPathPR = vi.fn().mockResolvedValue({
+  url: 'https://github.com/test/repo/pull/1',
+  number: 1,
+  merged: false,
+});
+vi.mock('../utils/fastPathOrchestration', () => ({
+  createFastPathPR: (...args: unknown[]) => mockCreateFastPathPR(...args),
+}));
+
+const mockDispatchWorkflow = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../../utils/github/github-api', () => ({
+  dispatchWorkflow: (...args: unknown[]) => mockDispatchWorkflow(...args),
+}));
+
+// PR polling mock — returns isMerged state controlled by test
+let prPollingMerged = false;
+vi.mock('./usePRPolling', () => ({
+  usePRPolling: () => ({
+    isMerged: prPollingMerged,
+    error: null,
+  }),
+}));
+
+// Workflow polling mock
+let workflowConclusion: string | null = null;
+vi.mock('./useWorkflowPolling', () => ({
+  useWorkflowPolling: () => ({
+    runConclusion: workflowConclusion,
+    runUrl: null,
+    error: null,
+  }),
+}));
+
+// Deployment health mock
+vi.mock('./useDeploymentHealth', () => ({
+  useDeploymentHealth: () => ({
+    serviceEndpoint: null,
+    isHealthy: false,
+  }),
+}));
+
+import { useFastPathOrchestration } from './useFastPathOrchestration';
+
+const selectedRepo = { owner: 'test', repo: 'repo', defaultBranch: 'main' };
+const containerConfig = createContainerConfig();
+
+const defaultProps = {
+  clusterName: 'my-cluster',
+  namespace: 'demo',
+  appName: 'my-app',
+  subscriptionId: 'sub-1',
+  resourceGroup: 'rg-1',
+  tenantId: 'tenant-1',
+  selectedRepo,
+  containerConfig,
+  identityId: 'id-1',
+};
+
+const dockerfileSelection = { path: 'Dockerfile', buildContext: '.' };
+
+describe('useFastPathOrchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prPollingMerged = false;
+    workflowConclusion = null;
+    localStorage.clear();
+  });
+
+  it('should start in Configured state', () => {
+    const { result } = renderHook(() => useFastPathOrchestration(defaultProps));
+    expect(result.current.pipeline.state.deploymentState).toBe('Configured');
+  });
+
+  describe('handleDeploy', () => {
+    it('should transition through generating → PR creating → PR awaiting merge', async () => {
+      const { result } = renderHook(() => useFastPathOrchestration(defaultProps));
+
+      await act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+
+      expect(mockCreatePipelineSecrets).toHaveBeenCalled();
+      expect(mockCreateFastPathPR).toHaveBeenCalled();
+      expect(result.current.pipeline.state.deploymentState).toBe('FastPathPRAwaitingMerge');
+      expect(result.current.pipeline.state.fastPathPr.number).toBe(1);
+    });
+
+    it('should transition to Failed on secret creation error', async () => {
+      mockCreatePipelineSecrets.mockRejectedValueOnce(new Error('secret error'));
+
+      const { result } = renderHook(() => useFastPathOrchestration(defaultProps));
+
+      await act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+
+      expect(result.current.pipeline.state.deploymentState).toBe('Failed');
+      expect(result.current.pipeline.state.error).toBe('secret error');
+    });
+
+    it('should transition to Failed on PR creation error', async () => {
+      mockCreateFastPathPR.mockRejectedValueOnce(new Error('PR failed'));
+
+      const { result } = renderHook(() => useFastPathOrchestration(defaultProps));
+
+      await act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+
+      expect(result.current.pipeline.state.deploymentState).toBe('Failed');
+      expect(result.current.pipeline.state.error).toBe('PR failed');
+    });
+
+    it('should not deploy twice when already in flight', async () => {
+      const { result } = renderHook(() => useFastPathOrchestration(defaultProps));
+
+      // Start first deploy
+      const promise1 = act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+
+      // Try second deploy while first is in flight — should be no-op
+      const promise2 = act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+
+      await Promise.all([promise1, promise2]);
+
+      expect(mockCreateFastPathPR).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('state-driven transitions', () => {
+    it('should transition to PipelineRunning when PR is merged', async () => {
+      const { result, rerender } = renderHook(() => useFastPathOrchestration(defaultProps));
+
+      // Get to FastPathPRAwaitingMerge
+      await act(async () => {
+        await result.current.handleDeploy(dockerfileSelection);
+      });
+      expect(result.current.pipeline.state.deploymentState).toBe('FastPathPRAwaitingMerge');
+
+      // Simulate PR merge detected by polling
+      prPollingMerged = true;
+      rerender();
+
+      // The effect should fire and transition to PipelineRunning
+      expect(result.current.pipeline.state.deploymentState).toBe('PipelineRunning');
+    });
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.ts
@@ -26,6 +26,11 @@ function currentState(ref: React.RefObject<FastPathDeploymentState>): FastPathDe
   return ref.current;
 }
 
+/** Extracts a human-readable message from an unknown caught value. */
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
 export interface UseFastPathOrchestrationProps {
   clusterName: string;
   namespace: string;
@@ -130,6 +135,8 @@ export const useFastPathOrchestration = ({
       pipeline.setConfig(config);
       pipeline.setDockerfileDetected([selection.path]);
       pipeline.setGenerating();
+      // Sync ref eagerly — useLayoutEffect won't run until after this callback yields
+      deploymentStateRef.current = 'FastPathGenerating';
 
       try {
         // Create secrets first (needed for the workflow to authenticate)
@@ -144,13 +151,14 @@ export const useFastPathOrchestration = ({
         };
 
         pipeline.setPRCreating();
+        deploymentStateRef.current = 'FastPathPRCreating';
         const pr = await createFastPathPR(gitHubAuth.octokit, fastPathConfig);
         if (currentState(deploymentStateRef) !== 'FastPathPRCreating') return;
 
         pipeline.setPRCreated(pr);
       } catch (err) {
         if (currentState(deploymentStateRef) === 'Failed') return;
-        pipeline.setFailed(err instanceof Error ? err.message : 'Failed to create fast-path PR');
+        pipeline.setFailed(errorMessage(err, 'Failed to create fast-path PR'));
       } finally {
         deployInFlightRef.current = false;
       }
@@ -220,7 +228,7 @@ export const useFastPathOrchestration = ({
         );
       } catch (err) {
         if (currentState(deploymentStateRef) !== 'PipelineRunning') return;
-        pipeline.setFailed(err instanceof Error ? err.message : 'Failed to dispatch workflow');
+        pipeline.setFailed(errorMessage(err, 'Failed to dispatch workflow'));
       } finally {
         dispatchInFlightRef.current = false;
       }
@@ -238,7 +246,7 @@ export const useFastPathOrchestration = ({
         selectedRepo.defaultBranch
       );
     } catch (err) {
-      pipeline.setFailed(err instanceof Error ? err.message : 'Failed to redeploy');
+      pipeline.setFailed(errorMessage(err, 'Failed to redeploy'));
     }
   }, [gitHubAuth.octokit, selectedRepo, pipeline.setFailed]);
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathOrchestration.ts
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type { GitHubRepo } from '../../../types/github';
+import { dispatchWorkflow } from '../../../utils/github/github-api';
+import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
+import { PIPELINE_WORKFLOW_FILENAME } from '../constants';
+import { useGitHubAuthContext } from '../GitHubAuthContext';
+import type { PipelineConfig } from '../types';
+import { createFastPathPR, type FastPathPRConfig } from '../utils/fastPathOrchestration';
+import { createPipelineSecrets } from '../utils/pipelineOrchestration';
+import type { UseDeploymentHealthResult } from './useDeploymentHealth';
+import { useDeploymentHealth } from './useDeploymentHealth';
+import type { DockerfileSelection } from './useDockerfileDiscovery';
+import type { FastPathDeploymentState } from './useFastPathPipelineState';
+import type { UseFastPathPipelineStateResult } from './useFastPathPipelineState';
+import { useFastPathPipelineState } from './useFastPathPipelineState';
+import type { UsePRPollingResult } from './usePRPolling';
+import { usePRPolling } from './usePRPolling';
+import type { UseWorkflowPollingResult } from './useWorkflowPolling';
+import { useWorkflowPolling } from './useWorkflowPolling';
+
+/** Reads the current deployment state from a ref without triggering TS narrowing. */
+function currentState(ref: React.RefObject<FastPathDeploymentState>): FastPathDeploymentState {
+  return ref.current;
+}
+
+export interface UseFastPathOrchestrationProps {
+  clusterName: string;
+  namespace: string;
+  appName: string;
+  subscriptionId: string;
+  resourceGroup: string;
+  tenantId: string;
+  selectedRepo: GitHubRepo | null;
+  containerConfig: ContainerConfig;
+  identityId: string;
+}
+
+export interface UseFastPathOrchestrationResult {
+  pipeline: UseFastPathPipelineStateResult;
+  /** Kicks off fast-path generation + PR creation + workflow dispatch. */
+  handleDeploy: (selection: DockerfileSelection) => Promise<void>;
+  /** Re-dispatches the deploy workflow (for redeploy from Deployed state). */
+  handleRedeploy: () => Promise<void>;
+  fastPathPrPolling: UsePRPollingResult;
+  workflowPolling: UseWorkflowPollingResult;
+  deploymentHealth: UseDeploymentHealthResult;
+}
+
+/**
+ * Orchestrates the fast-path pipeline: deterministic generation → single PR →
+ * auto-dispatch → monitor deployment. Parallel to useGitHubPipelineOrchestration
+ * but with fewer states and no Copilot agent interaction.
+ */
+export const useFastPathOrchestration = ({
+  clusterName,
+  namespace,
+  appName,
+  subscriptionId,
+  resourceGroup,
+  tenantId,
+  selectedRepo,
+  containerConfig,
+  identityId,
+}: UseFastPathOrchestrationProps): UseFastPathOrchestrationResult => {
+  const deployInFlightRef = useRef(false);
+  const dispatchInFlightRef = useRef(false);
+  const deploymentStateRef = useRef<FastPathDeploymentState>('Configured');
+
+  const gitHubAuth = useGitHubAuthContext();
+  const repoKey = selectedRepo ? `${selectedRepo.owner}/${selectedRepo.repo}` : null;
+  const pipeline = useFastPathPipelineState(repoKey);
+
+  useLayoutEffect(() => {
+    deploymentStateRef.current = pipeline.state.deploymentState;
+  }, [pipeline.state.deploymentState]);
+
+  // PR polling — active when waiting for the fast-path PR to be merged
+  const fastPathPrPolling = usePRPolling(
+    gitHubAuth.octokit,
+    selectedRepo?.owner ?? '',
+    selectedRepo?.repo ?? '',
+    pipeline.state.fastPathPr.number,
+    pipeline.state.deploymentState === 'FastPathPRAwaitingMerge'
+  );
+
+  // Workflow polling — active after PR merge triggers the deploy workflow
+  const workflowPolling = useWorkflowPolling(
+    gitHubAuth.octokit,
+    selectedRepo?.owner ?? '',
+    selectedRepo?.repo ?? '',
+    selectedRepo?.defaultBranch ?? null,
+    pipeline.state.deploymentState === 'PipelineRunning'
+  );
+
+  // Deployment health — monitors pods/services after workflow dispatched
+  const deploymentHealth = useDeploymentHealth(
+    appName,
+    namespace,
+    clusterName,
+    pipeline.state.deploymentState === 'PipelineRunning' ||
+      pipeline.state.deploymentState === 'Deployed'
+  );
+
+  /**
+   * Main deploy action: generates templates, creates PR, sets up secrets,
+   * and transitions through the fast-path states.
+   */
+  const handleDeploy = useCallback(
+    async (selection: DockerfileSelection) => {
+      if (!gitHubAuth.octokit || !selectedRepo) return;
+      if (deployInFlightRef.current) return;
+      deployInFlightRef.current = true;
+
+      const config: PipelineConfig = {
+        tenantId,
+        identityId,
+        subscriptionId,
+        clusterName,
+        resourceGroup,
+        namespace,
+        appName,
+        serviceType: containerConfig.serviceType,
+        containerConfig,
+        repo: selectedRepo,
+      };
+
+      pipeline.setConfig(config);
+      pipeline.setDockerfileDetected([selection.path]);
+      pipeline.setGenerating();
+
+      try {
+        // Create secrets first (needed for the workflow to authenticate)
+        await createPipelineSecrets(gitHubAuth.octokit, config);
+        if (currentState(deploymentStateRef) !== 'FastPathGenerating') return;
+
+        const fastPathConfig: FastPathPRConfig = {
+          pipelineConfig: config,
+          dockerfilePath: selection.path,
+          buildContextPath: selection.buildContext,
+          containerConfig,
+        };
+
+        pipeline.setPRCreating();
+        const pr = await createFastPathPR(gitHubAuth.octokit, fastPathConfig);
+        if (currentState(deploymentStateRef) !== 'FastPathPRCreating') return;
+
+        pipeline.setPRCreated(pr);
+      } catch (err) {
+        if (currentState(deploymentStateRef) === 'Failed') return;
+        pipeline.setFailed(err instanceof Error ? err.message : 'Failed to create fast-path PR');
+      } finally {
+        deployInFlightRef.current = false;
+      }
+    },
+    [
+      gitHubAuth.octokit,
+      selectedRepo,
+      tenantId,
+      identityId,
+      subscriptionId,
+      clusterName,
+      resourceGroup,
+      namespace,
+      appName,
+      containerConfig,
+      pipeline.setConfig,
+      pipeline.setDockerfileDetected,
+      pipeline.setGenerating,
+      pipeline.setPRCreating,
+      pipeline.setPRCreated,
+      pipeline.setFailed,
+    ]
+  );
+
+  // State-driven orchestration: reacts to polling results
+  useEffect(() => {
+    switch (pipeline.state.deploymentState) {
+      case 'FastPathPRAwaitingMerge':
+        if (fastPathPrPolling.isMerged) {
+          pipeline.setPRMerged();
+        }
+        break;
+
+      case 'PipelineRunning':
+        if (workflowPolling.runConclusion === 'success') {
+          pipeline.setDeployed(deploymentHealth.serviceEndpoint ?? undefined);
+        } else if (workflowPolling.runConclusion === 'failure') {
+          pipeline.setFailed('GitHub Actions workflow failed');
+        }
+        break;
+    }
+  }, [
+    pipeline.state.deploymentState,
+    fastPathPrPolling.isMerged,
+    workflowPolling.runConclusion,
+    deploymentHealth.serviceEndpoint,
+    pipeline.setPRMerged,
+    pipeline.setDeployed,
+    pipeline.setFailed,
+  ]);
+
+  // Auto-dispatch workflow after PR merge
+  useEffect(() => {
+    if (pipeline.state.deploymentState !== 'PipelineRunning') return;
+    if (dispatchInFlightRef.current) return;
+    if (!gitHubAuth.octokit || !selectedRepo) return;
+
+    dispatchInFlightRef.current = true;
+    (async () => {
+      try {
+        await dispatchWorkflow(
+          gitHubAuth.octokit!,
+          selectedRepo.owner,
+          selectedRepo.repo,
+          PIPELINE_WORKFLOW_FILENAME,
+          selectedRepo.defaultBranch
+        );
+      } catch (err) {
+        if (currentState(deploymentStateRef) !== 'PipelineRunning') return;
+        pipeline.setFailed(err instanceof Error ? err.message : 'Failed to dispatch workflow');
+      } finally {
+        dispatchInFlightRef.current = false;
+      }
+    })();
+  }, [pipeline.state.deploymentState, gitHubAuth.octokit, selectedRepo, pipeline.setFailed]);
+
+  const handleRedeploy = useCallback(async () => {
+    if (!gitHubAuth.octokit || !selectedRepo) return;
+    try {
+      await dispatchWorkflow(
+        gitHubAuth.octokit,
+        selectedRepo.owner,
+        selectedRepo.repo,
+        PIPELINE_WORKFLOW_FILENAME,
+        selectedRepo.defaultBranch
+      );
+    } catch (err) {
+      pipeline.setFailed(err instanceof Error ? err.message : 'Failed to redeploy');
+    }
+  }, [gitHubAuth.octokit, selectedRepo, pipeline.setFailed]);
+
+  return {
+    pipeline,
+    handleDeploy,
+    handleRedeploy,
+    fastPathPrPolling,
+    workflowPolling,
+    deploymentHealth,
+  };
+};

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.test.ts
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PipelineConfig } from '../types';
+import {
+  FAST_PATH_DEPLOYMENT_STATES,
+  type FastPathState,
+  useFastPathPipelineState,
+} from './useFastPathPipelineState';
+
+const validConfig: PipelineConfig = {
+  tenantId: 'tenant-123',
+  identityId: 'identity-456',
+  subscriptionId: 'sub-789',
+  clusterName: 'my-cluster',
+  resourceGroup: 'my-rg',
+  namespace: 'production',
+  appName: 'my-app',
+  serviceType: 'LoadBalancer',
+  repo: { owner: 'testuser', repo: 'my-repo', defaultBranch: 'main' },
+};
+
+const repoKey = 'testuser/my-repo';
+
+/**
+ * Helper: transitions the hook through valid states up to the target.
+ */
+function transitionTo(
+  result: { current: ReturnType<typeof useFastPathPipelineState> },
+  target: FastPathState['deploymentState']
+) {
+  if (target === 'Configured') return;
+
+  act(() => result.current.setDockerfileDetected(['Dockerfile']));
+  if (target === 'DockerfileDetected') return;
+
+  act(() => result.current.setGenerating());
+  if (target === 'FastPathGenerating') return;
+
+  act(() => result.current.setPRCreating());
+  if (target === 'FastPathPRCreating') return;
+
+  act(() =>
+    result.current.setPRCreated({
+      url: 'https://github.com/test/repo/pull/1',
+      number: 1,
+      merged: false,
+    })
+  );
+  if (target === 'FastPathPRAwaitingMerge') return;
+
+  act(() => result.current.setPRMerged());
+  if (target === 'PipelineRunning') return;
+
+  if (target === 'Deployed') {
+    act(() => result.current.setDeployed());
+    return;
+  }
+
+  if (target === 'AsyncAgentTriggered') {
+    act(() => result.current.setDeployed());
+    act(() => result.current.setAsyncAgentTriggered('https://github.com/test/repo/issues/10'));
+    return;
+  }
+
+  if (target === 'Failed') {
+    act(() => result.current.setFailed('something broke'));
+    return;
+  }
+}
+
+describe('useFastPathPipelineState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initialization', () => {
+    it('should start in Configured state', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      expect(result.current.state.deploymentState).toBe('Configured');
+      expect(result.current.state.config).toBeNull();
+      expect(result.current.state.fastPathPr).toEqual({
+        url: null,
+        number: null,
+        merged: false,
+      });
+    });
+
+    it('should export all deployment states', () => {
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('Configured');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('DockerfileDetected');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('FastPathGenerating');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('FastPathPRCreating');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('FastPathPRAwaitingMerge');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('PipelineRunning');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('Deployed');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('AsyncAgentTriggered');
+      expect(FAST_PATH_DEPLOYMENT_STATES).toContain('Failed');
+    });
+  });
+
+  describe('valid transitions', () => {
+    it('should transition through the happy path', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      transitionTo(result, 'DockerfileDetected');
+      expect(result.current.state.deploymentState).toBe('DockerfileDetected');
+      expect(result.current.state.dockerfilePaths).toEqual(['Dockerfile']);
+
+      transitionTo(result, 'FastPathGenerating');
+      expect(result.current.state.deploymentState).toBe('FastPathGenerating');
+
+      transitionTo(result, 'FastPathPRCreating');
+      expect(result.current.state.deploymentState).toBe('FastPathPRCreating');
+
+      transitionTo(result, 'FastPathPRAwaitingMerge');
+      expect(result.current.state.deploymentState).toBe('FastPathPRAwaitingMerge');
+      expect(result.current.state.fastPathPr.url).toBe('https://github.com/test/repo/pull/1');
+
+      transitionTo(result, 'PipelineRunning');
+      expect(result.current.state.deploymentState).toBe('PipelineRunning');
+      expect(result.current.state.fastPathPr.merged).toBe(true);
+
+      transitionTo(result, 'Deployed');
+      expect(result.current.state.deploymentState).toBe('Deployed');
+    });
+
+    it('should transition from Deployed to AsyncAgentTriggered', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'Deployed');
+
+      act(() => result.current.setAsyncAgentTriggered('https://github.com/test/repo/issues/10'));
+      expect(result.current.state.deploymentState).toBe('AsyncAgentTriggered');
+      expect(result.current.state.asyncAgentIssueUrl).toBe(
+        'https://github.com/test/repo/issues/10'
+      );
+    });
+
+    it('should allow SET_FAILED from any state', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'FastPathGenerating');
+
+      act(() => result.current.setFailed('generation failed'));
+      expect(result.current.state.deploymentState).toBe('Failed');
+      expect(result.current.state.error).toBe('generation failed');
+    });
+
+    it('should set serviceEndpoint on deploy', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'PipelineRunning');
+
+      act(() => result.current.setDeployed('http://10.0.0.1'));
+      expect(result.current.state.serviceEndpoint).toBe('http://10.0.0.1');
+    });
+  });
+
+  describe('invalid transitions', () => {
+    it('should reject SET_GENERATING from Configured', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      act(() => result.current.setGenerating());
+      expect(result.current.state.deploymentState).toBe('Configured');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid fast-path transition'));
+      warnSpy.mockRestore();
+    });
+
+    it('should reject SET_PR_MERGED from Configured', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      act(() => result.current.setPRMerged());
+      expect(result.current.state.deploymentState).toBe('Configured');
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('RETRY', () => {
+    it('should return to lastSuccessfulState on retry', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'FastPathPRAwaitingMerge');
+
+      act(() => result.current.setFailed('merge failed'));
+      expect(result.current.state.deploymentState).toBe('Failed');
+
+      act(() => result.current.retry());
+      expect(result.current.state.deploymentState).toBe('FastPathPRAwaitingMerge');
+      expect(result.current.state.error).toBeNull();
+    });
+
+    it('should return to Configured when no lastSuccessfulState', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      act(() => result.current.setFailed('early failure'));
+      act(() => result.current.retry());
+      expect(result.current.state.deploymentState).toBe('Configured');
+    });
+
+    it('should not record transient states as lastSuccessfulState', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'DockerfileDetected');
+      // FastPathGenerating is transient
+      act(() => result.current.setGenerating());
+      act(() => result.current.setFailed('gen failed'));
+      act(() => result.current.retry());
+      // Should go back to DockerfileDetected, not FastPathGenerating
+      expect(result.current.state.deploymentState).toBe('DockerfileDetected');
+    });
+  });
+
+  describe('config management', () => {
+    it('should set config', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      act(() => result.current.setConfig(validConfig));
+      expect(result.current.state.config).toEqual(validConfig);
+      expect(result.current.state.deploymentState).toBe('Configured');
+    });
+
+    it('should update config partially', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      act(() => result.current.setConfig(validConfig));
+      act(() => result.current.updateConfig({ appName: 'new-app' }));
+      expect(result.current.state.config?.appName).toBe('new-app');
+      expect(result.current.state.config?.clusterName).toBe('my-cluster');
+    });
+  });
+
+  describe('persistence', () => {
+    it('should persist state after debounce', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'DockerfileDetected');
+
+      act(() => vi.advanceTimersByTime(1000));
+      const stored = localStorage.getItem('aks-desktop:fast-path-state:testuser/my-repo');
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.deploymentState).toBe('DockerfileDetected');
+      expect(parsed.__schemaVersion).toBe(1);
+    });
+
+    it('should load persisted state on mount', () => {
+      // Persist some state
+      const { result: first } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(first, 'FastPathPRAwaitingMerge');
+      act(() => vi.advanceTimersByTime(1000));
+
+      // Mount a new hook — should load persisted state
+      const { result: second } = renderHook(() => useFastPathPipelineState(repoKey));
+      expect(second.current.state.deploymentState).toBe('FastPathPRAwaitingMerge');
+    });
+
+    it('should clear terminal states from storage', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      transitionTo(result, 'Deployed');
+      act(() => vi.advanceTimersByTime(1000));
+
+      const stored = localStorage.getItem('aks-desktop:fast-path-state:testuser/my-repo');
+      expect(stored).toBeNull();
+    });
+
+    it('should ignore malformed persisted data', () => {
+      localStorage.setItem('aks-desktop:fast-path-state:testuser/my-repo', 'not-json');
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      expect(result.current.state.deploymentState).toBe('Configured');
+    });
+
+    it('should ignore persisted data with wrong schema version', () => {
+      localStorage.setItem(
+        'aks-desktop:fast-path-state:testuser/my-repo',
+        JSON.stringify({ __schemaVersion: 999, deploymentState: 'DockerfileDetected' })
+      );
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+      expect(result.current.state.deploymentState).toBe('Configured');
+    });
+  });
+
+  describe('LOAD_STATE', () => {
+    it('should replace state entirely on LOAD_STATE', () => {
+      const { result } = renderHook(() => useFastPathPipelineState(repoKey));
+
+      const loaded: FastPathState = {
+        deploymentState: 'FastPathPRAwaitingMerge',
+        config: validConfig,
+        dockerfilePaths: ['Dockerfile'],
+        fastPathPr: {
+          url: 'https://github.com/test/repo/pull/1',
+          number: 1,
+          merged: false,
+        },
+        asyncAgentIssueUrl: null,
+        serviceEndpoint: null,
+        lastSuccessfulState: 'FastPathPRAwaitingMerge',
+        error: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      act(() => result.current.loadState(loaded));
+      expect(result.current.state).toEqual(loaded);
+    });
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.ts
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
+import type { PipelineConfig, PRTracking } from '../types';
+
+/** Storage key prefix — separate from the agent-path pipeline state. */
+const FAST_PATH_STORAGE_PREFIX = 'aks-desktop:fast-path-state:';
+
+/** Schema version for fast-path state. Bump when the shape changes. */
+const FAST_PATH_SCHEMA_VERSION = 1;
+
+export const FAST_PATH_DEPLOYMENT_STATES = [
+  'Configured',
+  'DockerfileDetected',
+  'FastPathGenerating',
+  'FastPathPRCreating',
+  'FastPathPRAwaitingMerge',
+  'PipelineRunning',
+  'Deployed',
+  'AsyncAgentTriggered',
+  'Failed',
+] as const;
+
+export type FastPathDeploymentState = (typeof FAST_PATH_DEPLOYMENT_STATES)[number];
+
+export interface FastPathState {
+  deploymentState: FastPathDeploymentState;
+  config: PipelineConfig | null;
+  dockerfilePaths: string[];
+  fastPathPr: PRTracking;
+  asyncAgentIssueUrl: string | null;
+  serviceEndpoint: string | null;
+  lastSuccessfulState: FastPathDeploymentState | null;
+  error: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+type FastPathAction =
+  | { type: 'SET_CONFIG'; config: PipelineConfig }
+  | { type: 'UPDATE_CONFIG'; partial: Partial<PipelineConfig> }
+  | { type: 'SET_DOCKERFILE_DETECTED'; paths: string[] }
+  | { type: 'SET_GENERATING' }
+  | { type: 'SET_PR_CREATING' }
+  | { type: 'SET_PR_CREATED'; pr: PRTracking }
+  | { type: 'SET_PR_MERGED' }
+  | { type: 'SET_PIPELINE_RUNNING' }
+  | { type: 'SET_DEPLOYED'; serviceEndpoint?: string }
+  | { type: 'SET_ASYNC_AGENT_TRIGGERED'; issueUrl: string }
+  | { type: 'SET_FAILED'; error: string }
+  | { type: 'RETRY' }
+  | { type: 'LOAD_STATE'; state: FastPathState };
+
+/**
+ * Transient (in-flight) states that should not be recorded as lastSuccessfulState
+ * because RETRY would land on a dead-end (the orchestration effect only transitions
+ * *into* them, not *from* them).
+ */
+const TRANSIENT_STATES: ReadonlySet<FastPathDeploymentState> = new Set([
+  'FastPathGenerating',
+  'FastPathPRCreating',
+]);
+
+const NON_RESUMABLE_STATES: ReadonlySet<FastPathDeploymentState> = new Set([
+  ...TRANSIENT_STATES,
+  'Failed',
+]);
+
+const VALID_DEPLOYMENT_STATES: ReadonlySet<string> = new Set<string>(FAST_PATH_DEPLOYMENT_STATES);
+
+/** Terminal states that don't need persistence — nothing to resume. */
+const TERMINAL_STATES: ReadonlySet<FastPathDeploymentState> = new Set([
+  'Deployed',
+  'AsyncAgentTriggered',
+]);
+
+const INITIAL_STATE: FastPathState = {
+  deploymentState: 'Configured',
+  config: null,
+  dockerfilePaths: [],
+  fastPathPr: { url: null, number: null, merged: false },
+  asyncAgentIssueUrl: null,
+  serviceEndpoint: null,
+  lastSuccessfulState: null,
+  error: null,
+  createdAt: null,
+  updatedAt: null,
+};
+
+const VALID_TRANSITIONS: Record<
+  FastPathAction['type'],
+  ReadonlySet<FastPathDeploymentState> | null
+> = {
+  SET_CONFIG: new Set(['Configured']),
+  UPDATE_CONFIG: null,
+  SET_DOCKERFILE_DETECTED: new Set(['Configured']),
+  SET_GENERATING: new Set(['DockerfileDetected']),
+  SET_PR_CREATING: new Set(['FastPathGenerating']),
+  SET_PR_CREATED: new Set(['FastPathPRCreating']),
+  SET_PR_MERGED: new Set(['FastPathPRAwaitingMerge']),
+  SET_PIPELINE_RUNNING: new Set(['FastPathPRAwaitingMerge']),
+  SET_DEPLOYED: new Set(['PipelineRunning']),
+  SET_ASYNC_AGENT_TRIGGERED: new Set(['Deployed']),
+  SET_FAILED: null,
+  RETRY: new Set(['Failed']),
+  LOAD_STATE: null,
+};
+
+const SIMPLE_TRANSITIONS: Partial<Record<FastPathAction['type'], FastPathDeploymentState>> = {
+  SET_GENERATING: 'FastPathGenerating',
+  SET_PR_CREATING: 'FastPathPRCreating',
+};
+
+const now = () => new Date().toISOString();
+
+const loadPersistedState = (repoKey: string): FastPathState | null => {
+  try {
+    const stored = localStorage.getItem(FAST_PATH_STORAGE_PREFIX + repoKey);
+    if (!stored) return null;
+    const parsed: unknown = JSON.parse(stored);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (
+      !('__schemaVersion' in parsed) ||
+      (parsed as Record<string, unknown>).__schemaVersion !== FAST_PATH_SCHEMA_VERSION
+    ) {
+      return null;
+    }
+    if (
+      !('deploymentState' in parsed) ||
+      typeof (parsed as Record<string, unknown>).deploymentState !== 'string'
+    ) {
+      return null;
+    }
+    const deploymentState = (parsed as Record<string, unknown>).deploymentState as string;
+    if (!VALID_DEPLOYMENT_STATES.has(deploymentState)) return null;
+    if (TERMINAL_STATES.has(deploymentState as FastPathDeploymentState)) {
+      localStorage.removeItem(FAST_PATH_STORAGE_PREFIX + repoKey);
+      return null;
+    }
+    const data = parsed as Record<string, unknown>;
+    return {
+      ...INITIAL_STATE,
+      ...data,
+      deploymentState: deploymentState as FastPathDeploymentState,
+      fastPathPr: {
+        ...INITIAL_STATE.fastPathPr,
+        ...(typeof data.fastPathPr === 'object' && data.fastPathPr !== null
+          ? (data.fastPathPr as Record<string, unknown>)
+          : {}),
+      },
+    } as FastPathState;
+  } catch {
+    return null;
+  }
+};
+
+const persistState = (repoKey: string, state: FastPathState): void => {
+  try {
+    if (TERMINAL_STATES.has(state.deploymentState)) {
+      localStorage.removeItem(FAST_PATH_STORAGE_PREFIX + repoKey);
+      return;
+    }
+    localStorage.setItem(
+      FAST_PATH_STORAGE_PREFIX + repoKey,
+      JSON.stringify({ __schemaVersion: FAST_PATH_SCHEMA_VERSION, ...state })
+    );
+  } catch (err) {
+    console.warn('Failed to persist fast-path state:', err);
+  }
+};
+
+function fastPathReducer(state: FastPathState, action: FastPathAction): FastPathState {
+  const validSources = VALID_TRANSITIONS[action.type];
+  if (validSources && !validSources.has(state.deploymentState)) {
+    console.warn(`Invalid fast-path transition: ${action.type} from ${state.deploymentState}`);
+    return state;
+  }
+
+  let next: FastPathState;
+
+  const simpleTarget = SIMPLE_TRANSITIONS[action.type];
+  if (simpleTarget) {
+    next = { ...state, deploymentState: simpleTarget, updatedAt: now() };
+  } else {
+    switch (action.type) {
+      case 'SET_CONFIG':
+        next = {
+          ...state,
+          deploymentState: 'Configured',
+          config: action.config,
+          createdAt: state.createdAt ?? now(),
+          updatedAt: now(),
+        };
+        break;
+
+      case 'UPDATE_CONFIG':
+        next = {
+          ...state,
+          config: state.config ? { ...state.config, ...action.partial } : null,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_DOCKERFILE_DETECTED':
+        next = {
+          ...state,
+          deploymentState: 'DockerfileDetected',
+          dockerfilePaths: action.paths,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_PR_CREATED':
+        next = {
+          ...state,
+          deploymentState: 'FastPathPRAwaitingMerge',
+          fastPathPr: action.pr,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_PR_MERGED':
+        next = {
+          ...state,
+          deploymentState: 'PipelineRunning',
+          fastPathPr: { ...state.fastPathPr, merged: true },
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_PIPELINE_RUNNING':
+        next = {
+          ...state,
+          deploymentState: 'PipelineRunning',
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_DEPLOYED':
+        next = {
+          ...state,
+          deploymentState: 'Deployed',
+          serviceEndpoint: action.serviceEndpoint ?? state.serviceEndpoint,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_ASYNC_AGENT_TRIGGERED':
+        next = {
+          ...state,
+          deploymentState: 'AsyncAgentTriggered',
+          asyncAgentIssueUrl: action.issueUrl,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'SET_FAILED':
+        next = {
+          ...state,
+          deploymentState: 'Failed',
+          error: action.error,
+          updatedAt: now(),
+        };
+        break;
+
+      case 'RETRY': {
+        const retryTarget = state.lastSuccessfulState ?? 'Configured';
+        return {
+          ...state,
+          deploymentState: retryTarget,
+          error: null,
+          updatedAt: now(),
+        };
+      }
+
+      case 'LOAD_STATE':
+        return action.state;
+
+      default:
+        return state;
+    }
+  }
+
+  if (!NON_RESUMABLE_STATES.has(next.deploymentState)) {
+    next.lastSuccessfulState = next.deploymentState;
+  }
+  return next;
+}
+
+export interface UseFastPathPipelineStateResult {
+  state: FastPathState;
+  setConfig: (config: PipelineConfig) => void;
+  updateConfig: (config: Partial<PipelineConfig>) => void;
+  setDockerfileDetected: (paths: string[]) => void;
+  setGenerating: () => void;
+  setPRCreating: () => void;
+  setPRCreated: (pr: PRTracking) => void;
+  setPRMerged: () => void;
+  setDeployed: (serviceEndpoint?: string) => void;
+  setAsyncAgentTriggered: (issueUrl: string) => void;
+  setFailed: (error: string) => void;
+  retry: () => void;
+  loadState: (state: FastPathState) => void;
+}
+
+/**
+ * Manages fast-path pipeline state transitions with localStorage persistence.
+ * Parallel to useGitHubPipelineState but with fewer states for the deterministic
+ * deploy flow.
+ *
+ * @param repoKey - '{owner}/{repo}' used as localStorage key. Pass null before repo is selected.
+ */
+export const useFastPathPipelineState = (
+  repoKey: string | null
+): UseFastPathPipelineStateResult => {
+  const [pipelineState, dispatch] = useReducer(fastPathReducer, repoKey, (key: string | null) => {
+    if (key) {
+      const persisted = loadPersistedState(key);
+      if (persisted) return persisted;
+    }
+    return INITIAL_STATE;
+  });
+
+  const prevRepoKeyRef = useRef(repoKey);
+  const lastLoadedStateRef = useRef<FastPathState | null>(null);
+
+  useLayoutEffect(() => {
+    if (repoKey === prevRepoKeyRef.current) return;
+    prevRepoKeyRef.current = repoKey;
+    const persisted = repoKey ? loadPersistedState(repoKey) : null;
+    const loaded = persisted ?? INITIAL_STATE;
+    lastLoadedStateRef.current = loaded;
+    dispatch({ type: 'LOAD_STATE', state: loaded });
+  }, [repoKey]);
+
+  const latestStateRef = useRef(pipelineState);
+  latestStateRef.current = pipelineState;
+
+  const repoKeyRef = useRef(repoKey);
+  useEffect(() => {
+    repoKeyRef.current = repoKey;
+  }, [repoKey]);
+
+  // Debounced persistence — flush synchronously on unmount.
+  useEffect(() => {
+    if (!repoKey) return;
+    if (lastLoadedStateRef.current === pipelineState) {
+      lastLoadedStateRef.current = null;
+      return;
+    }
+    const id = setTimeout(() => persistState(repoKey, pipelineState), 1000);
+    return () => {
+      clearTimeout(id);
+      persistState(repoKeyRef.current!, latestStateRef.current);
+    };
+  }, [repoKey, pipelineState]);
+
+  const actions = useMemo(
+    () => ({
+      setConfig: (config: PipelineConfig) => dispatch({ type: 'SET_CONFIG', config }),
+      updateConfig: (partial: Partial<PipelineConfig>) =>
+        dispatch({ type: 'UPDATE_CONFIG', partial }),
+      setDockerfileDetected: (paths: string[]) =>
+        dispatch({ type: 'SET_DOCKERFILE_DETECTED', paths }),
+      setGenerating: () => dispatch({ type: 'SET_GENERATING' }),
+      setPRCreating: () => dispatch({ type: 'SET_PR_CREATING' }),
+      setPRCreated: (pr: PRTracking) => dispatch({ type: 'SET_PR_CREATED', pr }),
+      setPRMerged: () => dispatch({ type: 'SET_PR_MERGED' }),
+      setDeployed: (serviceEndpoint?: string) =>
+        dispatch({ type: 'SET_DEPLOYED', serviceEndpoint }),
+      setAsyncAgentTriggered: (issueUrl: string) =>
+        dispatch({ type: 'SET_ASYNC_AGENT_TRIGGERED', issueUrl }),
+      setFailed: (error: string) => dispatch({ type: 'SET_FAILED', error }),
+      retry: () => dispatch({ type: 'RETRY' }),
+      loadState: (state: FastPathState) => dispatch({ type: 'LOAD_STATE', state }),
+    }),
+    []
+  );
+
+  return {
+    state: pipelineState,
+    ...actions,
+  };
+};

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useFastPathPipelineState.ts
@@ -67,7 +67,7 @@ const NON_RESUMABLE_STATES: ReadonlySet<FastPathDeploymentState> = new Set([
   'Failed',
 ]);
 
-const VALID_DEPLOYMENT_STATES: ReadonlySet<string> = new Set<string>(FAST_PATH_DEPLOYMENT_STATES);
+const VALID_DEPLOYMENT_STATES = new Set<string>(FAST_PATH_DEPLOYMENT_STATES);
 
 /** Terminal states that don't need persistence — nothing to resume. */
 const TERMINAL_STATES: ReadonlySet<FastPathDeploymentState> = new Set([
@@ -118,31 +118,25 @@ const loadPersistedState = (repoKey: string): FastPathState | null => {
   try {
     const stored = localStorage.getItem(FAST_PATH_STORAGE_PREFIX + repoKey);
     if (!stored) return null;
+
     const parsed: unknown = JSON.parse(stored);
     if (typeof parsed !== 'object' || parsed === null) return null;
-    if (
-      !('__schemaVersion' in parsed) ||
-      (parsed as Record<string, unknown>).__schemaVersion !== FAST_PATH_SCHEMA_VERSION
-    ) {
-      return null;
-    }
-    if (
-      !('deploymentState' in parsed) ||
-      typeof (parsed as Record<string, unknown>).deploymentState !== 'string'
-    ) {
-      return null;
-    }
-    const deploymentState = (parsed as Record<string, unknown>).deploymentState as string;
-    if (!VALID_DEPLOYMENT_STATES.has(deploymentState)) return null;
-    if (TERMINAL_STATES.has(deploymentState as FastPathDeploymentState)) {
+
+    const data = parsed as Record<string, unknown>;
+    if (data.__schemaVersion !== FAST_PATH_SCHEMA_VERSION) return null;
+    if (typeof data.deploymentState !== 'string') return null;
+    if (!VALID_DEPLOYMENT_STATES.has(data.deploymentState)) return null;
+
+    const deploymentState = data.deploymentState as FastPathDeploymentState;
+    if (TERMINAL_STATES.has(deploymentState)) {
       localStorage.removeItem(FAST_PATH_STORAGE_PREFIX + repoKey);
       return null;
     }
-    const data = parsed as Record<string, unknown>;
+
     return {
       ...INITIAL_STATE,
       ...data,
-      deploymentState: deploymentState as FastPathDeploymentState,
+      deploymentState,
       fastPathPr: {
         ...INITIAL_STATE.fastPathPr,
         ...(typeof data.fastPathPr === 'object' && data.fastPathPr !== null

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineState.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineState.test.ts
@@ -53,6 +53,7 @@ function transitionTo(
       hasSetupWorkflow: false,
       hasAgentConfig: false,
       hasDeployWorkflow: false,
+      dockerfilePaths: [],
     })
   );
   if (target === 'AcrSelection') return;
@@ -212,6 +213,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: false,
           hasAgentConfig: false,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
 
@@ -228,6 +230,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: false,
           hasAgentConfig: false,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
       act(() => result.current.setAcrCompleted());
@@ -246,6 +249,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: false,
           hasAgentConfig: false,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
 
@@ -262,6 +266,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: false,
           hasAgentConfig: false,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
       act(() => result.current.setAcrCompleted());
@@ -283,6 +288,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: true,
           hasAgentConfig: true,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
 
@@ -302,6 +308,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: true,
           hasAgentConfig: true,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
 
@@ -322,6 +329,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: true,
           hasAgentConfig: true,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         });
       });
 
@@ -467,6 +475,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: true,
           hasAgentConfig: true,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         })
       );
       expect(result.current.state.deploymentState).toBe('AcrSelection');
@@ -490,6 +499,7 @@ describe('useGitHubPipelineState', () => {
           hasSetupWorkflow: true,
           hasAgentConfig: true,
           hasDeployWorkflow: false,
+          dockerfilePaths: [],
         })
       );
       act(() => result.current.setAcrCompleted());

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.ts
@@ -12,6 +12,7 @@ export type WorkloadIdentitySetupStatus =
   | 'checking'
   | 'creating-identity'
   | 'assigning-roles'
+  | 'warning-kubelet-acr-pull'
   | 'creating-credential'
   | 'done'
   | 'error';

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.ts
@@ -87,6 +87,7 @@ export const useWorkloadIdentitySetup = (): UseWorkloadIdentitySetupReturn => {
         isManagedNamespace,
         namespaceName,
         azureRbacEnabled,
+        isPipeline: true,
         purpose: 'GitHub Actions Identity',
         onStatusChange: setStatus,
       });

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathOrchestration.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathOrchestration.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { Octokit } from '@octokit/rest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createContainerConfig, createValidConfig } from '../__fixtures__/pipelineConfig';
+
+const { mockGetDefaultBranchSha, mockCreateBranch, mockCreateOrUpdateFile, mockCreatePullRequest } =
+  vi.hoisted(() => ({
+    mockGetDefaultBranchSha: vi.fn(),
+    mockCreateBranch: vi.fn(),
+    mockCreateOrUpdateFile: vi.fn(),
+    mockCreatePullRequest: vi.fn(),
+  }));
+
+vi.mock('../../../utils/github/github-api', () => ({
+  getDefaultBranchSha: mockGetDefaultBranchSha,
+  createBranch: mockCreateBranch,
+  createOrUpdateFile: mockCreateOrUpdateFile,
+  createPullRequest: mockCreatePullRequest,
+}));
+
+const { mockGenerateDeployWorkflow, mockGenerateDeploymentManifest, mockGenerateServiceManifest } =
+  vi.hoisted(() => ({
+    mockGenerateDeployWorkflow: vi.fn(() => 'workflow-yaml'),
+    mockGenerateDeploymentManifest: vi.fn(() => 'deployment-yaml'),
+    mockGenerateServiceManifest: vi.fn(() => 'service-yaml'),
+  }));
+
+vi.mock('./fastPathTemplates', () => ({
+  generateDeployWorkflow: mockGenerateDeployWorkflow,
+  generateDeploymentManifest: mockGenerateDeploymentManifest,
+  generateServiceManifest: mockGenerateServiceManifest,
+}));
+
+import { createFastPathPR, type FastPathPRConfig } from './fastPathOrchestration';
+
+const mockRequest = vi.fn();
+const mockOctokit = { request: mockRequest } as unknown as Octokit;
+
+const validConfig = createValidConfig({
+  acrLoginServer: 'acrprod.azurecr.io',
+});
+
+const baseFastPathConfig: FastPathPRConfig = {
+  pipelineConfig: validConfig,
+  dockerfilePath: './Dockerfile',
+  buildContextPath: '.',
+  containerConfig: createContainerConfig(),
+};
+
+describe('fastPathOrchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDefaultBranchSha.mockResolvedValue('sha123');
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCreateOrUpdateFile.mockResolvedValue(undefined);
+    mockCreatePullRequest.mockResolvedValue({
+      number: 10,
+      url: 'https://github.com/testuser/my-repo/pull/10',
+    });
+  });
+
+  describe('createFastPathPR', () => {
+    it('should create branch from default branch SHA', async () => {
+      await createFastPathPR(mockOctokit, baseFastPathConfig);
+
+      expect(mockGetDefaultBranchSha).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        'main'
+      );
+      expect(mockCreateBranch).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        expect.stringContaining('aks-project/fast-path-my-app-'),
+        'sha123'
+      );
+    });
+
+    it('should push workflow + deployment + service manifests', async () => {
+      await createFastPathPR(mockOctokit, baseFastPathConfig);
+
+      expect(mockCreateOrUpdateFile).toHaveBeenCalledTimes(3);
+      expect(mockCreateOrUpdateFile).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        '.github/workflows/deploy-to-aks.yml',
+        'workflow-yaml',
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(mockCreateOrUpdateFile).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        'deploy/kubernetes/deployment.yaml',
+        'deployment-yaml',
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(mockCreateOrUpdateFile).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        'deploy/kubernetes/service.yaml',
+        'service-yaml',
+        expect.any(String),
+        expect.any(String)
+      );
+    });
+
+    it('should call template generators with correct config', async () => {
+      await createFastPathPR(mockOctokit, baseFastPathConfig);
+
+      expect(mockGenerateDeployWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appName: 'my-app',
+          clusterName: 'my-cluster',
+          resourceGroup: 'my-rg',
+          namespace: 'production',
+          acrName: 'acrprod',
+          dockerfilePath: './Dockerfile',
+          buildContextPath: '.',
+          defaultBranch: 'main',
+        })
+      );
+      expect(mockGenerateDeploymentManifest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appName: 'my-app',
+          namespace: 'production',
+          acrName: 'acrprod',
+          repoOwner: 'testuser',
+          repoName: 'my-repo',
+        }),
+        baseFastPathConfig.containerConfig
+      );
+    });
+
+    it('should open PR with descriptive body', async () => {
+      const result = await createFastPathPR(mockOctokit, baseFastPathConfig);
+
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(
+        mockOctokit,
+        'testuser',
+        'my-repo',
+        expect.stringContaining('my-app'),
+        expect.stringContaining('deploy-to-aks.yml'),
+        expect.stringContaining('aks-project/fast-path-my-app-'),
+        'main'
+      );
+      expect(result).toEqual({
+        url: 'https://github.com/testuser/my-repo/pull/10',
+        number: 10,
+        merged: false,
+      });
+    });
+
+    it('should clean up branch on failure', async () => {
+      mockCreateOrUpdateFile.mockRejectedValueOnce(new Error('push failed'));
+
+      await expect(createFastPathPR(mockOctokit, baseFastPathConfig)).rejects.toThrow(
+        'push failed'
+      );
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        'DELETE /repos/{owner}/{repo}/git/refs/{ref}',
+        expect.objectContaining({
+          owner: 'testuser',
+          repo: 'my-repo',
+          ref: expect.stringContaining('heads/aks-project/fast-path-my-app-'),
+        })
+      );
+    });
+
+    it('should derive ACR name from acrLoginServer', async () => {
+      await createFastPathPR(mockOctokit, baseFastPathConfig);
+
+      expect(mockGenerateDeployWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ acrName: 'acrprod' })
+      );
+    });
+
+    it('should derive ACR name from acrResourceId when no login server', async () => {
+      const configWithResourceId = createValidConfig({
+        acrLoginServer: undefined,
+        acrResourceId:
+          '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+      });
+
+      await createFastPathPR(mockOctokit, {
+        ...baseFastPathConfig,
+        pipelineConfig: configWithResourceId,
+      });
+
+      expect(mockGenerateDeployWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ acrName: 'myacr' })
+      );
+    });
+
+    it('should throw when ACR name cannot be derived', async () => {
+      const configNoAcr = createValidConfig({
+        acrLoginServer: undefined,
+        acrResourceId: undefined,
+      });
+
+      await expect(
+        createFastPathPR(mockOctokit, {
+          ...baseFastPathConfig,
+          pipelineConfig: configNoAcr,
+        })
+      ).rejects.toThrow('ACR');
+    });
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathOrchestration.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathOrchestration.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { Octokit } from '@octokit/rest';
+import {
+  createBranch,
+  createOrUpdateFile,
+  createPullRequest,
+  getDefaultBranchSha,
+} from '../../../utils/github/github-api';
+import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
+import { PIPELINE_WORKFLOW_FILENAME } from '../constants';
+import type { PipelineConfig, PRTracking } from '../types';
+import {
+  generateDeploymentManifest,
+  generateDeployWorkflow,
+  generateServiceManifest,
+} from './fastPathTemplates';
+
+export interface FastPathPRConfig {
+  pipelineConfig: PipelineConfig;
+  dockerfilePath: string;
+  buildContextPath: string;
+  containerConfig: ContainerConfig;
+}
+
+/**
+ * Derives the ACR short name from PipelineConfig.
+ * Tries acrLoginServer first ("myacr.azurecr.io" → "myacr"),
+ * falls back to acrResourceId (".../registries/myacr" → "myacr").
+ */
+function deriveAcrName(config: PipelineConfig): string {
+  if (config.acrLoginServer) {
+    const name = config.acrLoginServer.split('.')[0];
+    if (name) return name;
+  }
+  if (config.acrResourceId) {
+    const segments = config.acrResourceId.split('/');
+    const idx = segments.findIndex(s => s.toLowerCase() === 'registries');
+    if (idx !== -1 && idx + 1 < segments.length && segments[idx + 1]) {
+      return segments[idx + 1];
+    }
+  }
+  throw new Error(
+    'Cannot derive ACR name: neither acrLoginServer nor acrResourceId is set on PipelineConfig'
+  );
+}
+
+/**
+ * Creates a single PR containing the deploy workflow + K8s manifests.
+ * On failure, attempts to clean up the created branch.
+ */
+export async function createFastPathPR(
+  octokit: Octokit,
+  config: FastPathPRConfig
+): Promise<PRTracking> {
+  const { pipelineConfig, dockerfilePath, buildContextPath, containerConfig } = config;
+  const { owner, repo, defaultBranch } = pipelineConfig.repo;
+  const branchName = `aks-project/fast-path-${pipelineConfig.appName}-${Date.now()}`;
+  const acrName = deriveAcrName(pipelineConfig);
+
+  const sha = await getDefaultBranchSha(octokit, owner, repo, defaultBranch);
+  await createBranch(octokit, owner, repo, branchName, sha);
+
+  try {
+    const workflowYaml = generateDeployWorkflow({
+      appName: pipelineConfig.appName,
+      clusterName: pipelineConfig.clusterName,
+      resourceGroup: pipelineConfig.resourceGroup,
+      namespace: pipelineConfig.namespace,
+      acrName,
+      dockerfilePath,
+      buildContextPath,
+      defaultBranch,
+    });
+
+    const manifestConfig = {
+      appName: pipelineConfig.appName,
+      namespace: pipelineConfig.namespace,
+      acrName,
+      repoOwner: owner,
+      repoName: repo,
+    };
+
+    const deploymentYaml = generateDeploymentManifest(manifestConfig, containerConfig);
+    const serviceYaml = generateServiceManifest(manifestConfig, containerConfig);
+
+    await createOrUpdateFile(
+      octokit,
+      owner,
+      repo,
+      `.github/workflows/${PIPELINE_WORKFLOW_FILENAME}`,
+      workflowYaml,
+      `Add AKS deploy workflow for ${pipelineConfig.appName}`,
+      branchName
+    );
+
+    await createOrUpdateFile(
+      octokit,
+      owner,
+      repo,
+      'deploy/kubernetes/deployment.yaml',
+      deploymentYaml,
+      `Add Kubernetes deployment manifest for ${pipelineConfig.appName}`,
+      branchName
+    );
+
+    await createOrUpdateFile(
+      octokit,
+      owner,
+      repo,
+      'deploy/kubernetes/service.yaml',
+      serviceYaml,
+      `Add Kubernetes service manifest for ${pipelineConfig.appName}`,
+      branchName
+    );
+
+    const pr = await createPullRequest(
+      octokit,
+      owner,
+      repo,
+      `Deploy ${pipelineConfig.appName} to AKS`,
+      [
+        '## AKS Desktop — Fast Path Deploy',
+        '',
+        'This PR adds a deterministic deployment pipeline for this application.',
+        '',
+        '### Files added',
+        `- \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\` — Build + deploy workflow`,
+        '- `deploy/kubernetes/deployment.yaml` — Kubernetes Deployment manifest',
+        '- `deploy/kubernetes/service.yaml` — Kubernetes Service manifest',
+        '',
+        '### AKS Configuration',
+        `- **Cluster**: ${pipelineConfig.clusterName}`,
+        `- **Resource Group**: ${pipelineConfig.resourceGroup}`,
+        `- **Namespace**: ${pipelineConfig.namespace}`,
+        `- **Dockerfile**: ${dockerfilePath}`,
+        '',
+        '---',
+        '_Created by AKS Desktop (Fast Path)_',
+      ].join('\n'),
+      branchName,
+      defaultBranch
+    );
+
+    return { url: pr.url, number: pr.number, merged: false };
+  } catch (err) {
+    // Best-effort cleanup: delete the branch to avoid dangling refs
+    try {
+      await octokit.request('DELETE /repos/{owner}/{repo}/git/refs/{ref}', {
+        owner,
+        repo,
+        ref: `heads/${branchName}`,
+      });
+    } catch (cleanupErr) {
+      console.warn(`Failed to clean up branch ${branchName}:`, cleanupErr);
+    }
+    throw err;
+  }
+}

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { generateDeployWorkflow } from './fastPathTemplates';
+
+const baseConfig = {
+  appName: 'contoso-air',
+  clusterName: 'aks-prod',
+  resourceGroup: 'rg-prod',
+  namespace: 'demo',
+  acrName: 'acrprod',
+  dockerfilePath: './Dockerfile',
+  buildContextPath: '.',
+  defaultBranch: 'main',
+};
+
+describe('generateDeployWorkflow', () => {
+  it('should generate a valid workflow YAML with two jobs', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('name: Deploy to AKS');
+    expect(yaml).toContain('buildImage:');
+    expect(yaml).toContain('deploy:');
+    expect(yaml).toContain('needs: [buildImage]');
+  });
+
+  it('should use pinned kubelogin version', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain("kubelogin-version: 'v0.1.6'");
+    expect(yaml).not.toContain('skip-cache');
+  });
+
+  it('should include actions: read permission', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('actions: read');
+  });
+
+  it('should use Azure/k8s-deploy@v5 for deployment', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('Azure/k8s-deploy@v5');
+    expect(yaml).not.toContain('kubectl apply');
+  });
+
+  it('should include explicit Dockerfile path and build context', () => {
+    const yaml = generateDeployWorkflow({
+      ...baseConfig,
+      dockerfilePath: './src/web/Dockerfile',
+      buildContextPath: './src/web',
+    });
+    expect(yaml).toContain('DOCKER_FILE: ./src/web/Dockerfile');
+    expect(yaml).toContain('BUILD_CONTEXT_PATH: ./src/web');
+  });
+
+  it('should set continue-on-error on annotation steps', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('continue-on-error: true');
+  });
+
+  it('should use use-kubelogin: true in aks-set-context', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain("use-kubelogin: 'true'");
+  });
+
+  it('should parameterize all config values', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('AZURE_CONTAINER_REGISTRY: acrprod');
+    expect(yaml).toContain('CONTAINER_NAME: contoso-air');
+    expect(yaml).toContain('CLUSTER_NAME: aks-prod');
+    expect(yaml).toContain('CLUSTER_RESOURCE_GROUP: rg-prod');
+    expect(yaml).toContain('NAMESPACE: demo');
+  });
+
+  it('should trigger on push to default branch and workflow_dispatch', () => {
+    const yaml = generateDeployWorkflow(baseConfig);
+    expect(yaml).toContain('branches: [main]');
+    expect(yaml).toContain('workflow_dispatch');
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { generateDeployWorkflow } from './fastPathTemplates';
+import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
+import {
+  generateDeploymentManifest,
+  generateDeployWorkflow,
+  generateServiceManifest,
+} from './fastPathTemplates';
 
 const baseConfig = {
   appName: 'contoso-air',
@@ -71,5 +76,104 @@ describe('generateDeployWorkflow', () => {
     const yaml = generateDeployWorkflow(baseConfig);
     expect(yaml).toContain('branches: [main]');
     expect(yaml).toContain('workflow_dispatch');
+  });
+});
+
+const baseManifestConfig = {
+  appName: 'contoso-air',
+  namespace: 'demo',
+  acrName: 'acrprod',
+  repoOwner: 'pauldotyu',
+  repoName: 'contoso-air',
+};
+
+const baseContainerConfig: Partial<ContainerConfig> = {
+  replicas: 1,
+  targetPort: 3000,
+  servicePort: 80,
+  useCustomServicePort: true,
+  serviceType: 'ClusterIP',
+  enableResources: true,
+  cpuRequest: '100m',
+  cpuLimit: '500m',
+  memoryRequest: '128Mi',
+  memoryLimit: '512Mi',
+  enableLivenessProbe: true,
+  livenessPath: '/',
+  livenessInitialDelay: 15,
+  livenessPeriod: 20,
+  livenessTimeout: 5,
+  livenessFailure: 3,
+  livenessSuccess: 1,
+  enableReadinessProbe: false,
+  enableStartupProbe: false,
+  allowPrivilegeEscalation: false,
+  runAsNonRoot: false,
+  readOnlyRootFilesystem: false,
+  enablePodAntiAffinity: false,
+  enableTopologySpreadConstraints: false,
+};
+
+describe('generateDeploymentManifest', () => {
+  it('should generate a valid deployment YAML', () => {
+    const yaml = generateDeploymentManifest(
+      baseManifestConfig,
+      baseContainerConfig as ContainerConfig
+    );
+    expect(yaml).toContain('kind: Deployment');
+    expect(yaml).toContain('name: contoso-air');
+    expect(yaml).toContain('namespace: demo');
+    expect(yaml).toContain('containerPort: 3000');
+    expect(yaml).toContain('replicas: 1');
+  });
+
+  it('should include pipeline annotations', () => {
+    const yaml = generateDeploymentManifest(
+      baseManifestConfig,
+      baseContainerConfig as ContainerConfig
+    );
+    expect(yaml).toContain('aks-project/deployed-by: pipeline');
+    expect(yaml).toContain('aks-project/pipeline-repo: pauldotyu/contoso-air');
+  });
+
+  it('should include resource limits when enabled', () => {
+    const yaml = generateDeploymentManifest(
+      baseManifestConfig,
+      baseContainerConfig as ContainerConfig
+    );
+    expect(yaml).toContain('cpu: 100m');
+    expect(yaml).toContain('memory: 128Mi');
+  });
+
+  it('should include liveness probe when enabled', () => {
+    const yaml = generateDeploymentManifest(
+      baseManifestConfig,
+      baseContainerConfig as ContainerConfig
+    );
+    expect(yaml).toContain('livenessProbe:');
+    expect(yaml).toContain('path: /');
+    expect(yaml).not.toContain('readinessProbe:');
+    expect(yaml).not.toContain('startupProbe:');
+  });
+
+  it('should omit resources when not enabled', () => {
+    const yaml = generateDeploymentManifest(baseManifestConfig, {
+      ...baseContainerConfig,
+      enableResources: false,
+    } as ContainerConfig);
+    expect(yaml).not.toContain('resources:');
+  });
+});
+
+describe('generateServiceManifest', () => {
+  it('should generate a valid service YAML', () => {
+    const yaml = generateServiceManifest(
+      baseManifestConfig,
+      baseContainerConfig as ContainerConfig
+    );
+    expect(yaml).toContain('kind: Service');
+    expect(yaml).toContain('type: ClusterIP');
+    expect(yaml).toContain('port: 80');
+    expect(yaml).toContain('targetPort: 3000');
   });
 });

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+export interface WorkflowConfig {
+  appName: string;
+  clusterName: string;
+  resourceGroup: string;
+  namespace: string;
+  acrName: string;
+  dockerfilePath: string;
+  buildContextPath: string;
+  defaultBranch: string;
+}
+
+/**
+ * Generates a deterministic deploy-to-aks.yml workflow.
+ * Based on the proven aks-devhub workflow with all known bug fixes applied.
+ */
+export function generateDeployWorkflow(config: WorkflowConfig): string {
+  return `name: Deploy to AKS
+
+on:
+  push:
+    branches: [${config.defaultBranch}]
+  workflow_dispatch:
+
+env:
+  ACR_RESOURCE_GROUP: ${config.resourceGroup}
+  AZURE_CONTAINER_REGISTRY: ${config.acrName}
+  CONTAINER_NAME: ${config.appName}
+  CLUSTER_NAME: ${config.clusterName}
+  CLUSTER_RESOURCE_GROUP: ${config.resourceGroup}
+  DEPLOYMENT_MANIFEST_PATH: ./deploy/kubernetes
+  DOCKER_FILE: ${config.dockerfilePath}
+  BUILD_CONTEXT_PATH: ${config.buildContextPath}
+  NAMESPACE: ${config.namespace}
+
+jobs:
+  buildImage:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: \${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build and push image to ACR
+        run: |
+          az acr build \\
+            --registry \${{ env.AZURE_CONTAINER_REGISTRY }} \\
+            -g \${{ env.ACR_RESOURCE_GROUP }} \\
+            -f \${{ env.DOCKER_FILE }} \\
+            --image \${{ env.CONTAINER_NAME }}:\${{ github.sha }} \\
+            \${{ env.BUILD_CONTEXT_PATH }}
+
+  deploy:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [buildImage]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: \${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: \${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: \${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up kubelogin
+        uses: azure/use-kubelogin@v1
+        with:
+          kubelogin-version: 'v0.1.6'
+
+      - name: Get K8s context
+        uses: azure/aks-set-context@v4
+        with:
+          resource-group: \${{ env.CLUSTER_RESOURCE_GROUP }}
+          cluster-name: \${{ env.CLUSTER_NAME }}
+          admin: 'false'
+          use-kubelogin: 'true'
+
+      - name: Deploy application
+        uses: Azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: \${{ env.DEPLOYMENT_MANIFEST_PATH }}
+          images: |
+            \${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/\${{ env.CONTAINER_NAME }}:\${{ github.sha }}
+          namespace: \${{ env.NAMESPACE }}
+
+      - name: Annotate namespace
+        continue-on-error: true
+        run: |
+          kubectl annotate namespace \${{ env.NAMESPACE }} \\
+            aks-project/pipeline-repo=\${{ github.repository }} \\
+            --overwrite
+
+      - name: Annotate deployment
+        continue-on-error: true
+        run: |
+          kubectl annotate deployment --all \\
+            -n \${{ env.NAMESPACE }} \\
+            aks-project/pipeline-run-url=\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }} \\
+            "aks-project/pipeline-workflow=\${{ github.workflow }}" \\
+            --overwrite
+`;
+}

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/fastPathTemplates.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
+import type { ContainerConfig } from '../../DeployWizard/hooks/useContainerConfiguration';
+import { getProbeConfigs } from './probeHelpers';
+
 export interface WorkflowConfig {
   appName: string;
   clusterName: string;
@@ -114,5 +117,155 @@ jobs:
             aks-project/pipeline-run-url=\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }} \\
             "aks-project/pipeline-workflow=\${{ github.workflow }}" \\
             --overwrite
+`;
+}
+
+export interface ManifestConfig {
+  appName: string;
+  namespace: string;
+  acrName: string;
+  repoOwner: string;
+  repoName: string;
+}
+
+function indent(text: string, spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map(line => (line.trim() ? pad + line : line))
+    .join('\n');
+}
+
+function generateProbeYaml(
+  type: string,
+  path: string,
+  port: number,
+  initialDelay: number,
+  period: number,
+  timeout: number,
+  failure: number,
+  success: number
+): string {
+  return `${type}:
+          httpGet:
+            path: ${path}
+            port: ${port}
+          initialDelaySeconds: ${initialDelay}
+          periodSeconds: ${period}
+          timeoutSeconds: ${timeout}
+          failureThreshold: ${failure}
+          successThreshold: ${success}`;
+}
+
+/**
+ * Generates a Kubernetes Deployment manifest from container config.
+ */
+export function generateDeploymentManifest(config: ManifestConfig, cc: ContainerConfig): string {
+  const probes = getProbeConfigs(cc)
+    .filter(p => p.enabled)
+    .map(p => {
+      const tag = p.name.charAt(0).toLowerCase() + p.name.slice(1) + 'Probe';
+      return generateProbeYaml(
+        tag,
+        p.path,
+        cc.targetPort,
+        p.initialDelay,
+        p.period,
+        p.timeout,
+        p.failure,
+        p.success
+      );
+    });
+
+  const probesBlock = probes.length > 0 ? '\n' + indent(probes.join('\n'), 8) : '';
+
+  const resourcesBlock = cc.enableResources
+    ? `
+        resources:
+          requests:
+            cpu: ${cc.cpuRequest}
+            memory: ${cc.memoryRequest}
+          limits:
+            cpu: ${cc.cpuLimit}
+            memory: ${cc.memoryLimit}`
+    : '';
+
+  const securityLines: string[] = [];
+  if (cc.allowPrivilegeEscalation === false) securityLines.push('allowPrivilegeEscalation: false');
+  if (cc.runAsNonRoot) securityLines.push('runAsNonRoot: true');
+  if (cc.readOnlyRootFilesystem) securityLines.push('readOnlyRootFilesystem: true');
+  const securityBlock =
+    securityLines.length > 0
+      ? `\n        securityContext:\n${securityLines.map(l => `          ${l}`).join('\n')}`
+      : '';
+
+  const antiAffinityBlock = cc.enablePodAntiAffinity
+    ? `
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: ${config.appName}
+              topologyKey: kubernetes.io/hostname`
+    : '';
+
+  const topologyBlock = cc.enableTopologySpreadConstraints
+    ? `
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: ${config.appName}`
+    : '';
+
+  return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${config.appName}
+  namespace: ${config.namespace}
+  annotations:
+    aks-project/deployed-by: pipeline
+    aks-project/pipeline-repo: ${config.repoOwner}/${config.repoName}
+spec:
+  replicas: ${cc.replicas}
+  selector:
+    matchLabels:
+      app: ${config.appName}
+  template:
+    metadata:
+      labels:
+        app: ${config.appName}
+    spec:${antiAffinityBlock}${topologyBlock}
+      containers:
+      - name: ${config.appName}
+        image: ${config.acrName}.azurecr.io/${config.appName}:latest
+        ports:
+        - containerPort: ${cc.targetPort}${resourcesBlock}${probesBlock}${securityBlock}
+`;
+}
+
+/**
+ * Generates a Kubernetes Service manifest from container config.
+ */
+export function generateServiceManifest(config: ManifestConfig, cc: ContainerConfig): string {
+  const servicePort = cc.useCustomServicePort ? cc.servicePort : cc.targetPort;
+  return `apiVersion: v1
+kind: Service
+metadata:
+  name: ${config.appName}
+  namespace: ${config.namespace}
+spec:
+  type: ${cc.serviceType}
+  ports:
+  - port: ${servicePort}
+    targetPort: ${cc.targetPort}
+    protocol: TCP
+  selector:
+    app: ${config.appName}
 `;
 }

--- a/plugins/aks-desktop/src/types/github.ts
+++ b/plugins/aks-desktop/src/types/github.ts
@@ -25,6 +25,8 @@ export interface RepoReadiness {
   hasAgentConfig: boolean;
   /** Whether deploy-to-aks.yml exists on the default branch. */
   hasDeployWorkflow: boolean;
+  /** Paths to Dockerfiles found in the repo (empty if none). */
+  dockerfilePaths: string[];
 }
 
 /**

--- a/plugins/aks-desktop/src/utils/azure/az-identity-kubelet.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-identity-kubelet.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunAzCommand = vi.fn();
 vi.mock('./az-cli-core', () => ({
@@ -10,9 +10,18 @@ vi.mock('./az-cli-core', () => ({
   isValidGuid: (s: string) => /^[0-9a-f-]{36}$/.test(s),
 }));
 
+vi.mock('./az-validation', () => ({
+  isValidAzResourceName: (s: string) => /^[a-zA-Z0-9-_]+$/.test(s),
+  parseManagedIdentityOutput: vi.fn(),
+}));
+
 import { getKubeletIdentityObjectId } from './az-identity';
 
 describe('getKubeletIdentityObjectId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should return the kubelet identity objectId from az aks show', async () => {
     mockRunAzCommand.mockResolvedValue({
       success: true,
@@ -45,6 +54,36 @@ describe('getKubeletIdentityObjectId', () => {
     expect(result.error).toContain('kubelet identity');
   });
 
+  it('should return error when data is a non-string type', async () => {
+    mockRunAzCommand.mockResolvedValue({
+      success: true,
+      data: 12345,
+    });
+
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('kubelet identity');
+  });
+
+  it('should return error when data is an object', async () => {
+    mockRunAzCommand.mockResolvedValue({
+      success: true,
+      data: { nested: 'value' },
+    });
+
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('kubelet identity');
+  });
+
   it('should return error when az command fails', async () => {
     mockRunAzCommand.mockResolvedValue({
       success: false,
@@ -57,5 +96,38 @@ describe('getKubeletIdentityObjectId', () => {
       clusterName: 'my-aks',
     });
     expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid subscription ID', async () => {
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: 'not-a-guid',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('subscription ID');
+    expect(mockRunAzCommand).not.toHaveBeenCalled();
+  });
+
+  it('should reject invalid resource group name', async () => {
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'bad group name!',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('resource group or cluster name');
+    expect(mockRunAzCommand).not.toHaveBeenCalled();
+  });
+
+  it('should reject invalid cluster name', async () => {
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'bad cluster!',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('resource group or cluster name');
+    expect(mockRunAzCommand).not.toHaveBeenCalled();
   });
 });

--- a/plugins/aks-desktop/src/utils/azure/az-identity-kubelet.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-identity-kubelet.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mockRunAzCommand = vi.fn();
+vi.mock('./az-cli-core', () => ({
+  runAzCommand: (...args: unknown[]) => mockRunAzCommand(...args),
+  debugLog: vi.fn(),
+  isValidGuid: (s: string) => /^[0-9a-f-]{36}$/.test(s),
+}));
+
+import { getKubeletIdentityObjectId } from './az-identity';
+
+describe('getKubeletIdentityObjectId', () => {
+  it('should return the kubelet identity objectId from az aks show', async () => {
+    mockRunAzCommand.mockResolvedValue({
+      success: true,
+      data: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    });
+
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result).toEqual({
+      success: true,
+      objectId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    });
+  });
+
+  it('should return error when identityProfile is missing', async () => {
+    mockRunAzCommand.mockResolvedValue({
+      success: true,
+      data: null,
+    });
+
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('kubelet identity');
+  });
+
+  it('should return error when az command fails', async () => {
+    mockRunAzCommand.mockResolvedValue({
+      success: false,
+      error: 'ResourceNotFound',
+    });
+
+    const result = await getKubeletIdentityObjectId({
+      subscriptionId: '11111111-2222-3333-4444-555555555555',
+      resourceGroup: 'my-rg',
+      clusterName: 'my-aks',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/plugins/aks-desktop/src/utils/azure/az-identity.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-identity.ts
@@ -245,6 +245,52 @@ export async function getManagedNamespaceResourceId(options: {
   return { success: true, resourceId: result.data };
 }
 
+/**
+ * Gets the kubelet identity's objectId for an AKS cluster.
+ * Used to assign AcrPull so nodes can pull container images.
+ */
+export async function getKubeletIdentityObjectId(options: {
+  subscriptionId: string;
+  resourceGroup: string;
+  clusterName: string;
+}): Promise<{ success: boolean; objectId?: string; error?: string }> {
+  const { subscriptionId, resourceGroup, clusterName } = options;
+
+  const result = await runAzCommand(
+    [
+      'aks',
+      'show',
+      '--name',
+      clusterName,
+      '--resource-group',
+      resourceGroup,
+      '--subscription',
+      subscriptionId,
+      '--query',
+      'identityProfile.kubeletidentity.objectId',
+      '-o',
+      'json',
+    ],
+    `getKubeletIdentity(${clusterName})`,
+    `Failed to get kubelet identity for cluster ${clusterName}`,
+    (stdout: string) => JSON.parse(stdout)
+  );
+
+  if (!result.success) {
+    return { success: false, error: result.error ?? 'Failed to get cluster details' };
+  }
+
+  const objectId = result.data;
+  if (!objectId || typeof objectId !== 'string') {
+    return {
+      success: false,
+      error: `Cluster ${clusterName} does not have a kubelet identity configured`,
+    };
+  }
+
+  return { success: true, objectId };
+}
+
 export async function listManagedIdentities(options: {
   resourceGroup: string;
   subscriptionId: string;

--- a/plugins/aks-desktop/src/utils/azure/az-identity.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-identity.ts
@@ -256,6 +256,13 @@ export async function getKubeletIdentityObjectId(options: {
 }): Promise<{ success: boolean; objectId?: string; error?: string }> {
   const { subscriptionId, resourceGroup, clusterName } = options;
 
+  if (!isValidGuid(subscriptionId)) {
+    return { success: false, error: 'Invalid subscription ID format' };
+  }
+  if (!isValidAzResourceName(resourceGroup) || !isValidAzResourceName(clusterName)) {
+    return { success: false, error: 'Invalid resource group or cluster name format' };
+  }
+
   const result = await runAzCommand(
     [
       'aks',
@@ -268,7 +275,7 @@ export async function getKubeletIdentityObjectId(options: {
       subscriptionId,
       '--query',
       'identityProfile.kubeletidentity.objectId',
-      '-o',
+      '--output',
       'json',
     ],
     `getKubeletIdentity(${clusterName})`,

--- a/plugins/aks-desktop/src/utils/azure/identityRoles.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityRoles.test.ts
@@ -105,6 +105,12 @@ describe('computeRequiredRoles', () => {
       managedNamespaceResourceId,
     };
 
+    it('should not be affected by isPipeline flag', () => {
+      const rolesWithout = computeRequiredRoles(managedCtx);
+      const rolesWith = computeRequiredRoles({ ...managedCtx, isPipeline: true });
+      expect(rolesWith).toEqual(rolesWithout);
+    });
+
     it('assigns AKS RBAC Writer and Namespace User at MNS scope', () => {
       const roles = computeRequiredRoles(managedCtx);
 

--- a/plugins/aks-desktop/src/utils/azure/identityRoles.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityRoles.test.ts
@@ -75,6 +75,27 @@ describe('computeRequiredRoles', () => {
       const roleNames = roles.map(r => r.role);
       expect(roleNames).not.toContain('Azure Kubernetes Service RBAC Writer');
     });
+
+    it('should include AKS RBAC Writer for pipeline identity even without azureRbacEnabled', () => {
+      const roles = computeRequiredRoles({
+        ...baseContext,
+        isManagedNamespace: false,
+        isPipeline: true,
+      });
+      const roleNames = roles.map(r => r.role);
+      expect(roleNames).toContain('Azure Kubernetes Service RBAC Writer');
+      expect(roleNames).toContain('Azure Kubernetes Service Cluster User Role');
+    });
+
+    it('should include AKS RBAC Writer for pipeline identity with ACR', () => {
+      const roles = computeRequiredRoles({
+        ...baseContext,
+        isManagedNamespace: false,
+        isPipeline: true,
+        acrResourceId,
+      });
+      expect(roles).toHaveLength(4); // AcrPush + AcrTasksContributor + ClusterUser + RBACWriter
+    });
   });
 
   describe('Managed Namespace', () => {

--- a/plugins/aks-desktop/src/utils/azure/identityRoles.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityRoles.ts
@@ -15,6 +15,8 @@ interface IdentityRoleContextBase {
   resourceGroup: string;
   clusterName: string;
   acrResourceId?: string;
+  /** When true, always includes AKS RBAC Writer (needed for annotation permissions). */
+  isPipeline?: boolean;
 }
 
 interface NormalNamespaceRoleContext extends IdentityRoleContextBase {
@@ -61,7 +63,7 @@ export function computeRequiredRoles(ctx: IdentityRoleContext): RoleAssignment[]
     roles.push({ role: AKS_NAMESPACE_USER, scope: ctx.managedNamespaceResourceId });
   } else {
     roles.push({ role: AKS_CLUSTER_USER, scope: clusterScope });
-    if (ctx.azureRbacEnabled) {
+    if (ctx.azureRbacEnabled || ctx.isPipeline) {
       roles.push({ role: AKS_RBAC_WRITER, scope: clusterScope });
     }
   }

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
@@ -244,4 +244,80 @@ describe('ensureIdentityWithRoles', () => {
       ],
     });
   });
+
+  it('should still return identity when getKubeletIdentityObjectId fails', async () => {
+    setupHappyPath();
+    mockGetKubeletIdentityObjectId.mockResolvedValue({
+      success: false,
+      error: 'Cluster not found',
+    });
+    const onStatusChange = vi.fn();
+
+    const result = await ensureIdentityWithRoles({
+      ...baseConfig,
+      acrResourceId:
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+      isPipeline: true,
+      onStatusChange,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.clientId).toBe('cid');
+    // Should emit warning status
+    expect(onStatusChange).toHaveBeenCalledWith('warning-kubelet-acr-pull');
+    // Should not attempt kubelet role assignment
+    expect(mockAssignRolesToIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still return identity when kubelet AcrPull assignment fails', async () => {
+    setupHappyPath();
+    mockGetKubeletIdentityObjectId.mockResolvedValue({
+      success: true,
+      objectId: 'kubelet-principal-1',
+    });
+    // First call succeeds (identity roles), second call fails (kubelet AcrPull)
+    mockAssignRolesToIdentity
+      .mockResolvedValueOnce({ success: true, results: [] })
+      .mockResolvedValueOnce({ success: false, error: 'Forbidden' });
+    const onStatusChange = vi.fn();
+
+    const result = await ensureIdentityWithRoles({
+      ...baseConfig,
+      acrResourceId:
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+      isPipeline: true,
+      onStatusChange,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.clientId).toBe('cid');
+    expect(onStatusChange).toHaveBeenCalledWith('warning-kubelet-acr-pull');
+  });
+
+  it('should skip kubelet AcrPull when isPipeline is true but acrResourceId is missing', async () => {
+    setupHappyPath();
+
+    await ensureIdentityWithRoles({
+      ...baseConfig,
+      isPipeline: true,
+    });
+
+    expect(mockGetKubeletIdentityObjectId).not.toHaveBeenCalled();
+    // Only the identity role assignment call
+    expect(mockAssignRolesToIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip kubelet AcrPull when acrResourceId is set but isPipeline is false', async () => {
+    setupHappyPath();
+
+    await ensureIdentityWithRoles({
+      ...baseConfig,
+      acrResourceId:
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+      isPipeline: false,
+    });
+
+    expect(mockGetKubeletIdentityObjectId).not.toHaveBeenCalled();
+    expect(mockAssignRolesToIdentity).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
@@ -12,6 +12,7 @@ const mockGetManagedIdentity = vi.fn();
 const mockCreateManagedIdentity = vi.fn();
 const mockAssignRolesToIdentity = vi.fn();
 const mockGetManagedNamespaceResourceId = vi.fn();
+const mockGetKubeletIdentityObjectId = vi.fn();
 
 vi.mock('./az-subscriptions', () => ({
   resourceGroupExists: (...args: any[]) => mockResourceGroupExists(...args),
@@ -24,6 +25,7 @@ vi.mock('./az-identity', () => ({
   createManagedIdentity: (...args: any[]) => mockCreateManagedIdentity(...args),
   assignRolesToIdentity: (...args: any[]) => mockAssignRolesToIdentity(...args),
   getManagedNamespaceResourceId: (...args: any[]) => mockGetManagedNamespaceResourceId(...args),
+  getKubeletIdentityObjectId: (...args: any[]) => mockGetKubeletIdentityObjectId(...args),
   buildClusterScope: (sub: string, rg: string, cluster: string) =>
     `/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.ContainerService/managedClusters/${cluster}`,
 }));
@@ -205,5 +207,41 @@ describe('ensureIdentityWithRoles', () => {
     mockCreateResourceGroup.mockResolvedValue({ success: false, error: 'Permission denied' });
 
     await expect(ensureIdentityWithRoles(baseConfig)).rejects.toThrow('Permission denied');
+  });
+
+  it('should assign AcrPull to kubelet identity when ACR is provided', async () => {
+    setupHappyPath();
+    mockGetKubeletIdentityObjectId.mockResolvedValue({
+      success: true,
+      objectId: 'kubelet-principal-1',
+    });
+
+    await ensureIdentityWithRoles({
+      ...baseConfig,
+      subscriptionId: 'sub-1',
+      resourceGroup: 'rg-1',
+      identityResourceGroup: 'id-rg',
+      identityName: 'id-1',
+      clusterName: 'aks-1',
+      acrResourceId:
+        '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+      isManagedNamespace: false,
+      isPipeline: true,
+      onStatusChange: vi.fn(),
+    });
+
+    // Second call to assignRolesToIdentity is for kubelet AcrPull
+    expect(mockAssignRolesToIdentity).toHaveBeenCalledTimes(2);
+    expect(mockAssignRolesToIdentity).toHaveBeenLastCalledWith({
+      principalId: 'kubelet-principal-1',
+      subscriptionId: 'sub-1',
+      roles: [
+        {
+          role: 'AcrPull',
+          scope:
+            '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/myacr',
+        },
+      ],
+    });
   });
 });

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
@@ -13,7 +13,10 @@ import {
   type IdentitySetupStatus,
 } from './identitySetup';
 
-export type RoleAssignmentStatus = IdentitySetupStatus | 'assigning-roles';
+export type RoleAssignmentStatus =
+  | IdentitySetupStatus
+  | 'assigning-roles'
+  | 'warning-kubelet-acr-pull';
 
 export interface EnsureIdentityWithRolesConfig {
   subscriptionId: string;
@@ -90,6 +93,7 @@ export async function ensureIdentityWithRoles(
       if (!nsResult.success || !nsResult.resourceId) {
         throw new Error(nsResult.error ?? 'Failed to get managed namespace resource ID');
       }
+      // isPipeline is not passed here — it only affects the normal namespace branch
       return computeRequiredRoles({
         subscriptionId,
         resourceGroup,
@@ -97,7 +101,6 @@ export async function ensureIdentityWithRoles(
         acrResourceId,
         isManagedNamespace: true,
         managedNamespaceResourceId: nsResult.resourceId,
-        isPipeline,
       });
     }
     return computeRequiredRoles({
@@ -142,11 +145,10 @@ export async function ensureIdentityWithRoles(
         roles: [{ role: 'AcrPull', scope: acrResourceId }],
       });
       if (!kubeletRoleResult.success) {
-        console.warn('Failed to assign AcrPull to kubelet identity:', kubeletRoleResult.error);
-        // Non-fatal: the user may have already configured ACR integration
+        onStatusChange('warning-kubelet-acr-pull');
       }
     } else {
-      console.warn('Could not resolve kubelet identity:', kubeletResult.error);
+      onStatusChange('warning-kubelet-acr-pull');
     }
   }
 

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { assignRolesToIdentity, getManagedNamespaceResourceId } from './az-identity';
+import {
+  assignRolesToIdentity,
+  getKubeletIdentityObjectId,
+  getManagedNamespaceResourceId,
+} from './az-identity';
 import { computeRequiredRoles } from './identityRoles';
 import {
   ensureIdentityAndResourceGroup,
@@ -122,6 +126,28 @@ export async function ensureIdentityWithRoles(
       .map(r => `${r.role}: ${r.error}`)
       .join('; ');
     throw new Error(`Failed to assign roles: ${failedRoles}`);
+  }
+
+  // Assign AcrPull to the kubelet identity so nodes can pull images from ACR
+  if (acrResourceId && isPipeline) {
+    const kubeletResult = await getKubeletIdentityObjectId({
+      subscriptionId,
+      resourceGroup,
+      clusterName,
+    });
+    if (kubeletResult.success && kubeletResult.objectId) {
+      const kubeletRoleResult = await assignRolesToIdentity({
+        principalId: kubeletResult.objectId,
+        subscriptionId,
+        roles: [{ role: 'AcrPull', scope: acrResourceId }],
+      });
+      if (!kubeletRoleResult.success) {
+        console.warn('Failed to assign AcrPull to kubelet identity:', kubeletRoleResult.error);
+        // Non-fatal: the user may have already configured ACR integration
+      }
+    } else {
+      console.warn('Could not resolve kubelet identity:', kubeletResult.error);
+    }
   }
 
   return identity;

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.ts
@@ -25,6 +25,8 @@ export interface EnsureIdentityWithRolesConfig {
   namespaceName?: string;
   /** Whether Azure RBAC for Kubernetes is enabled on the cluster. */
   azureRbacEnabled?: boolean;
+  /** When true, always includes AKS RBAC Writer for annotation permissions. */
+  isPipeline?: boolean;
   /** Purpose label for the resource group tags (e.g. 'GitHub Actions Identity', 'Workload Identity'). */
   purpose?: string;
   onStatusChange: (status: RoleAssignmentStatus) => void;
@@ -50,6 +52,7 @@ export async function ensureIdentityWithRoles(
     isManagedNamespace,
     namespaceName,
     azureRbacEnabled,
+    isPipeline,
     purpose,
     onStatusChange,
   } = config;
@@ -90,6 +93,7 @@ export async function ensureIdentityWithRoles(
         acrResourceId,
         isManagedNamespace: true,
         managedNamespaceResourceId: nsResult.resourceId,
+        isPipeline,
       });
     }
     return computeRequiredRoles({
@@ -99,6 +103,7 @@ export async function ensureIdentityWithRoles(
       acrResourceId,
       isManagedNamespace: false,
       azureRbacEnabled,
+      isPipeline,
     });
   })();
 

--- a/plugins/aks-desktop/src/utils/github/github-api.test.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.test.ts
@@ -1139,5 +1139,13 @@ describe('github-api', () => {
       const result = await findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main');
       expect(result).toEqual(['src/Dockerfile']);
     });
+
+    it('should propagate errors', async () => {
+      mockOctokit.git.getTree.mockRejectedValue(new Error('Server Error'));
+
+      await expect(findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main')).rejects.toThrow(
+        'Failed to search repo tree for Dockerfiles in owner/repo'
+      );
+    });
   });
 });

--- a/plugins/aks-desktop/src/utils/github/github-api.test.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.test.ts
@@ -151,12 +151,14 @@ describe('github-api', () => {
   describe('checkRepoReadiness', () => {
     it('should detect all files present', async () => {
       mockOctokit.repos.getContent.mockResolvedValue({ data: {} });
+      mockOctokit.git.getTree.mockResolvedValue({ data: { tree: [] } });
 
       const result = await checkRepoReadiness(mockOctokit as never, 'owner', 'repo', 'main');
       expect(result).toEqual({
         hasSetupWorkflow: true,
         hasAgentConfig: true,
         hasDeployWorkflow: true,
+        dockerfilePaths: [],
       });
     });
 
@@ -164,12 +166,14 @@ describe('github-api', () => {
       const notFoundError = new Error('Not Found');
       Object.assign(notFoundError, { status: 404 });
       mockOctokit.repos.getContent.mockRejectedValue(notFoundError);
+      mockOctokit.git.getTree.mockResolvedValue({ data: { tree: [] } });
 
       const result = await checkRepoReadiness(mockOctokit as never, 'owner', 'repo', 'main');
       expect(result).toEqual({
         hasSetupWorkflow: false,
         hasAgentConfig: false,
         hasDeployWorkflow: false,
+        dockerfilePaths: [],
       });
     });
 
@@ -181,13 +185,48 @@ describe('github-api', () => {
         .mockResolvedValueOnce({ data: {} }) // setup workflow exists
         .mockRejectedValueOnce(notFoundError) // agent config missing
         .mockRejectedValueOnce(notFoundError); // deploy workflow missing
+      mockOctokit.git.getTree.mockResolvedValue({ data: { tree: [] } });
 
       const result = await checkRepoReadiness(mockOctokit as never, 'owner', 'repo', 'main');
       expect(result).toEqual({
         hasSetupWorkflow: true,
         hasAgentConfig: false,
         hasDeployWorkflow: false,
+        dockerfilePaths: [],
       });
+    });
+
+    it('should include dockerfilePaths when Dockerfiles are found', async () => {
+      mockOctokit.repos.getContent.mockResolvedValue({ data: {} });
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: {
+          tree: [
+            { path: 'Dockerfile', type: 'blob' },
+            { path: 'src/api/Dockerfile', type: 'blob' },
+          ],
+        },
+      });
+
+      const result = await checkRepoReadiness(mockOctokit as never, 'owner', 'repo', 'main');
+      expect(result).toEqual({
+        hasSetupWorkflow: true,
+        hasAgentConfig: true,
+        hasDeployWorkflow: true,
+        dockerfilePaths: ['Dockerfile', 'src/api/Dockerfile'],
+      });
+    });
+
+    it('should return empty dockerfilePaths when no defaultBranch provided', async () => {
+      mockOctokit.repos.getContent.mockResolvedValue({ data: {} });
+
+      const result = await checkRepoReadiness(mockOctokit as never, 'owner', 'repo');
+      expect(result).toEqual({
+        hasSetupWorkflow: true,
+        hasAgentConfig: true,
+        hasDeployWorkflow: true,
+        dockerfilePaths: [],
+      });
+      expect(mockOctokit.git.getTree).not.toHaveBeenCalled();
     });
 
     it('should propagate non-404 errors', async () => {

--- a/plugins/aks-desktop/src/utils/github/github-api.test.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.test.ts
@@ -38,6 +38,7 @@ const mockOctokit = {
   git: {
     getRef: vi.fn(),
     createRef: vi.fn(),
+    getTree: vi.fn(),
   },
   pulls: {
     create: vi.fn(),
@@ -80,6 +81,7 @@ import {
   createOrUpdateRepoSecret,
   createPullRequest,
   dispatchWorkflow,
+  findDockerfiles,
   findLinkedPullRequest,
   getCurrentUser,
   getDefaultBranchSha,
@@ -1042,6 +1044,61 @@ describe('github-api', () => {
           SECRET: 'value',
         })
       ).rejects.toThrow('Failed to get repo public key');
+    });
+  });
+
+  describe('findDockerfiles', () => {
+    it('should find Dockerfiles in repo tree', async () => {
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: {
+          tree: [
+            { path: 'Dockerfile', type: 'blob' },
+            { path: 'src/web/Dockerfile', type: 'blob' },
+            { path: 'README.md', type: 'blob' },
+            { path: 'src', type: 'tree' },
+          ],
+        },
+      });
+
+      const result = await findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main');
+      expect(result).toEqual(['Dockerfile', 'src/web/Dockerfile']);
+    });
+
+    it('should return empty array when no Dockerfiles found', async () => {
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: { tree: [{ path: 'README.md', type: 'blob' }] },
+      });
+
+      const result = await findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main');
+      expect(result).toEqual([]);
+    });
+
+    it('should match case-insensitively', async () => {
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: {
+          tree: [
+            { path: 'dockerfile', type: 'blob' },
+            { path: 'app/DOCKERFILE', type: 'blob' },
+          ],
+        },
+      });
+
+      const result = await findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main');
+      expect(result).toEqual(['dockerfile', 'app/DOCKERFILE']);
+    });
+
+    it('should ignore directories named Dockerfile', async () => {
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: {
+          tree: [
+            { path: 'Dockerfile', type: 'tree' },
+            { path: 'src/Dockerfile', type: 'blob' },
+          ],
+        },
+      });
+
+      const result = await findDockerfiles(mockOctokit as never, 'owner', 'repo', 'main');
+      expect(result).toEqual(['src/Dockerfile']);
     });
   });
 });

--- a/plugins/aks-desktop/src/utils/github/github-api.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.ts
@@ -193,6 +193,36 @@ export async function checkAppInstallation(
   }
 }
 
+/**
+ * Searches the repo tree for files named "Dockerfile" (case-insensitive).
+ * Returns an array of paths, e.g. ['Dockerfile', 'src/web/Dockerfile'].
+ */
+export async function findDockerfiles(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string
+): Promise<string[]> {
+  try {
+    const { data } = await octokit.git.getTree({
+      owner,
+      repo,
+      tree_sha: ref,
+      recursive: '1',
+    });
+    return data.tree
+      .filter(
+        entry =>
+          entry.type === 'blob' &&
+          entry.path !== undefined &&
+          entry.path.split('/').pop()?.toLowerCase() === 'dockerfile'
+      )
+      .map(entry => entry.path!);
+  } catch (err) {
+    throw apiError(`Failed to search repo tree for Dockerfiles`, err);
+  }
+}
+
 /** Returns the SHA of the tip commit on the given branch. */
 export async function getDefaultBranchSha(
   octokit: Octokit,

--- a/plugins/aks-desktop/src/utils/github/github-api.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.ts
@@ -117,19 +117,16 @@ export async function checkRepoReadiness(
   defaultBranch?: string
 ): Promise<RepoReadiness> {
   try {
-    const [hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow] = await Promise.all([
-      fileExists(octokit, owner, repo, COPILOT_SETUP_STEPS_PATH, defaultBranch),
-      fileExists(octokit, owner, repo, AGENT_CONFIG_PATH, defaultBranch),
-      fileExists(
-        octokit,
-        owner,
-        repo,
-        `.github/workflows/${PIPELINE_WORKFLOW_FILENAME}`,
-        defaultBranch
-      ),
-    ]);
+    const ref = defaultBranch;
+    const [hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow, dockerfilePaths] =
+      await Promise.all([
+        fileExists(octokit, owner, repo, COPILOT_SETUP_STEPS_PATH, ref),
+        fileExists(octokit, owner, repo, AGENT_CONFIG_PATH, ref),
+        fileExists(octokit, owner, repo, `.github/workflows/${PIPELINE_WORKFLOW_FILENAME}`, ref),
+        ref ? findDockerfiles(octokit, owner, repo, ref) : Promise.resolve([]),
+      ]);
 
-    return { hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow };
+    return { hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow, dockerfilePaths };
   } catch (error) {
     throw apiError(`Failed to check repo readiness for ${owner}/${repo}`, error);
   }

--- a/plugins/aks-desktop/src/utils/github/github-api.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.ts
@@ -117,13 +117,18 @@ export async function checkRepoReadiness(
   defaultBranch?: string
 ): Promise<RepoReadiness> {
   try {
-    const ref = defaultBranch;
     const [hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow, dockerfilePaths] =
       await Promise.all([
-        fileExists(octokit, owner, repo, COPILOT_SETUP_STEPS_PATH, ref),
-        fileExists(octokit, owner, repo, AGENT_CONFIG_PATH, ref),
-        fileExists(octokit, owner, repo, `.github/workflows/${PIPELINE_WORKFLOW_FILENAME}`, ref),
-        ref ? findDockerfiles(octokit, owner, repo, ref) : Promise.resolve([]),
+        fileExists(octokit, owner, repo, COPILOT_SETUP_STEPS_PATH, defaultBranch),
+        fileExists(octokit, owner, repo, AGENT_CONFIG_PATH, defaultBranch),
+        fileExists(
+          octokit,
+          owner,
+          repo,
+          `.github/workflows/${PIPELINE_WORKFLOW_FILENAME}`,
+          defaultBranch
+        ),
+        defaultBranch ? findDockerfiles(octokit, owner, repo, defaultBranch) : Promise.resolve([]),
       ]);
 
     return { hasSetupWorkflow, hasAgentConfig, hasDeployWorkflow, dockerfilePaths };
@@ -207,6 +212,11 @@ export async function findDockerfiles(
       tree_sha: ref,
       recursive: '1',
     });
+    if (data.truncated) {
+      console.warn(
+        `Repository tree for ${owner}/${repo} was truncated; Dockerfile list may be incomplete`
+      );
+    }
     return data.tree
       .filter(
         entry =>
@@ -216,7 +226,7 @@ export async function findDockerfiles(
       )
       .map(entry => entry.path!);
   } catch (err) {
-    throw apiError(`Failed to search repo tree for Dockerfiles`, err);
+    throw apiError(`Failed to search repo tree for Dockerfiles in ${owner}/${repo}`, err);
   }
 }
 


### PR DESCRIPTION
## Summary

Core state machine and orchestration for the fast path pipeline — deterministic deploy flow that bypasses the Copilot agent when a Dockerfile is detected.

- **`useFastPathPipelineState`** — 9-state reducer with transition table, localStorage persistence, RETRY logic, and transient state handling (mirrors `useGitHubPipelineState` patterns)
- **`createFastPathPR`** — creates branch, generates workflow + K8s manifests from templates, pushes all files as single PR, cleans up branch on failure
- **`useFastPathOrchestration`** — wires state machine + PR polling + workflow polling + deployment health; handles `handleDeploy` (secrets → generate → PR → poll) and `handleRedeploy` callbacks with in-flight guards

## Changes Made

- New `hooks/useFastPathPipelineState.ts` — state types, reducer, persistence, action dispatchers
- New `hooks/useFastPathOrchestration.ts` — main orchestration hook with effect-driven transitions
- New `utils/fastPathOrchestration.ts` — `createFastPathPR()` utility with ACR name derivation
- Tests for all three (33 new tests total)

## Dependencies

⚠️ Based on octopus merge of PRs #561, #562, #564. Will need rebase after those merge.

## Related Issues

Part of #557 (Fast Path Pipeline)
Closes #553

## Test Plan

- [x] State machine: 19 tests — transitions, guards, RETRY, persistence, schema validation
- [x] `createFastPathPR`: 8 tests — branch/file creation, PR body, cleanup, ACR derivation
- [x] Orchestration hook: 6 tests — happy path, error handling, in-flight guard, PR merge transition
- [x] Type check passes
- [x] Lint passes

