### PR TITLE
AzureProfilePage: Extract hooks, add docs and tests

### DIFF
--- a/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
@@ -13,60 +13,35 @@ import {
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
-import { useAzureAuth } from '../../hooks/useAzureAuth';
-import { PROFILE_REDIRECT_DELAY_MS } from '../../utils/constants/timing';
+import React from 'react';
+import { useAzureProfilePage } from './hooks/useAzureProfilePage';
 
+/**
+ * Azure Profile page.
+ *
+ * Displays the logged-in user's Azure account details and provides actions to
+ * add a cluster or log out. Redirects to `/azure/login` when the user is not
+ * authenticated.
+ *
+ * All stateful logic (auth state, logout flow, navigation, redirect guard)
+ * lives in {@link useAzureProfilePage}.
+ */
 export default function AzureProfilePage() {
-  const history = useHistory();
   const { t } = useTranslation();
-  const authStatus = useAzureAuth();
-  const [loggingOut, setLoggingOut] = useState(false);
   const theme = useTheme();
+  const {
+    isChecking,
+    isLoggedIn,
+    username,
+    tenantId,
+    subscriptionId,
+    loggingOut,
+    handleBack,
+    handleAddCluster,
+    handleLogout,
+  } = useAzureProfilePage();
 
-  const handleBack = () => {
-    history.push('/');
-  };
-
-  const handleAddCluster = () => {
-    history.push('/add-cluster-aks');
-  };
-
-  const handleLogout = async () => {
-    setLoggingOut(true);
-    try {
-      // Import dynamically to avoid circular dependencies
-      const { runCommandAsync } = await import('../../utils/azure/az-cli-core');
-      const result = await runCommandAsync('az', ['logout']);
-
-      if (result.stderr && result.stderr.includes('ERROR:')) {
-        console.error('Azure CLI logout error:', result.stderr);
-        setLoggingOut(false);
-        return;
-      }
-
-      // Trigger update event for sidebar label
-      window.dispatchEvent(new CustomEvent('azure-auth-update'));
-
-      // Redirect to login page after logout
-      setTimeout(() => {
-        history.push('/azure/login');
-      }, PROFILE_REDIRECT_DELAY_MS);
-    } catch (error) {
-      console.error('Error logging out:', error);
-      setLoggingOut(false);
-    }
-  };
-
-  // Redirect to login page if not logged in
-  React.useEffect(() => {
-    if (!authStatus.isChecking && !authStatus.isLoggedIn) {
-      history.push('/azure/login');
-    }
-  }, [authStatus.isChecking, authStatus.isLoggedIn, history]);
-
-  if (authStatus.isChecking) {
+  if (isChecking) {
     return (
       <Box
         sx={{
@@ -96,7 +71,7 @@ export default function AzureProfilePage() {
   }
 
   // Don't render anything if not logged in (will redirect)
-  if (!authStatus.isLoggedIn) {
+  if (!isLoggedIn) {
     return null;
   }
 
@@ -151,10 +126,10 @@ export default function AzureProfilePage() {
             </Typography>
 
             <Typography variant="body1" sx={{ mb: 3, color: theme.palette.text.secondary }}>
-              {t('Logged in as')} <strong>{authStatus.username}</strong>
+              {t('Logged in as')} <strong>{username}</strong>
             </Typography>
 
-            {authStatus.tenantId && (
+            {tenantId && (
               <Box
                 sx={{
                   mb: 3,
@@ -175,12 +150,12 @@ export default function AzureProfilePage() {
                   Tenant ID
                 </Typography>
                 <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
-                  {authStatus.tenantId}
+                  {tenantId}
                 </Typography>
               </Box>
             )}
 
-            {authStatus.subscriptionId && (
+            {subscriptionId && (
               <Box
                 sx={{
                   mb: 3,
@@ -201,7 +176,7 @@ export default function AzureProfilePage() {
                   Default Subscription ID
                 </Typography>
                 <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
-                  {authStatus.subscriptionId}
+                  {subscriptionId}
                 </Typography>
               </Box>
             )}

--- a/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
@@ -1,20 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { Icon, InlineIcon } from '@iconify/react';
+import { Icon } from '@iconify/react';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CircularProgress,
-  Container,
-  Typography,
-} from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { Box, Button, Card, CircularProgress, Container, Typography } from '@mui/material';
 import React from 'react';
 import { useAzureProfilePage } from './hooks/useAzureProfilePage';
+
+const pageSx = { minHeight: '100vh', backgroundColor: 'background.default', pt: 2 } as const;
+const infoBoxSx = {
+  mb: 3,
+  p: 2,
+  border: 1,
+  borderColor: 'divider',
+  borderRadius: 1,
+  textAlign: 'left',
+} as const;
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Box sx={infoBoxSx}>
+      <Typography variant="caption" sx={{ fontWeight: 600, mb: 0.5, color: 'text.secondary' }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
 
 /**
  * Azure Profile page.
@@ -28,7 +42,6 @@ import { useAzureProfilePage } from './hooks/useAzureProfilePage';
  */
 export default function AzureProfilePage() {
   const { t } = useTranslation();
-  const theme = useTheme();
   const {
     isChecking,
     isLoggedIn,
@@ -43,13 +56,7 @@ export default function AzureProfilePage() {
 
   if (isChecking) {
     return (
-      <Box
-        sx={{
-          minHeight: '100vh',
-          backgroundColor: theme.palette.background.default,
-          pt: 2,
-        }}
-      >
+      <Box sx={pageSx}>
         <Container maxWidth="sm">
           <Box
             sx={{
@@ -76,134 +83,77 @@ export default function AzureProfilePage() {
   }
 
   return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        backgroundColor: theme.palette.background.default,
-        pt: 2,
-      }}
-    >
+    <Box sx={pageSx}>
       <Container maxWidth="sm">
-        {/* Back Button */}
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-          <Box
-            onClick={handleBack}
-            role="button"
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'pointer',
-              color: theme.palette.text.secondary,
-              '&:hover': {
-                color: theme.palette.primary.main,
-              },
-            }}
-          >
-            <Box pt={0.5}>
-              <InlineIcon icon="mdi:chevron-left" height={20} width={20} />
-            </Box>
-            <Box fontSize={14} sx={{ textTransform: 'uppercase' }}>
-              {t('Back')}
-            </Box>
-          </Box>
-        </Box>
+        <Button
+          variant="text"
+          onClick={handleBack}
+          startIcon={<Icon icon="mdi:chevron-left" height={20} width={20} aria-hidden="true" />}
+          sx={{
+            mb: 3,
+            color: 'text.secondary',
+            textTransform: 'uppercase',
+            fontSize: 14,
+            '&:hover': { color: 'primary.main' },
+          }}
+        >
+          {t('Back')}
+        </Button>
 
         <Card sx={{ textAlign: 'center', p: 4 }}>
-          <CardContent>
-            <Box
-              component={Icon}
-              icon="logos:microsoft-azure"
-              sx={{
-                fontSize: 64,
-                color: 'primary.main',
-                mb: 2,
-                display: 'inline-block',
-              }}
-            />
+          <Box
+            component={Icon}
+            icon="logos:microsoft-azure"
+            aria-hidden="true"
+            sx={{
+              fontSize: 64,
+              color: 'primary.main',
+              mb: 2,
+              display: 'block',
+              mx: 'auto',
+            }}
+          />
 
-            <Typography variant="h4" sx={{ mb: 1, fontWeight: 600 }}>
-              {t('Azure Account')}
-            </Typography>
+          <Typography variant="h4" sx={{ mb: 1, fontWeight: 600 }}>
+            {t('Azure Account')}
+          </Typography>
 
-            <Typography variant="body1" sx={{ mb: 3, color: theme.palette.text.secondary }}>
-              {t('Logged in as')} <strong>{username}</strong>
-            </Typography>
+          <Typography variant="body1" sx={{ mb: 3, color: 'text.secondary' }}>
+            {t('Logged in as')} <strong>{username}</strong>
+          </Typography>
 
-            {tenantId && (
-              <Box
-                sx={{
-                  mb: 3,
-                  p: 2,
-                  backgroundColor: theme.palette.action.hover,
-                  borderRadius: theme.shape.borderRadius,
-                  textAlign: 'left',
-                }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{
-                    fontWeight: 600,
-                    mb: 0.5,
-                    color: theme.palette.text.secondary,
-                  }}
-                >
-                  Tenant ID
-                </Typography>
-                <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
-                  {tenantId}
-                </Typography>
-              </Box>
-            )}
+          {tenantId && <InfoRow label="Tenant ID" value={tenantId} />}
 
-            {subscriptionId && (
-              <Box
-                sx={{
-                  mb: 3,
-                  p: 2,
-                  backgroundColor: theme.palette.action.hover,
-                  borderRadius: theme.shape.borderRadius,
-                  textAlign: 'left',
-                }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{
-                    fontWeight: 600,
-                    mb: 0.5,
-                    color: theme.palette.text.secondary,
-                  }}
-                >
-                  Default Subscription ID
-                </Typography>
-                <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
-                  {subscriptionId}
-                </Typography>
-              </Box>
-            )}
+          {subscriptionId && <InfoRow label="Default Subscription ID" value={subscriptionId} />}
 
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 3 }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleAddCluster}
-                startIcon={<Icon icon="mdi:cloud-plus" />}
-                sx={{ p: 1.5, textTransform: 'none', fontSize: 16 }}
-              >
-                {t('Add Cluster from Azure')}
-              </Button>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 3 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleAddCluster}
+              startIcon={<Icon icon="mdi:cloud-plus" aria-hidden="true" />}
+              sx={{ p: 1.5, textTransform: 'none', fontSize: 16 }}
+            >
+              {t('Add Cluster from Azure')}
+            </Button>
 
-              <Button
-                variant="outlined"
-                color="primary"
-                onClick={handleLogout}
-                disabled={loggingOut}
-                startIcon={loggingOut ? <CircularProgress size={20} /> : <Icon icon="mdi:logout" />}
-                sx={{ p: 1.5, textTransform: 'none', fontSize: 16 }}
-              >
-                {loggingOut ? `${t('Logging out')}...` : t('Log out')}
-              </Button>
-            </Box>
-          </CardContent>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={handleLogout}
+              disabled={loggingOut}
+              startIcon={
+                loggingOut ? (
+                  <CircularProgress size={20} aria-hidden="true" />
+                ) : (
+                  <Icon icon="mdi:logout" aria-hidden="true" />
+                )
+              }
+              sx={{ p: 1.5, textTransform: 'none', fontSize: 16 }}
+            >
+              {loggingOut ? `${t('Logging out')}...` : t('Log out')}
+            </Button>
+          </Box>
         </Card>
       </Container>
     </Box>

--- a/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureProfilePage.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@iconify/react';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Box, Button, Card, CircularProgress, Container, Typography } from '@mui/material';
 import React from 'react';
+import { CopyButton } from '../shared/CopyButton';
 import { useAzureProfilePage } from './hooks/useAzureProfilePage';
 
 const pageSx = { minHeight: '100vh', backgroundColor: 'background.default', pt: 2 } as const;
@@ -20,9 +21,12 @@ const infoBoxSx = {
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
     <Box sx={infoBoxSx}>
-      <Typography variant="caption" sx={{ fontWeight: 600, mb: 0.5, color: 'text.secondary' }}>
-        {label}
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
+        <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+          {label}
+        </Typography>
+        <CopyButton text={value} />
+      </Box>
       <Typography variant="body2" sx={{ fontSize: '1rem', wordBreak: 'break-all' }}>
         {value}
       </Typography>

--- a/plugins/aks-desktop/src/components/AzureAuth/hooks/useAzureProfilePage.test.ts
+++ b/plugins/aks-desktop/src/components/AzureAuth/hooks/useAzureProfilePage.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockUseAzureAuth = vi.hoisted(() => vi.fn());
+const mockRunCommandAsync = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', () => ({
+  useHistory: () => ({ push: mockPush }),
+}));
+
+vi.mock('../../../hooks/useAzureAuth', () => ({
+  useAzureAuth: mockUseAzureAuth,
+}));
+
+// Covers the dynamic import inside handleLogout.
+vi.mock('../../../utils/azure/az-cli-core', () => ({
+  runCommandAsync: mockRunCommandAsync,
+  isAzError: (stderr: string) => stderr.includes('ERROR:'),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Import after mocks are in place
+import { useAzureProfilePage } from './useAzureProfilePage';
+
+const AUTH_LOGGED_IN = {
+  isChecking: false,
+  isLoggedIn: true,
+  username: 'user@contoso.com',
+  tenantId: 'tenant-abc',
+  subscriptionId: 'sub-123',
+};
+
+const AUTH_CHECKING = {
+  isChecking: true,
+  isLoggedIn: false,
+  username: undefined,
+  tenantId: undefined,
+  subscriptionId: undefined,
+};
+
+const AUTH_LOGGED_OUT = {
+  isChecking: false,
+  isLoggedIn: false,
+  username: undefined,
+  tenantId: undefined,
+  subscriptionId: undefined,
+};
+
+describe('useAzureProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockUseAzureAuth.mockReturnValue(AUTH_LOGGED_IN);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('exposes auth state fields from useAzureAuth', () => {
+    const { result } = renderHook(() => useAzureProfilePage());
+    expect(result.current.isChecking).toBe(false);
+    expect(result.current.isLoggedIn).toBe(true);
+    expect(result.current.username).toBe('user@contoso.com');
+    expect(result.current.tenantId).toBe('tenant-abc');
+    expect(result.current.subscriptionId).toBe('sub-123');
+  });
+
+  test('redirects to /azure/login when not logged in and not checking', () => {
+    mockUseAzureAuth.mockReturnValue(AUTH_LOGGED_OUT);
+    renderHook(() => useAzureProfilePage());
+    expect(mockPush).toHaveBeenCalledWith('/azure/login');
+  });
+
+  test('does not redirect while auth is still checking', () => {
+    mockUseAzureAuth.mockReturnValue(AUTH_CHECKING);
+    renderHook(() => useAzureProfilePage());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('does not redirect when logged in', () => {
+    renderHook(() => useAzureProfilePage());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('handleBack navigates to /', () => {
+    const { result } = renderHook(() => useAzureProfilePage());
+    act(() => result.current.handleBack());
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  test('handleAddCluster navigates to /add-cluster-aks', () => {
+    const { result } = renderHook(() => useAzureProfilePage());
+    act(() => result.current.handleAddCluster());
+    expect(mockPush).toHaveBeenCalledWith('/add-cluster-aks');
+  });
+
+  test('handleLogout dispatches azure-auth-update and redirects on success', async () => {
+    mockRunCommandAsync.mockResolvedValue({ stderr: '' });
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    const { result } = renderHook(() => useAzureProfilePage());
+    await act(() => result.current.handleLogout());
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'azure-auth-update' })
+    );
+    // loggingOut stays true — component unmounts on redirect, no need to reset
+    expect(result.current.loggingOut).toBe(true);
+
+    act(() => vi.runAllTimers());
+    expect(mockPush).toHaveBeenCalledWith('/azure/login');
+  });
+
+  test('redirect guard defers to timeout during active logout flow', async () => {
+    mockRunCommandAsync.mockResolvedValue({ stderr: '' });
+
+    const { result, rerender } = renderHook(() => useAzureProfilePage());
+    await act(() => result.current.handleLogout());
+
+    // Auth state updates to logged-out before the timeout fires.
+    mockUseAzureAuth.mockReturnValue(AUTH_LOGGED_OUT);
+    rerender();
+
+    // Guard does not redirect immediately — loggingOut suppresses it.
+    expect(mockPush).not.toHaveBeenCalled();
+
+    // The timeout handles the redirect instead.
+    act(() => vi.runAllTimers());
+    expect(mockPush).toHaveBeenCalledWith('/azure/login');
+  });
+
+  test('handleLogout does not redirect when stderr contains ERROR:', async () => {
+    mockRunCommandAsync.mockResolvedValue({ stderr: 'ERROR: not logged in' });
+
+    const { result } = renderHook(() => useAzureProfilePage());
+    await act(() => result.current.handleLogout());
+
+    act(() => vi.runAllTimers());
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(result.current.loggingOut).toBe(false);
+  });
+
+  test('handleLogout sets loggingOut false when an error is thrown', async () => {
+    mockRunCommandAsync.mockRejectedValue(new Error('CLI not found'));
+
+    const { result } = renderHook(() => useAzureProfilePage());
+    await act(() => result.current.handleLogout());
+
+    expect(result.current.loggingOut).toBe(false);
+  });
+
+  test('clears redirect timer on unmount to prevent stray navigation', async () => {
+    mockRunCommandAsync.mockResolvedValue({ stderr: '' });
+
+    const { result, unmount } = renderHook(() => useAzureProfilePage());
+    await act(() => result.current.handleLogout());
+
+    unmount();
+    act(() => vi.runAllTimers());
+    expect(mockPush).not.toHaveBeenCalledWith('/azure/login');
+  });
+});

--- a/plugins/aks-desktop/src/components/AzureAuth/hooks/useAzureProfilePage.ts
+++ b/plugins/aks-desktop/src/components/AzureAuth/hooks/useAzureProfilePage.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useAzureAuth } from '../../../hooks/useAzureAuth';
+import { PROFILE_REDIRECT_DELAY_MS } from '../../../utils/constants/timing';
+
+/**
+ * Return type for {@link useAzureProfilePage}.
+ */
+export interface UseAzureProfilePageResult {
+  /** Whether the auth state is still being determined. */
+  isChecking: boolean;
+  /** Whether the user is currently logged in to Azure. */
+  isLoggedIn: boolean;
+  /** The logged-in user's Azure username, or `undefined` if not available. */
+  username: string | undefined;
+  /** The active tenant ID, or `undefined` if not available. */
+  tenantId: string | undefined;
+  /** The default subscription ID, or `undefined` if not available. */
+  subscriptionId: string | undefined;
+  /** `true` while the logout command is in flight. */
+  loggingOut: boolean;
+  /** Navigates back to the home page. */
+  handleBack: () => void;
+  /** Navigates to the Add Cluster from Azure page. */
+  handleAddCluster: () => void;
+  /**
+   * Initiates the Azure CLI logout flow. On success, dispatches an
+   * `azure-auth-update` event and redirects to the login page after
+   * {@link PROFILE_REDIRECT_DELAY_MS}.
+   */
+  handleLogout: () => Promise<void>;
+}
+
+/**
+ * Encapsulates all stateful logic for the Azure Profile page.
+ *
+ * Responsibilities:
+ * - Exposes the current Azure auth state fields needed by the page.
+ * - Redirects to `/azure/login` when the user is not logged in.
+ * - Provides `handleBack`, `handleAddCluster`, and `handleLogout` callbacks.
+ * - Manages the `loggingOut` in-flight state for the logout button.
+ */
+export function useAzureProfilePage(): UseAzureProfilePageResult {
+  const history = useHistory();
+  const authStatus = useAzureAuth();
+  const [loggingOut, setLoggingOut] = useState(false);
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Redirect to login page when the user is not (or no longer) logged in,
+  // except while an explicit logout flow is already handling the redirect.
+  useEffect(() => {
+    if (!loggingOut && !authStatus.isChecking && !authStatus.isLoggedIn) {
+      history.push('/azure/login');
+    }
+  }, [authStatus.isChecking, authStatus.isLoggedIn, history, loggingOut]);
+
+  const handleBack = () => {
+    history.push('/');
+  };
+
+  const handleAddCluster = () => {
+    history.push('/add-cluster-aks');
+  };
+
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    try {
+      // Dynamic import avoids circular dependencies at module load time.
+      const { runCommandAsync, isAzError } = await import('../../../utils/azure/az-cli-core');
+      const result = await runCommandAsync('az', ['logout']);
+
+      if (result.stderr && isAzError(result.stderr)) {
+        console.error('Azure CLI logout error:', result.stderr);
+        setLoggingOut(false);
+        return;
+      }
+
+      // Notify the sidebar label to refresh its auth state.
+      window.dispatchEvent(new CustomEvent('azure-auth-update'));
+
+      // Stay in loggingOut=true state until the component unmounts on redirect.
+      redirectTimerRef.current = setTimeout(() => {
+        history.push('/azure/login');
+      }, PROFILE_REDIRECT_DELAY_MS);
+    } catch (error) {
+      console.error('Error logging out:', error);
+      setLoggingOut(false);
+    }
+  };
+
+  return {
+    isChecking: authStatus.isChecking,
+    isLoggedIn: authStatus.isLoggedIn,
+    username: authStatus.username,
+    tenantId: authStatus.tenantId,
+    subscriptionId: authStatus.subscriptionId,
+    loggingOut,
+    handleBack,
+    handleAddCluster,
+    handleLogout,
+  };
+}


### PR DESCRIPTION
These changes extract all logic from `AzureProfilePage` into a dedicated `useAzureProfilePage` hook, clean up the component, and add copy-to-clipboard for account info fields.

Fixes: #126 

### Summary
- Extracts auth state, logout flow, navigation, and redirect guard into `useAzureProfilePage` with a typed `UseAzureProfilePageResult` interface; adds TSDocs and unit tests
- Refactors the component for accessibility and cleaner markup: proper MUI `Button` elements, system tokens over `useTheme()`, and `InfoRow` extraction for repeated label/value fields
- Adds copy-to-clipboard to `InfoRow` via the existing `CopyButton` component for tenant ID and subscription ID

### Testing
- [x] Verify back button is keyboard-accessible (Tab to focus, Enter to activate)
- [x] Verify copy-to-clipboard on tenant ID and subscription ID fields shows "Copied!" confirmation and copies the correct value
- [x] Run `cd plugins/aks-desktop && npm test` and ensure the tests pass 