### PR TITLE
aksd: frontend: Fix selected source icon contrast in DeployWizrd

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/components/SourceStep.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/SourceStep.tsx
@@ -135,7 +135,7 @@ export default function SourceStep({ sourceType, onSourceTypeChange }: SourceSte
                       icon={iconName}
                       width={36}
                       height={36}
-                      color="contrastText"
+                      color={theme.palette.primary[selected ? 'contrastText' : 'main']}
                       aria-hidden="true"
                     />
                   </Box>


### PR DESCRIPTION
## Description

Noticed a small visual inconsistency in DeployWizard source selection step- the selected item's icon didn't change to proper contrasting colors for the background in some themes- leading to a visual blank box upon selection. (More noticeable in high contrast themes like Dark / Monochrome Light)

Current state:

<img width="1259" height="386" alt="image" src="https://github.com/user-attachments/assets/a7741a47-e988-4234-9180-f00df6103163" />
<img width="1301" height="405" alt="image" src="https://github.com/user-attachments/assets/e7f317c4-f304-4a44-9ed5-9406d0514c1a" />


Really minor issue- looks like the 'contrastText' property was hardcoded (presumably to be auto-handled by electron?), so color switches weren't consistent theme wide. 

This PR swaps out the hardcoded styling for a state aware color selection from the palette to specifically use either contrastText or main.

Post-fix:

<img width="1269" height="400" alt="image" src="https://github.com/user-attachments/assets/809147bb-9110-4a7d-9478-6898ab3816aa" />
<img width="1286" height="394" alt="image" src="https://github.com/user-attachments/assets/a28f5af6-1877-49c3-b17f-2e2cde445e5f" />

