### PR TITLE
Reduce Copilot agent prompt size and surface token-limit failures

### DIFF
--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useAgentPRDiscovery.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useAgentPRDiscovery.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+
+import type { Octokit } from '@octokit/rest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../utils/github/github-api', () => ({
+  findLinkedPullRequest: vi.fn(),
+  getIssue: vi.fn(),
+  listIssueComments: vi.fn(),
+}));
+
+import {
+  findLinkedPullRequest,
+  getIssue,
+  listIssueComments,
+} from '../../../utils/github/github-api';
+import { useAgentPRDiscovery } from './useAgentPRDiscovery';
+
+const fakeOctokit = {} as unknown as Octokit;
+const ISSUE_NUMBER = 42;
+const OWNER = 'test-owner';
+const REPO = 'test-repo';
+const ISSUE_URL = `https://github.com/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}`;
+
+describe('useAgentPRDiscovery — failure classification', () => {
+  beforeEach(() => {
+    vi.mocked(findLinkedPullRequest).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('classifies closed issue + token-limit comment as token-limit', async () => {
+    vi.mocked(getIssue).mockResolvedValue({
+      number: ISSUE_NUMBER,
+      state: 'closed',
+      url: ISSUE_URL,
+    });
+    vi.mocked(listIssueComments).mockResolvedValue([
+      { body: 'Tool ran successfully', user: 'copilot' },
+      {
+        body: 'Run failed: prompt token count of 70921 exceeds the limit of 64000',
+        user: 'copilot',
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useAgentPRDiscovery(fakeOctokit, OWNER, REPO, true, ISSUE_NUMBER)
+    );
+
+    await waitFor(() => expect(result.current.issueClosed).toBe(true));
+    expect(result.current.failureReason).toBe('token-limit');
+    expect(result.current.prNumber).toBeNull();
+    expect(listIssueComments).toHaveBeenCalledWith(fakeOctokit, OWNER, REPO, ISSUE_NUMBER);
+  });
+
+  it("returns 'unknown' when closed issue has no token-limit comment", async () => {
+    vi.mocked(getIssue).mockResolvedValue({
+      number: ISSUE_NUMBER,
+      state: 'closed',
+      url: ISSUE_URL,
+    });
+    vi.mocked(listIssueComments).mockResolvedValue([
+      { body: 'agent finished without making changes', user: 'copilot' },
+    ]);
+
+    const { result } = renderHook(() =>
+      useAgentPRDiscovery(fakeOctokit, OWNER, REPO, true, ISSUE_NUMBER)
+    );
+
+    await waitFor(() => expect(result.current.issueClosed).toBe(true));
+    expect(result.current.failureReason).toBe('unknown');
+  });
+
+  it("returns 'unknown' when comment fetch throws (best-effort)", async () => {
+    vi.mocked(getIssue).mockResolvedValue({
+      number: ISSUE_NUMBER,
+      state: 'closed',
+      url: ISSUE_URL,
+    });
+    vi.mocked(listIssueComments).mockRejectedValue(new Error('GitHub API rate limit'));
+
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useAgentPRDiscovery(fakeOctokit, OWNER, REPO, true, ISSUE_NUMBER)
+    );
+
+    await waitFor(() => expect(result.current.issueClosed).toBe(true));
+    expect(result.current.failureReason).toBe('unknown');
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Failed to fetch issue comments for failure classification:',
+      expect.any(Error)
+    );
+
+    consoleWarn.mockRestore();
+  });
+});

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useAgentPRDiscovery.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useAgentPRDiscovery.ts
@@ -3,9 +3,16 @@
 
 import { Octokit } from '@octokit/rest';
 import { useCallback } from 'react';
-import { findLinkedPullRequest, getIssue } from '../../../utils/github/github-api';
+import {
+  findLinkedPullRequest,
+  getIssue,
+  listIssueComments,
+} from '../../../utils/github/github-api';
 import { AGENT_DISCOVERY_MAX_POLLS, POLLING_INTERVAL_MS } from '../constants';
 import { usePolling } from './usePolling';
+
+/** Reason classification for an agent run that closed without producing a PR. */
+export type AgentFailureReason = 'token-limit' | 'unknown';
 
 interface UseAgentPRDiscoveryResult {
   prUrl: string | null;
@@ -14,6 +21,8 @@ interface UseAgentPRDiscoveryResult {
   /** PR number of a draft PR the agent is still working on. */
   draftPrNumber: number | null;
   issueClosed: boolean;
+  /** Set when issueClosed is true and we could classify the failure from issue comments. */
+  failureReason: AgentFailureReason | null;
   isTimedOut: boolean;
   error: string | null;
   stopPolling: () => void;
@@ -26,6 +35,21 @@ interface AgentPRPollData {
   merged: boolean;
   draftPrNumber: number | null;
   issueClosed: boolean;
+  failureReason: AgentFailureReason | null;
+}
+
+/**
+ * Detects the Copilot evaluator's prompt-token-limit error in issue comments.
+ * The runtime posts a failure message containing the literal API error string,
+ * e.g. `prompt token count of 70921 exceeds the limit of 64000`.
+ */
+const TOKEN_LIMIT_PATTERN = /prompt token count of \d+ exceeds the limit/i;
+
+function classifyFailureFromComments(comments: Array<{ body: string }>): AgentFailureReason {
+  for (const c of comments) {
+    if (TOKEN_LIMIT_PATTERN.test(c.body)) return 'token-limit';
+  }
+  return 'unknown';
 }
 
 /**
@@ -36,7 +60,9 @@ interface AgentPRPollData {
  *    cross-referenced PRs. This is deterministic — the agent's PR references
  *    the trigger issue, creating a timeline event.
  * 2. **Issue status** (termination signal): If no linked PR is found and the
- *    issue is closed, the agent completed without creating a PR.
+ *    issue is closed, the agent completed without creating a PR. In that
+ *    case we also fetch issue comments to classify the failure (e.g. the
+ *    Copilot evaluator hitting its 64k token cap).
  *
  * @param octokit - Authenticated Octokit client. Pass null to disable.
  * @param owner - Repository owner.
@@ -66,6 +92,7 @@ export const useAgentPRDiscovery = (
             merged: linked.merged,
             draftPrNumber: null,
             issueClosed: false,
+            failureReason: null,
           };
         }
         return {
@@ -74,6 +101,7 @@ export const useAgentPRDiscovery = (
           merged: false,
           draftPrNumber: linked.number,
           issueClosed: false,
+          failureReason: null,
         };
       }
     } catch (err) {
@@ -83,12 +111,21 @@ export const useAgentPRDiscovery = (
     try {
       const issue = await getIssue(octokit, owner, repo, issueNumber);
       if (issue.state === 'closed') {
+        let failureReason: AgentFailureReason = 'unknown';
+        try {
+          const comments = await listIssueComments(octokit, owner, repo, issueNumber);
+          failureReason = classifyFailureFromComments(comments);
+        } catch (err) {
+          // Comment fetch is best-effort; default to 'unknown'.
+          console.warn('Failed to fetch issue comments for failure classification:', err);
+        }
         return {
           prUrl: null,
           prNumber: null,
           merged: false,
           draftPrNumber: null,
           issueClosed: true,
+          failureReason,
         };
       }
     } catch (err) {
@@ -116,6 +153,7 @@ export const useAgentPRDiscovery = (
   const prMerged = data?.merged ?? false;
   const draftPrNumber = data?.draftPrNumber ?? null;
   const issueClosed = data?.issueClosed ?? false;
+  const failureReason = data?.failureReason ?? null;
 
   return {
     prUrl,
@@ -123,6 +161,7 @@ export const useAgentPRDiscovery = (
     prMerged,
     draftPrNumber,
     issueClosed,
+    failureReason,
     isTimedOut,
     error,
     stopPolling,

--- a/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineOrchestration.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/hooks/useGitHubPipelineOrchestration.ts
@@ -369,9 +369,18 @@ export const useGitHubPipelineOrchestration = ({
         if (agentPrDiscovery.prUrl && agentPrDiscovery.prNumber) {
           pipeline.setGeneratedPRCreated(agentPrDiscovery.prUrl, agentPrDiscovery.prNumber);
         } else if (agentPrDiscovery.issueClosed) {
-          pipeline.setFailed(
-            'Copilot agent completed but no deployment PR was found. Check the GitHub issue for details.'
-          );
+          if (agentPrDiscovery.failureReason === 'token-limit') {
+            pipeline.setFailed(
+              "The Copilot agent's evaluator hit its 64k input token limit before finishing. " +
+                'This typically happens on large repos or when the build retried many times. ' +
+                'Runs are non-deterministic, so trying again often succeeds. ' +
+                'Check the trigger issue for details.'
+            );
+          } else {
+            pipeline.setFailed(
+              'Copilot agent completed but no deployment PR was found. Check the GitHub issue for details.'
+            );
+          }
         } else if (agentPrDiscovery.isTimedOut) {
           pipeline.setFailed('Timed out waiting for Copilot agent to create PR');
         }
@@ -404,6 +413,7 @@ export const useGitHubPipelineOrchestration = ({
     agentPrDiscovery.prUrl,
     agentPrDiscovery.prNumber,
     agentPrDiscovery.issueClosed,
+    agentPrDiscovery.failureReason,
     agentPrDiscovery.isTimedOut,
     generatedPrPolling.isMerged,
     workflowPolling.runConclusion,

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.test.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.test.ts
@@ -112,6 +112,27 @@ describe('agentTemplates', () => {
       expect(result).toContain('needs: [buildImage]');
     });
 
+    it('caps build retries to bound trajectory size', () => {
+      const result = generateAgentConfig(validConfig);
+      // The unbounded "Repeat until successful" instruction must be gone.
+      expect(result).not.toMatch(/Repeat until successful/i);
+      // Replaced with an explicit cap so failed builds do not balloon trajectory tokens.
+      expect(result).toMatch(/retry up to \*\*2 more times\*\*/i);
+      expect(result).toMatch(/3 total attempts/i);
+    });
+
+    it('instructs agent to summarize large tool outputs instead of echoing them', () => {
+      const result = generateAgentConfig(validConfig);
+      expect(result).toMatch(/Do not echo large tool outputs/i);
+    });
+
+    it('updates the checklist per step, not per tool call', () => {
+      const result = generateAgentConfig(validConfig);
+      expect(result).toMatch(/once per numbered step/i);
+      // The old per-tool-call instruction must be gone.
+      expect(result).not.toMatch(/After \*\*each\*\* tool call/i);
+    });
+
     it('should include optional fields when provided', () => {
       const config: PipelineConfig = {
         ...validConfig,

--- a/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.ts
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/utils/agentTemplates.ts
@@ -186,101 +186,47 @@ description: "Analyze repository, generate a best-practice Dockerfile, Kubernete
 ---
 
 ## Role
-You are a containerization-focused coding agent. Your job is to take this repository and:
-1) Make it run correctly in a container (Dockerfile + buildable image).
-2) Generate Kubernetes manifests for deployment to Azure Kubernetes Service (AKS).
-3) Generate a GitHub Actions workflow for CI/CD deployment to AKS.
-
-## Hard Requirements
-- **Image tag must be \`${DEFAULT_IMAGE_TAG}\`** (always).
-- Maintain a checklist at \`artifacts/tool-call-checklist.md\` and update it immediately after each tool call.
-- **Always call these in order** for Dockerfile work:
-  1) \`containerization-assist-mcp/generate-dockerfile\`
-  2) \`containerization-assist-mcp/fix-dockerfile\`
-  3) \`containerization-assist-mcp/build-image\`
-
-## Tools
-Do not restrict tools. Use any available built-in tools and MCP tools.
-Prefer using these MCP tools when available:
-- containerization-assist-mcp/analyze-repo
-- containerization-assist-mcp/generate-dockerfile
-- containerization-assist-mcp/fix-dockerfile
-- containerization-assist-mcp/build-image
-- containerization-assist-mcp/scan-image
-- containerization-assist-mcp/generate-k8s-manifests
-
-If any specific tool is unavailable, fall back to shell commands and repo inspection.
-
-## Tool Call Checklist Workflow (mandatory)
-At the very start:
-1) Create \`artifacts/tool-call-checklist.md\`.
-2) Use the template below.
-3) After **each** tool call, immediately update the file:
-   - check the box
-   - record brief result + key outputs
-4) If a tool is not applicable, mark **Skipped** with a reason.
-
-### Checklist template (create exactly this structure)
-- [ ] containerization-assist-mcp/analyze-repo — Result:
-- [ ] containerization-assist-mcp/generate-dockerfile — Result:
-- [ ] containerization-assist-mcp/fix-dockerfile — Result:
-- [ ] containerization-assist-mcp/build-image — Result:
-- [ ] containerization-assist-mcp/scan-image — Result:
-- [ ] containerization-assist-mcp/generate-k8s-manifests — Result:
+Containerization-focused coding agent. Take this repository and:
+1) Make it run correctly in a container (Dockerfile + buildable image, tag = \`${DEFAULT_IMAGE_TAG}\`).
+2) Generate Kubernetes manifests for AKS in \`/deploy/kubernetes/\`.
+3) Generate a GitHub Actions deployment workflow at \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\`.
 
 ## Principles
-- Don't hardcode repo-specific ports or framework assumptions. Infer from analysis.
-- Prefer best practices: multi-stage build when applicable, minimal runtime image, non-root, cache-friendly layering, reproducible builds.
-- Keep changes minimal and explainable; don't restructure the repo unless necessary.
-- Always iterate on failures: **fix → rebuild** until green.
+- Infer ports/frameworks from analysis — do not hardcode.
+- Best practices: multi-stage build when applicable, minimal runtime image, non-root, cache-friendly layering.
+- Keep changes minimal; don't restructure the repo unless necessary.
+- **Do not echo large tool outputs back into prompts or the checklist.** Reference files by path and write a one-line summary (≤120 chars). This applies especially to \`analyze-repo\`, \`generate-k8s-manifests\`, and build logs.
 - Do not call \`containerization-assist-mcp/ops\`.
 
-## Required Execution Plan
+## Execution Plan
+Use \`containerization-assist-mcp\` tools when available; otherwise fall back to shell.
 
-### 0) Initialize the checklist
-Create \`artifacts/tool-call-checklist.md\` using the template above before any tool calls.
+1. \`containerization-assist-mcp/analyze-repo\` — at repo root.
+2. \`containerization-assist-mcp/generate-dockerfile\` — always, even if one exists.
+3. \`containerization-assist-mcp/fix-dockerfile\` — immediately after generate.
+4. \`containerization-assist-mcp/build-image\` — image name = sanitized repo name, tag = \`${DEFAULT_IMAGE_TAG}\`.
+   On failure: retry up to **2 more times** (\`fix-dockerfile\` → \`build-image\`).
+   If still failing after 3 total attempts, record the last error on the Step 4 (\`build-image\`) checklist line (≤120 chars) and continue to step 5 — the PR can still be reviewed by a human.
+5. \`containerization-assist-mcp/scan-image\` — after a successful build. Mark Skipped (with reason) if unavailable or build did not succeed.
+6. \`containerization-assist-mcp/generate-k8s-manifests\` — write to \`/deploy/kubernetes/\`.
 
-### 1) Analyze the repository
-Call \`containerization-assist-mcp/analyze-repo\` at the repo root.
-Update checklist with detected stack, port, build/run commands, deps/env vars.
+## Checklist
+Maintain \`artifacts/tool-call-checklist.md\`. Update **once per numbered step above** (not per tool call). Each entry: one line, ≤120 chars. Mark Skipped with a reason where applicable.
 
-### 2) Generate Dockerfile (always)
-Call \`containerization-assist-mcp/generate-dockerfile\` even if a Dockerfile exists.
-Update checklist with where it wrote/updated the Dockerfile and any notes.
-
-### 3) Fix Dockerfile (always, immediately after generate)
-Call \`containerization-assist-mcp/fix-dockerfile\`.
-Update checklist with fixes made.
-
-### 4) Build the image (tag must be ${DEFAULT_IMAGE_TAG})
-Call \`containerization-assist-mcp/build-image\` using:
-- image name = sanitized repo name
-- image tag = \`${DEFAULT_IMAGE_TAG}\`
-
-If build fails:
-- Call \`containerization-assist-mcp/fix-dockerfile\` (again)
-- Re-run \`build-image\`
-- Repeat until successful
-
-### 5) Scan the image (recommended)
-Call \`containerization-assist-mcp/scan-image\` after a successful build.
-If scan is unavailable/not applicable, mark Skipped with reason.
-
-### 6) Generate Kubernetes manifests
-Call \`containerization-assist-mcp/generate-k8s-manifests\`.
-
-## Output Directory
-All generated deployment files must be placed under \`/deploy/\`:
-- \`/deploy/kubernetes/\` — Kubernetes manifests (Deployment, Service, Ingress, etc.)
-- \`/deploy/README.md\` — (optional) description of the deployment setup
-- \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\` — deployment workflow
+Template:
+- [ ] 1. analyze-repo — Result:
+- [ ] 2. generate-dockerfile — Result:
+- [ ] 3. fix-dockerfile — Result:
+- [ ] 4. build-image — Result:
+- [ ] 5. scan-image — Result:
+- [ ] 6. generate-k8s-manifests — Result:
 
 ## AKS Deployment Configuration
 - Cluster: ${config.clusterName}
 - Resource Group: ${config.resourceGroup}
 - Namespace: ${config.namespace}
 - Service Type: ${config.serviceType}
-- Azure credentials are stored as GitHub repository secrets: \`AZURE_CLIENT_ID\`, \`AZURE_TENANT_ID\`, \`AZURE_SUBSCRIPTION_ID\`${
+- Azure credentials stored as GitHub repository secrets: \`AZURE_CLIENT_ID\`, \`AZURE_TENANT_ID\`, \`AZURE_SUBSCRIPTION_ID\`${
     config.acrLoginServer
       ? `\n- Container Registry: \`${config.acrLoginServer}\` (ACR name stored as secret \`AZURE_ACR_NAME\`)`
       : ''
@@ -291,56 +237,34 @@ All generated Deployment manifests MUST include these annotations in \`metadata.
 - \`aks-project/deployed-by: pipeline\`
 - \`aks-project/pipeline-repo: ${config.repo.owner}/${config.repo.repo}\`
 
-Example:
-\`\`\`yaml
-metadata:
-  name: ${config.appName}
-  namespace: ${config.namespace}
-  annotations:
-    aks-project/deployed-by: pipeline
-    aks-project/pipeline-repo: ${config.repo.owner}/${config.repo.repo}
-\`\`\`
-
 ## GitHub Actions Workflow Requirements
-Generate \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\` with the following:
-- Trigger ONLY on \`workflow_dispatch\` with the following required string inputs (and their defaults):
+Generate \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\`:
+- Trigger ONLY on \`workflow_dispatch\` with required string inputs:
   - \`cluster-name\` (default: \`${config.clusterName}\`)
   - \`resource-group\` (default: \`${config.resourceGroup}\`)
   - \`namespace\` (default: \`${config.namespace}\`)
-- Do NOT add a \`push\` trigger — deployment is always triggered explicitly
-- Use \`azure/login@v2\` with OIDC (\`secrets.AZURE_CLIENT_ID\`, \`secrets.AZURE_TENANT_ID\`, \`secrets.AZURE_SUBSCRIPTION_ID\`)
-- Use \`azure/aks-set-context@v4\` with cluster \`\${{ inputs.cluster-name }}\` and resource group \`\${{ inputs.resource-group }}\`
-- The deploy job MUST include \`actions: read\` in its permissions block (required for GITHUB_TOKEN access)
-- Split the workflow into two jobs: a \`buildImage\` job (build + push to ACR) and a \`deploy\` job (apply manifests) with \`needs: [buildImage]\`
-- Install kubelogin (required for AAD-enabled AKS clusters): \`azure/use-kubelogin@v1\` with \`kubelogin-version: '${KUBELOGIN_VERSION}'\`
-- Convert kubeconfig to use kubelogin: \`kubelogin convert-kubeconfig -l workloadidentity\`${
+- No \`push\` trigger.
+- Two jobs: \`buildImage\` (build + push to ACR) and \`deploy\` (apply manifests) with \`needs: [buildImage]\`. The \`deploy\` job permissions block MUST include \`actions: read\`.
+- Use \`azure/login@v2\` with OIDC (\`secrets.AZURE_CLIENT_ID\`, \`secrets.AZURE_TENANT_ID\`, \`secrets.AZURE_SUBSCRIPTION_ID\`).
+- Use \`azure/aks-set-context@v4\` with \`\${{ inputs.cluster-name }}\` and \`\${{ inputs.resource-group }}\`.
+- Install kubelogin via \`azure/use-kubelogin@v1\` with \`kubelogin-version: '${KUBELOGIN_VERSION}'\`, then \`kubelogin convert-kubeconfig -l workloadidentity\`.${
     config.acrLoginServer
-      ? `\n- Build and push the container image using ACR Tasks: \`az acr build --registry \${{ secrets.AZURE_ACR_NAME }} --image ${config.appName}:\${{ github.sha }} .\`\n- Update the container image reference in manifests to use \`${config.acrLoginServer}/${config.appName}:\${{ github.sha }}\``
+      ? `\n- Build/push image via ACR Tasks: \`az acr build --registry \${{ secrets.AZURE_ACR_NAME }} --image ${config.appName}:\${{ github.sha }} .\` — and update manifests to reference \`${config.acrLoginServer}/${config.appName}:\${{ github.sha }}\`.`
       : ''
   }${generateEnvVarWorkflowInstructions(config)}${generateWorkloadIdentityWorkflowInstructions(
     config
-  )}- Run: \`kubectl apply -f deploy/kubernetes/ -n \${{ inputs.namespace }}\`
-- After applying manifests, annotate each Deployment with the run URL and workflow name:
+  )}- Apply manifests: \`kubectl apply -f deploy/kubernetes/ -n \${{ inputs.namespace }}\`
+- After apply, annotate each Deployment with the run URL and workflow name:
   \`kubectl annotate deployment --all -n \${{ inputs.namespace }} aks-project/pipeline-run-url=\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }} "aks-project/pipeline-workflow=\${{ github.workflow }}" --overwrite\`
 
 ## Naming Conventions
 - PR title: "[AKS Desktop] Add deployment pipeline for ${config.appName}"
-- Commit messages: prefixed with "deploy:"
+- Commit messages prefixed with "deploy:"
 - K8s resource names: kebab-case, prefixed with \`${config.appName}\`
 
-## Validation Steps
-- Run \`kubectl apply --dry-run=client -f deploy/kubernetes/\` to validate manifests
-- Validate Dockerfile builds cleanly
-- Ensure all manifests target namespace: \`${config.namespace}\`
-- Verify service type matches: \`${config.serviceType}\`
-
-## Definition of Done
-- Dockerfile generated then fixed
-- Image builds successfully and is tagged **${DEFAULT_IMAGE_TAG}**
-- Kubernetes manifests generated in \`/deploy/kubernetes/\`
-- GitHub Actions deployment workflow generated at \`.github/workflows/${PIPELINE_WORKFLOW_FILENAME}\`
-- All validation steps pass
-- Checklist is complete
+## Validation
+- \`kubectl apply --dry-run=client -f deploy/kubernetes/\` succeeds.
+- All manifests target namespace \`${config.namespace}\` and service type \`${config.serviceType}\`.
 `;
 };
 

