### PR TITLE
aks-desktop: Optimize vitest test config

### DIFF
--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/libsodium-wrappers": "^0.7.14",
         "@types/react": "^19.2.0",
+        "@vitest/coverage-istanbul": "^3.2.4",
         "eslint-plugin-no-barrel-files": "^1.2.2",
         "jsdom": "^24.1.3",
         "react": "^18.3.1",
@@ -2012,9 +2013,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17284,18 +17285,54 @@
       "license": "MIT"
     },
     "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
+        "minimatch": "^10.2.2"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-decoder": {

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -12,7 +12,7 @@
     "tsc": "headlamp-plugin tsc",
     "storybook": "headlamp-plugin storybook",
     "storybook-build": "headlamp-plugin storybook-build",
-    "test": "headlamp-plugin test",
+    "test": "vitest run -c vitest.config.ts",
     "prettier": "prettier --write .",
     "i18n": "headlamp-plugin i18n"
   },

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -13,6 +13,8 @@
     "storybook": "headlamp-plugin storybook",
     "storybook-build": "headlamp-plugin storybook-build",
     "test": "vitest run -c vitest.config.ts",
+    "test:unit": "vitest run -c vitest.config.ts --project unit",
+    "test:a11y": "vitest run -c vitest.config.ts --project a11y",
     "prettier": "prettier --write .",
     "i18n": "headlamp-plugin i18n"
   },

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run -c vitest.config.ts",
     "test:unit": "vitest run -c vitest.config.ts --project unit",
     "test:a11y": "vitest run -c vitest.config.ts --project a11y",
+    "test:coverage": "vitest run -c vitest.config.ts --coverage",
     "prettier": "prettier --write .",
     "i18n": "headlamp-plugin i18n"
   },
@@ -51,6 +52,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/libsodium-wrappers": "^0.7.14",
     "@types/react": "^19.2.0",
+    "@vitest/coverage-istanbul": "^3.2.4",
     "eslint-plugin-no-barrel-files": "^1.2.2",
     "jsdom": "^24.1.3",
     "react": "^18.3.1",

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Virtual screen-reader tests for {@link RegisterAKSClusterDialogPure}.
  *

--- a/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.test.tsx
+++ b/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ClusterConfigurePanel.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ClusterConfigurePanel.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/CreateAKSProjectPure.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/CreateAKSProjectPure.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Screen reader tests using {@link https://www.guidepup.dev/docs/virtual
  * @guidepup/virtual-screen-reader}.

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/CreateAKSProjectPure.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/CreateAKSProjectPure.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Interaction tests for {@link CreateAKSProjectPure}.
  *

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useClusterCapabilities.test.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useClusterCapabilities.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.test.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 

--- a/plugins/aks-desktop/src/components/DeleteAKSProject/hooks/useProjectDeletion.test.ts
+++ b/plugins/aks-desktop/src/components/DeleteAKSProject/hooks/useProjectDeletion.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/DeleteAKSProject/hooks/useProjectPermissions.test.ts
+++ b/plugins/aks-desktop/src/components/DeleteAKSProject/hooks/useProjectPermissions.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.test.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';

