### PR TITLE
LogsTab: Extract hook, add docs and tests

### DIFF
--- a/plugins/aks-desktop/src/components/LogsTab/LogsTab.tsx
+++ b/plugins/aks-desktop/src/components/LogsTab/LogsTab.tsx
@@ -6,36 +6,38 @@ import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 // @ts-ignore todo: LogsViewer is not importing
 import { LogsViewer } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { type KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
-import { Box, Card, MenuItem, TextField, Typography } from '@mui/material';
+import { Box, Card, Typography } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-import React, { useEffect, useMemo, useState } from 'react';
+import React from 'react';
+import { DeploymentSelector } from '../shared/DeploymentSelector';
+import { useLogsTab } from './hooks/useLogsTab';
 
+/**
+ * Props for the {@link LogsTab} component.
+ */
 interface LogsTabProps {
+  /** All Kubernetes resources for the project; Deployments are filtered from this list. */
   projectResources: KubeObject[];
 }
 
+/**
+ * Displays live logs for a deployment in the project namespace.
+ *
+ * Shows an empty state when no deployments exist. When multiple deployments are present,
+ * renders a selector so the user can switch between them. Uses a visually-hidden live
+ * region to announce the empty state to screen readers.
+ *
+ * @param props.projectResources - All project resources; Deployments are extracted internally.
+ */
 const LogsTab = ({ projectResources }: LogsTabProps) => {
   const { t } = useTranslation();
-  const deployments = useMemo(
-    () => projectResources.filter(it => it.kind === 'Deployment'),
-    [projectResources]
-  );
-  const [deploymentId, setDeploymentId] = useState<string>('');
-  // Deferred flag: starts false so the live region mounts with empty text,
-  // then flips to true after the first paint so the text change is announced.
-  const [liveReady, setLiveReady] = useState(false);
-  useEffect(() => {
-    setLiveReady(true);
-  }, []);
-
-  if (!deploymentId && deployments.length > 0) {
-    setDeploymentId(deployments[0].jsonData.metadata.uid as string);
-  }
-
-  const selectedDeployment = useMemo(
-    () => deployments.find(it => it.jsonData.metadata.uid === deploymentId),
-    [deployments, deploymentId]
-  );
+  const {
+    deployments,
+    selectedDeployment,
+    selectedDeploymentName,
+    liveReady,
+    setSelectedDeploymentName,
+  } = useLogsTab(projectResources);
 
   return (
     <>
@@ -72,20 +74,12 @@ const LogsTab = ({ projectResources }: LogsTabProps) => {
         <>
           {deployments.length > 1 && (
             <Box sx={{ p: 2, px: 1 }}>
-              <TextField
-                select
-                size="small"
-                variant="outlined"
-                onChange={e => setDeploymentId(e.target.value)}
-                value={deploymentId}
-                label={t('Deployment')}
-              >
-                {deployments.map(d => (
-                  <MenuItem key={d.jsonData.metadata.uid} value={d.jsonData.metadata.uid}>
-                    {d.jsonData.metadata.name}
-                  </MenuItem>
-                ))}
-              </TextField>
+              <DeploymentSelector
+                selectedDeployment={selectedDeploymentName}
+                deployments={deployments.map(d => ({ name: d.jsonData.metadata.name as string }))}
+                onDeploymentChange={setSelectedDeploymentName}
+                suppressLiveRegion
+              />
             </Box>
           )}
           {selectedDeployment && (

--- a/plugins/aks-desktop/src/components/LogsTab/hooks/useLogsTab.test.ts
+++ b/plugins/aks-desktop/src/components/LogsTab/hooks/useLogsTab.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { useLogsTab } from './useLogsTab';
+
+/** Helper to create a minimal KubeObject-shaped resource. */
+function makeResource(kind: string, name: string, uid = `uid-${name}`) {
+  return {
+    kind,
+    jsonData: { metadata: { name, uid } },
+  } as any;
+}
+
+describe('useLogsTab', () => {
+  test('returns empty deployments when projectResources is empty', () => {
+    const { result } = renderHook(() => useLogsTab([]));
+
+    expect(result.current.deployments).toHaveLength(0);
+    expect(result.current.selectedDeployment).toBeUndefined();
+    expect(result.current.selectedDeploymentName).toBe('');
+  });
+
+  test('filters only Deployment resources from projectResources', () => {
+    const resources = [
+      makeResource('Deployment', 'app-1'),
+      makeResource('Service', 'svc-1'),
+      makeResource('Deployment', 'app-2'),
+      makeResource('ConfigMap', 'cm-1'),
+    ];
+
+    const { result } = renderHook(() => useLogsTab(resources));
+
+    expect(result.current.deployments).toHaveLength(2);
+    expect(result.current.deployments[0].jsonData.metadata.name).toBe('app-1');
+    expect(result.current.deployments[1].jsonData.metadata.name).toBe('app-2');
+  });
+
+  test('auto-selects the first deployment', () => {
+    const resources = [makeResource('Deployment', 'app-1'), makeResource('Deployment', 'app-2')];
+
+    const { result } = renderHook(() => useLogsTab(resources));
+
+    expect(result.current.selectedDeploymentName).toBe('app-1');
+    expect(result.current.selectedDeployment?.jsonData.metadata.name).toBe('app-1');
+  });
+
+  test('setSelectedDeploymentName updates the selected deployment', () => {
+    const resources = [makeResource('Deployment', 'app-1'), makeResource('Deployment', 'app-2')];
+
+    const { result } = renderHook(() => useLogsTab(resources));
+
+    expect(result.current.selectedDeploymentName).toBe('app-1');
+
+    act(() => result.current.setSelectedDeploymentName('app-2'));
+
+    expect(result.current.selectedDeploymentName).toBe('app-2');
+    expect(result.current.selectedDeployment?.jsonData.metadata.name).toBe('app-2');
+  });
+
+  test('does not overwrite a manually selected deployment when resources update', () => {
+    const resources = [makeResource('Deployment', 'app-1'), makeResource('Deployment', 'app-2')];
+    const { result, rerender } = renderHook(({ r }) => useLogsTab(r), {
+      initialProps: { r: resources },
+    });
+
+    act(() => result.current.setSelectedDeploymentName('app-2'));
+
+    // Simulate a resources update (e.g. watcher push) with the same deployments
+    rerender({ r: [...resources] });
+
+    expect(result.current.selectedDeploymentName).toBe('app-2');
+  });
+
+  test('liveReady is true after mount effects have run', async () => {
+    const { result } = renderHook(() => useLogsTab([]));
+
+    await act(async () => {});
+    expect(result.current.liveReady).toBe(true);
+  });
+
+  test('re-selects first deployment when the selected deployment is removed', () => {
+    const app1 = makeResource('Deployment', 'app-1');
+    const app2 = makeResource('Deployment', 'app-2');
+    const { result, rerender } = renderHook(({ r }) => useLogsTab(r), {
+      initialProps: { r: [app1, app2] },
+    });
+
+    act(() => result.current.setSelectedDeploymentName('app-2'));
+    expect(result.current.selectedDeploymentName).toBe('app-2');
+
+    // app-2 is removed from resources
+    rerender({ r: [app1] });
+
+    expect(result.current.selectedDeploymentName).toBe('app-1');
+    expect(result.current.selectedDeployment?.jsonData.metadata.name).toBe('app-1');
+  });
+});

--- a/plugins/aks-desktop/src/components/LogsTab/hooks/useLogsTab.ts
+++ b/plugins/aks-desktop/src/components/LogsTab/hooks/useLogsTab.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { type KubeObject } from '@kinvolk/headlamp-plugin/lib/lib/k8s/cluster';
+import { useEffect, useMemo, useState } from 'react';
+
+/**
+ * Return type for the {@link useLogsTab} hook.
+ */
+export interface UseLogsTabResult {
+  /** Deployments filtered from the provided project resources. */
+  deployments: KubeObject[];
+  /** The currently selected deployment, or undefined if none. */
+  selectedDeployment: KubeObject | undefined;
+  /** Name of the currently selected deployment, or an empty string if none is available. */
+  selectedDeploymentName: string;
+  /**
+   * Deferred flag that starts false so the live region mounts with empty text,
+   * then flips to true after the first paint so empty-state text changes are announced.
+   */
+  liveReady: boolean;
+  /** Updates the selected deployment by name. */
+  setSelectedDeploymentName: (name: string) => void;
+}
+
+/**
+ * Manages deployment filtering and selection state for the LogsTab component.
+ *
+ * Filters Deployments from the provided project resources and auto-selects the first
+ * one when none is selected. Also manages the deferred live-region flag used to
+ * announce the empty state to screen readers without a false announcement on mount.
+ *
+ * @param projectResources - All Kubernetes resources for the project; Deployments are extracted internally.
+ * @returns Filtered deployments, the resolved selected deployment object, selection state, and a setter.
+ */
+export const useLogsTab = (projectResources: KubeObject[]): UseLogsTabResult => {
+  const deployments = useMemo(
+    () => projectResources.filter(it => it.kind === 'Deployment'),
+    [projectResources]
+  );
+
+  const [selectedDeploymentName, setSelectedDeploymentName] = useState<string>('');
+  const [liveReady, setLiveReady] = useState(false);
+
+  useEffect(() => {
+    setLiveReady(true);
+  }, []);
+
+  // Auto-select first deployment when none is selected or the selected name no longer exists
+  useEffect(() => {
+    if (deployments.length === 0) return;
+    const stillExists = deployments.some(d => d.jsonData.metadata.name === selectedDeploymentName);
+    if (!stillExists) {
+      setSelectedDeploymentName(deployments[0].jsonData.metadata.name as string);
+    }
+  }, [deployments, selectedDeploymentName]);
+
+  const selectedDeployment = useMemo(
+    () => deployments.find(it => it.jsonData.metadata.name === selectedDeploymentName),
+    [deployments, selectedDeploymentName]
+  );
+
+  return {
+    deployments,
+    selectedDeployment,
+    selectedDeploymentName,
+    liveReady,
+    setSelectedDeploymentName,
+  };
+};


### PR DESCRIPTION
These changes extract all logic from `LogsTab` into a dedicated `useLogsTab` hook and replace the inline deployment dropdown with the shared `DeploymentSelector` deployment.

Fixes: #127 

### Summary

- Extracts deployment filtering, selection state, and live-region timing into `useLogsTab`
- Replaces inline `TextField` select with the shared `DeploymentSelector` component, passing `suppressLiveRegion` to avoid duplicate screen reader announcements
- Fixes a React anti-pattern where `setDeploymentId` was called during render; auto-selection now happens in a `useEffect`
- Fixes stale selection when a selected deployment is removed; the hook now falls back to the first available deployment
- Switches selection key from UID to deployment name, consistent with `ScalingTab`
- Adds TSDoc to `LogsTab`, `LogsTabProps`, and `useLogsTab` matching the codebase standard
- Adds 7 unit tests for the hook covering filtering, auto-selection, manual selection, rerender stability, and live-region state

### Testing
- [x] Run `cd plugins/aks-desktop && npm test` and ensure the tests pass