--- a/plugins/aks-desktop/src/utils/github/github-api.test.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.test.ts
@@ -45,7 +45,7 @@ const mockOctokit = {
     get: vi.fn(),
     list: vi.fn(),
   },
-  issues: { create: vi.fn(), get: vi.fn() },
+  issues: { create: vi.fn(), get: vi.fn(), listComments: vi.fn() },
   apps: {
     listInstallationsForAuthenticatedUser: vi.fn(),
     listInstallationReposForAuthenticatedUser: vi.fn(),
@@ -92,6 +92,7 @@ import {
   getRepoPublicKey,
   getStatusChecks,
   getWorkflowRun,
+  listIssueComments,
   listPullRequests,
   listUserRepos,
   listWorkflowRunJobs,
@@ -553,6 +554,103 @@ describe('github-api', () => {
       await expect(getIssue(mockOctokit as never, 'owner', 'repo', 5)).rejects.toThrow(
         'Failed to get issue #5 in owner/repo: Not Found'
       );
+    });
+  });
+
+  describe('listIssueComments', () => {
+    it('returns [] when the issue has no comments', async () => {
+      mockOctokit.issues.get.mockResolvedValue({ data: { comments: 0 } });
+
+      const result = await listIssueComments(mockOctokit as never, 'owner', 'repo', 5);
+
+      expect(result).toEqual([]);
+      expect(mockOctokit.issues.listComments).not.toHaveBeenCalled();
+    });
+
+    it('fetches page 1 for a single-page thread and returns all comments in order', async () => {
+      const comments = Array.from({ length: 12 }, (_, i) => ({
+        body: `c${i}`,
+        user: { login: 'u' },
+      }));
+      mockOctokit.issues.get.mockResolvedValue({ data: { comments: 12 } });
+      mockOctokit.issues.listComments.mockResolvedValue({ data: comments });
+
+      const result = await listIssueComments(mockOctokit as never, 'owner', 'repo', 5, 30);
+
+      expect(mockOctokit.issues.listComments).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.issues.listComments).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, per_page: 100 })
+      );
+      expect(result).toHaveLength(12);
+      expect(result[0].body).toBe('c0');
+      expect(result[result.length - 1].body).toBe('c11');
+    });
+
+    it('targets the last page only for long threads (tail semantics)', async () => {
+      const lastPage = Array.from({ length: 50 }, (_, i) => ({
+        body: `c${200 + i}`,
+        user: { login: 'u' },
+      }));
+      mockOctokit.issues.get.mockResolvedValue({ data: { comments: 250 } });
+      mockOctokit.issues.listComments.mockResolvedValue({ data: lastPage });
+
+      const result = await listIssueComments(mockOctokit as never, 'owner', 'repo', 5, 30);
+
+      expect(mockOctokit.issues.listComments).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.issues.listComments).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3, per_page: 100 })
+      );
+      expect(result).toHaveLength(30);
+      // Most-recent comment must be last in the returned slice.
+      expect(result[result.length - 1].body).toBe('c249');
+    });
+
+    it('fetches the previous page as well when perPage exceeds a single API page', async () => {
+      const page2 = Array.from({ length: 100 }, (_, i) => ({
+        body: `c${100 + i}`,
+        user: { login: 'u' },
+      }));
+      const page3 = Array.from({ length: 50 }, (_, i) => ({
+        body: `c${200 + i}`,
+        user: { login: 'u' },
+      }));
+      mockOctokit.issues.get.mockResolvedValue({ data: { comments: 250 } });
+      mockOctokit.issues.listComments
+        .mockResolvedValueOnce({ data: page2 })
+        .mockResolvedValueOnce({ data: page3 });
+
+      const result = await listIssueComments(mockOctokit as never, 'owner', 'repo', 5, 150);
+
+      expect(mockOctokit.issues.listComments).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.issues.listComments).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ page: 2 })
+      );
+      expect(mockOctokit.issues.listComments).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ page: 3 })
+      );
+      expect(result).toHaveLength(150);
+      expect(result[0].body).toBe('c100');
+      expect(result[result.length - 1].body).toBe('c249');
+    });
+
+    it('wraps errors from issues.get with apiError', async () => {
+      mockOctokit.issues.get.mockRejectedValue(new Error('boom'));
+
+      await expect(listIssueComments(mockOctokit as never, 'owner', 'repo', 42)).rejects.toThrow(
+        'Failed to list comments on issue #42 in owner/repo: boom'
+      );
+    });
+
+    it('maps a missing user to null', async () => {
+      mockOctokit.issues.get.mockResolvedValue({ data: { comments: 1 } });
+      mockOctokit.issues.listComments.mockResolvedValue({
+        data: [{ body: 'hi', user: null }],
+      });
+
+      const result = await listIssueComments(mockOctokit as never, 'owner', 'repo', 5);
+      expect(result).toEqual([{ body: 'hi', user: null }]);
     });
   });
 