--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Virtual screen-reader tests for {@link ConfigureYAML}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Virtual screen-reader tests for {@link DeployPure}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Interaction tests for {@link DeployPure}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Virtual screen-reader tests for {@link DeployWizardPure}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Interaction tests for {@link DeployWizardPure}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/components/SourceStep.guidepup.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/SourceStep.guidepup.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 /**
  * Virtual screen-reader tests for {@link SourceStep}.
  *

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.test.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWorkloadIdentity.test.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWorkloadIdentity.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.test.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/components/WorkloadIdentitySetup.test.tsx
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/components/WorkloadIdentitySetup.test.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineState.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineState.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PipelineConfig, PipelineState } from '../types';

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useWorkloadIdentitySetup.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/pipelineStorage.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/pipelineStorage.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SCHEMA_VERSION, STORAGE_KEY_PREFIX } from '../constants';
 import {

--- a/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/ImportAKSProjects.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';

--- a/plugins/aks-desktop/src/components/ImportAKSProjects/components/ConversionDialog.test.tsx
+++ b/plugins/aks-desktop/src/components/ImportAKSProjects/components/ConversionDialog.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';

--- a/plugins/aks-desktop/src/components/Metrics/hooks/useDeployments.test.ts
+++ b/plugins/aks-desktop/src/components/Metrics/hooks/useDeployments.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/Metrics/hooks/useNamespaceLabels.test.ts
+++ b/plugins/aks-desktop/src/components/Metrics/hooks/useNamespaceLabels.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/Metrics/hooks/usePods.test.ts
+++ b/plugins/aks-desktop/src/components/Metrics/hooks/usePods.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/Metrics/hooks/usePrometheusMetrics.test.ts
+++ b/plugins/aks-desktop/src/components/Metrics/hooks/usePrometheusMetrics.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.test.ts
+++ b/plugins/aks-desktop/src/components/Scaling/hooks/useChartData.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { clearChartDataCaches, useChartData } from './useChartData';

--- a/plugins/aks-desktop/src/hooks/useAzureContext.test.ts
+++ b/plugins/aks-desktop/src/hooks/useAzureContext.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAzureContext } from './useAzureContext';

--- a/plugins/aks-desktop/src/hooks/useNamespaceCapabilities.test.ts
+++ b/plugins/aks-desktop/src/hooks/useNamespaceCapabilities.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/hooks/useNamespaceDiscovery.test.ts
+++ b/plugins/aks-desktop/src/hooks/useNamespaceDiscovery.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/hooks/usePreviewFeatures.test.ts
+++ b/plugins/aks-desktop/src/hooks/usePreviewFeatures.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/hooks/useRegisteredClusters.test.ts
+++ b/plugins/aks-desktop/src/hooks/useRegisteredClusters.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { cleanup, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 

--- a/plugins/aks-desktop/src/utils/azure/identitySetup.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identitySetup.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockResourceGroupExists = vi.fn();

--- a/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/identityWithRoles.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockResourceGroupExists = vi.fn();

--- a/plugins/aks-desktop/src/utils/github/github-auth.test.ts
+++ b/plugins/aks-desktop/src/utils/github/github-auth.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearTokens,

--- a/plugins/aks-desktop/src/utils/shared/openExternalUrl.test.ts
+++ b/plugins/aks-desktop/src/utils/shared/openExternalUrl.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openExternalUrl } from './openExternalUrl';
 

--- a/plugins/aks-desktop/src/utils/test/clusterSettings.test.ts
+++ b/plugins/aks-desktop/src/utils/test/clusterSettings.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// @vitest-environment jsdom
 import { afterEach, describe, expect, test } from 'vitest';
 import { getClusterSettings, setClusterSettings } from '../shared/clusterSettings';
 

--- a/plugins/aks-desktop/vitest.config.ts
+++ b/plugins/aks-desktop/vitest.config.ts
@@ -1,0 +1,11 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: 'node_modules/@kinvolk/headlamp-plugin/config/setupTests.js',
+    clearMocks: true,
+  },
+});

--- a/plugins/aks-desktop/vitest.config.ts
+++ b/plugins/aks-desktop/vitest.config.ts
@@ -4,8 +4,26 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'jsdom',
-    setupFiles: 'node_modules/@kinvolk/headlamp-plugin/config/setupTests.js',
     clearMocks: true,
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          environment: 'jsdom',
+          setupFiles: 'node_modules/@kinvolk/headlamp-plugin/config/setupTests.js',
+          include: ['src/**/*.test.{ts,tsx}'],
+          exclude: ['src/**/*.guidepup.test.tsx'],
+        },
+      },
+      {
+        test: {
+          name: 'a11y',
+          environment: 'jsdom',
+          setupFiles: 'node_modules/@kinvolk/headlamp-plugin/config/setupTests.js',
+          include: ['src/**/*.guidepup.test.tsx'],
+          testTimeout: 30000,
+        },
+      },
+    ],
   },
 });

--- a/plugins/aks-desktop/vitest.config.ts
+++ b/plugins/aks-desktop/vitest.config.ts
@@ -1,10 +1,20 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vitest/config';
+import { coverageConfigDefaults,defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     clearMocks: true,
+    coverage: {
+      provider: 'istanbul',
+      reporter: [['text', { maxCols: 200 }], ['html']],
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        'src/**/*.stories*.{ts,tsx}',
+        'src/**/*.guidepup.test.tsx',
+      ],
+      include: ['src/**/*.{ts,tsx}'],
+    },
     projects: [
       {
         test: {


### PR DESCRIPTION
These changes improve the vitest test setup for `aks-desktop` by enabling mock isolation, separating slow a11y tests, and adding coverage reporting.

### Summary

- Introduces `vitest.config.ts` to replace the inherited `headlamp-plugin` test config
- Enables `clearMocks: true` globally to prevent mock state from leaking between tests
- Splits tests into `unit` and `a11y` projects so guidepup a11y tests can be run independently
- Adds `@vitest/coverage-istanbul` and coverage configuration matching Headlamp's frontend setup
- Adds `test:unit`, `test:a11y`, and `test:coverage` npm scripts
- Removes 40 redundant `@vitest-environment jsdom` annotations across test files

### Testing

- [x] Run `cd plugins/aks-desktop && npm test` and ensure all tests pass
- [x] Run `npm run test:unit` and verify only unit tests run
- [x] Run `npm run test:a11y` and verify only guidepup tests run
- [x] Run `npm run test:coverage` and verify a coverage report is generated