--- a/plugins/aks-desktop/src/utils/github/github-api.ts
+++ b/plugins/aks-desktop/src/utils/github/github-api.ts
@@ -608,6 +608,56 @@ export async function getIssue(
   }
 }
 
+/**
+ * Fetches the most recent `perPage` comments on an issue. Reads the issue's
+ * `comments` count via `issues.get` to compute the last page index, then
+ * requests that page directly (and the previous page when `perPage` exceeds a
+ * single API page). This guarantees we see the genuine tail of the thread —
+ * where runtime messages like the Copilot evaluator's token-limit failure are
+ * posted — rather than the oldest comments.
+ *
+ * Returns chronological order: oldest of the slice first, most recent last.
+ */
+export async function listIssueComments(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  perPage = 30
+): Promise<Array<{ body: string; user: string | null }>> {
+  const PAGE_SIZE = 100;
+  try {
+    const { data: issue } = await octokit.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+    const total = issue.comments ?? 0;
+    if (total === 0) return [];
+
+    const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    const pagesToFetch =
+      perPage > PAGE_SIZE && lastPage > 1 ? [lastPage - 1, lastPage] : [lastPage];
+
+    const collected: Array<{ body: string; user: string | null }> = [];
+    for (const page of pagesToFetch) {
+      const { data } = await octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        per_page: PAGE_SIZE,
+        page,
+      });
+      for (const c of data) {
+        collected.push({ body: c.body ?? '', user: c.user?.login ?? null });
+      }
+    }
+    return collected.slice(-perPage);
+  } catch (error) {
+    throw apiError(`Failed to list comments on issue #${issueNumber} in ${owner}/${repo}`, error);
+  }
+}
+
 /** Shape of a cross-reference event from the issue timeline API. */
 interface TimelineCrossReference {
   event: 'cross-referenced';


### PR DESCRIPTION
## Summary

Users hitting the Copilot Coding Agent's 64k evaluator token cap (`400 prompt token count of 70921 exceeds the limit of 64000`) saw a generic *"completed but no PR was found"* message with no actionable next step. This PR reduces the chance of hitting the cap and detects it when we do.

- **Trim `generateAgentConfig`** — collapse duplicated *Hard Requirements*, *Tools*, *Definition of Done* sections into a single Execution Plan; shorten the checklist workflow. Roughly halves the static prompt.
- **Cap build retries to 2** (3 attempts total). The previous *"repeat until successful"* loop was the largest source of trajectory inflation on repos with broken Dockerfiles.
- **Tell the agent not to echo large tool outputs** back into the checklist or subsequent prompts (biggest offenders: `analyze-repo`, `generate-k8s-manifests`, build logs).
- **Update the checklist once per numbered step** instead of after every tool call.
- **Detect the token-limit signature** in trigger-issue comments via a new `listIssueComments` helper, classify it as `failureReason: 'token-limit'`, and surface a specific message explaining the cap and that runs are non-deterministic so retrying often works.

## Test plan

- [x] `npm run tsc`
- [x] `npm run lint`
- [x] `npm run format -- --check`
- [x] `npm test -- --run agentTemplates useAgentPRDiscovery useGitHubPipelineOrchestration` (33 passed)
- [ ] Manual: trigger an agent run on a small repo and confirm the trimmed prompt still produces a working Dockerfile + manifests + workflow
- [ ] Manual: simulate a closed-without-PR issue with the token-limit string in a comment and confirm the new error message renders

