### PR TITLE
aksd: harden App Insights telemetry to anonymous app-usage counts

### DIFF
--- a/frontend/src/analyticsSetup.ts
+++ b/frontend/src/analyticsSetup.ts
@@ -16,6 +16,7 @@
 
 import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { privacyTelemetryInitializer } from './lib/analyticsPrivacy';
 
 if (import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING) {
   const reactPlugin = new ReactPlugin();
@@ -23,8 +24,24 @@ if (import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING) {
     config: {
       connectionString: import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING,
       extensions: [reactPlugin],
+
+      // Don't auto-collect anything that carries identifiers.
+      disableAjaxTracking: true, // K8s API URLs contain ns/resource names
+      disableFetchTracking: true, // Azure ARM URLs likewise
+      disableExceptionTracking: true, // we route exceptions ourselves, scrubbed
+      enableAutoRouteTracking: false, // don't auto-fire pageviews on URL change
+      autoTrackPageVisitTime: false,
+
+      // Drop user/session correlation.
+      disableCookiesUsage: true,
+      isStorageUseDisabled: true,
     },
   });
+  // Register the privacy scrubber BEFORE loadAppInsights() so any envelope
+  // the SDK emits or queues during initialization passes through it.
+  window.appInsights.addTelemetryInitializer(privacyTelemetryInitializer);
   window.appInsights.loadAppInsights();
-  window.appInsights.trackPageView();
+  // trackPageView() intentionally not called — the page URL contains
+  // cluster/namespace/resource names. LIST_VIEW / DETAILS_VIEW events from
+  // the redux middleware give us per-resource-kind visibility without URLs.
 }

--- a/frontend/src/analyticsSetup.ts
+++ b/frontend/src/analyticsSetup.ts
@@ -15,7 +15,32 @@
  */
 
 import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { ApplicationInsights, ITelemetryItem } from '@microsoft/applicationinsights-web';
+
+/**
+ * Strip identifying tags and URL fields from every outgoing telemetry envelope.
+ *
+ * This runs on the SDK's send pipeline and is the catch-all that protects us
+ * if a future SDK upgrade re-enables auto-collection or if a new call site
+ * forgets the "no identifiers" rule. It is intentionally aggressive.
+ *
+ * Exported for unit testing.
+ */
+export function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
+  envelope.tags = envelope.tags ?? {};
+  delete envelope.tags['ai.user.id'];
+  delete envelope.tags['ai.user.authUserId'];
+  delete envelope.tags['ai.user.accountId'];
+  delete envelope.tags['ai.session.id'];
+  delete envelope.tags['ai.location.ip'];
+
+  const baseData = envelope.data?.baseData as Record<string, unknown> | undefined;
+  if (baseData) {
+    if ('uri' in baseData) baseData.uri = '';
+    if ('refUri' in baseData) baseData.refUri = '';
+    if ('url' in baseData) baseData.url = '';
+  }
+}
 
 if (import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING) {
   const reactPlugin = new ReactPlugin();
@@ -23,8 +48,22 @@ if (import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING) {
     config: {
       connectionString: import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING,
       extensions: [reactPlugin],
+
+      // Don't auto-collect anything that carries identifiers.
+      disableAjaxTracking: true, // K8s API URLs contain ns/resource names
+      disableFetchTracking: true, // Azure ARM URLs likewise
+      disableExceptionTracking: true, // we route exceptions ourselves, scrubbed
+      enableAutoRouteTracking: false, // don't auto-fire pageviews on URL change
+      autoTrackPageVisitTime: false,
+
+      // Drop user/session correlation.
+      disableCookiesUsage: true,
+      isStorageUseDisabled: true,
     },
   });
   window.appInsights.loadAppInsights();
-  window.appInsights.trackPageView();
+  window.appInsights.addTelemetryInitializer(privacyTelemetryInitializer);
+  // trackPageView() intentionally not called — the page URL contains
+  // cluster/namespace/resource names. LIST_VIEW / DETAILS_VIEW events from
+  // the redux middleware give us per-resource-kind visibility without URLs.
 }

--- a/frontend/src/analyticsSetup.ts
+++ b/frontend/src/analyticsSetup.ts
@@ -15,32 +15,8 @@
  */
 
 import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
-import { ApplicationInsights, ITelemetryItem } from '@microsoft/applicationinsights-web';
-
-/**
- * Strip identifying tags and URL fields from every outgoing telemetry envelope.
- *
- * This runs on the SDK's send pipeline and is the catch-all that protects us
- * if a future SDK upgrade re-enables auto-collection or if a new call site
- * forgets the "no identifiers" rule. It is intentionally aggressive.
- *
- * Exported for unit testing.
- */
-export function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
-  envelope.tags = envelope.tags ?? {};
-  delete envelope.tags['ai.user.id'];
-  delete envelope.tags['ai.user.authUserId'];
-  delete envelope.tags['ai.user.accountId'];
-  delete envelope.tags['ai.session.id'];
-  delete envelope.tags['ai.location.ip'];
-
-  const baseData = envelope.data?.baseData as Record<string, unknown> | undefined;
-  if (baseData) {
-    if ('uri' in baseData) baseData.uri = '';
-    if ('refUri' in baseData) baseData.refUri = '';
-    if ('url' in baseData) baseData.url = '';
-  }
-}
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { privacyTelemetryInitializer } from './lib/analyticsPrivacy';
 
 if (import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING) {
   const reactPlugin = new ReactPlugin();

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as analytics from '../../../lib/analytics';
+import store from '../../../redux/stores/store';
+import ErrorBoundary from './ErrorBoundary';
+
+class CustomDomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomDomainError';
+  }
+}
+
+function Boom({ error }: { error: Error }): JSX.Element {
+  throw error;
+}
+
+describe('ErrorBoundary telemetry', () => {
+  let trackEventSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    trackEventSpy = vi.spyOn(analytics, 'trackEvent').mockImplementation(() => {});
+    // React logs caught errors via console.error in dev — silence to keep test output clean.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    trackEventSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('calls trackEvent with exception name and only error.name in properties', () => {
+    const err = new CustomDomainError(
+      "namespace 'payments' not found at https://example.test/api/v1/namespaces/payments"
+    );
+
+    render(
+      <Provider store={store}>
+        <ErrorBoundary fallback={<div>fallback</div>}>
+          <Boom error={err} />
+        </ErrorBoundary>
+      </Provider>
+    );
+
+    expect(trackEventSpy).toHaveBeenCalledWith('exception', { errorName: 'CustomDomainError' });
+
+    // No call shipped the message or stack.
+    for (const call of trackEventSpy.mock.calls) {
+      const [, properties] = call;
+      if (properties) {
+        for (const value of Object.values(properties)) {
+          expect(value).not.toContain('payments');
+          expect(value).not.toContain('https://');
+        }
+      }
+    }
+  });
+
+  it('uses the default Error.name "Error" for plain errors', () => {
+    render(
+      <Provider store={store}>
+        <ErrorBoundary fallback={<div>fallback</div>}>
+          <Boom error={new Error('boom')} />
+        </ErrorBoundary>
+      </Provider>
+    );
+
+    expect(trackEventSpy).toHaveBeenCalledWith('exception', { errorName: 'Error' });
+  });
+});

--- a/frontend/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Component, ComponentType, isValidElement, ReactElement, ReactNode } from 'react';
-import { trackException } from '../../../lib/analytics';
+import { trackEvent } from '../../../lib/analytics';
 import { eventAction, HeadlampEventType } from '../../../redux/headlampEventSlice';
 import store from '../../../redux/stores/store';
 
@@ -60,7 +60,10 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
   }
 
   componentDidCatch(error: Error) {
-    trackException(error);
+    // Send only the constructor name (e.g. "TypeError", "KubeApiError"),
+    // never the message or stack — error messages routinely contain
+    // identifiers (namespaces, resource names, URLs, YAML fragments).
+    trackEvent('exception', { errorName: error.name });
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps, prevState: State) {

--- a/frontend/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Component, ComponentType, isValidElement, ReactElement, ReactNode } from 'react';
-import { trackException } from '../../../lib/analytics';
+import { trackEvent } from '../../../lib/analytics';
 import { eventAction, HeadlampEventType } from '../../../redux/headlampEventSlice';
 import store from '../../../redux/stores/store';
 
@@ -60,7 +60,10 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
   }
 
   componentDidCatch(error: Error) {
-    trackException(error);
+    // Send only the constructor name (e.g. "TypeError", "KubeApiError"),
+    // never the message or stack — error messages routinely contain
+    // identifiers (namespaces, resource names, URLs, YAML fragments).
+    trackEvent('exception', { errorName: error?.name || 'Error' });
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps, prevState: State) {

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -27,7 +27,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <tbody
             class="MuiTableBody-root css-apqrd9-MuiTableBody-root"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-r7i92b-MuiTable-root"
+            class="MuiTable-root css-1f5u0uu-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-r7i92b-MuiTable-root"
+        class="MuiTable-root css-1f5u0uu-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
@@ -158,7 +158,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-bv8t57-MuiTable-root"
+        class="MuiTable-root css-14jq1ex-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
@@ -28,7 +28,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
@@ -28,7 +28,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -268,7 +268,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -379,7 +379,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -241,7 +241,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -253,7 +253,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -362,7 +362,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -226,7 +226,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -258,7 +258,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -347,7 +347,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-d21jum-MuiTable-root"
+                      class="MuiTable-root css-4d0x9t-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -402,7 +402,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-1t02l4h-MuiTable-root"
+                      class="MuiTable-root css-15jmevm-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -538,7 +538,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -238,7 +238,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                        class="MuiTable-root css-1ok7ihs-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -378,7 +378,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -270,7 +270,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -278,7 +278,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -221,7 +221,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-bv8t57-MuiTable-root"
+                        class="MuiTable-root css-14jq1ex-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -290,7 +290,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -397,7 +397,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                  class="MuiTable-root css-1ok7ihs-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -499,7 +499,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -290,7 +290,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -630,7 +630,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -366,7 +366,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -280,7 +280,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -439,7 +439,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -563,7 +563,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -467,7 +467,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -464,7 +464,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -453,7 +453,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -450,7 +450,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
+import { describe, expect, it } from 'vitest';
+import { privacyTelemetryInitializer } from '../analyticsSetup';
+
+function makeEnvelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
+  return {
+    name: 'Microsoft.ApplicationInsights.Event',
+    time: new Date().toISOString(),
+    ...overrides,
+  } as ITelemetryItem;
+}
+
+describe('privacyTelemetryInitializer', () => {
+  it('removes identifying tags', () => {
+    const envelope = makeEnvelope({
+      tags: {
+        'ai.user.id': 'user-abc',
+        'ai.user.authUserId': 'auth-xyz',
+        'ai.user.accountId': 'account-42',
+        'ai.session.id': 'session-99',
+        'ai.location.ip': '203.0.113.5',
+        'ai.cloud.role': 'web', // benign tag — should be preserved
+      },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    expect(envelope.tags).toEqual({ 'ai.cloud.role': 'web' });
+  });
+
+  it('clears uri, refUri, and url fields on baseData', () => {
+    const envelope = makeEnvelope({
+      data: {
+        baseData: {
+          uri: 'https://example.test/c/prod/namespaces/payments/pods/secret',
+          refUri: 'https://example.test/login',
+          url: 'https://example.test/api',
+          name: 'page-name', // unrelated field — should be preserved
+        },
+      },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    const baseData = envelope.data!.baseData as Record<string, unknown>;
+    expect(baseData.uri).toBe('');
+    expect(baseData.refUri).toBe('');
+    expect(baseData.url).toBe('');
+    expect(baseData.name).toBe('page-name');
+  });
+
+  it('handles envelopes without tags or baseData', () => {
+    const envelope = makeEnvelope();
+    expect(() => privacyTelemetryInitializer(envelope)).not.toThrow();
+    expect(envelope.tags).toEqual({});
+  });
+
+  it('does not add fields that were not already present on baseData', () => {
+    const envelope = makeEnvelope({
+      data: { baseData: { name: 'evt' } },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    const baseData = envelope.data!.baseData as Record<string, unknown>;
+    expect('uri' in baseData).toBe(false);
+    expect('refUri' in baseData).toBe(false);
+    expect('url' in baseData).toBe(false);
+  });
+});

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ApplicationInsights, ITelemetryItem } from '@microsoft/applicationinsights-web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { trackException } from './analytics';
+import { privacyTelemetryInitializer } from './analyticsPrivacy';
+
+function makeEnvelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
+  return {
+    name: 'Microsoft.ApplicationInsights.Event',
+    time: new Date().toISOString(),
+    ...overrides,
+  } as ITelemetryItem;
+}
+
+describe('privacyTelemetryInitializer', () => {
+  it('removes identifying tags', () => {
+    const envelope = makeEnvelope({
+      tags: {
+        'ai.user.id': 'user-abc',
+        'ai.user.authUserId': 'auth-xyz',
+        'ai.user.accountId': 'account-42',
+        'ai.session.id': 'session-99',
+        'ai.location.ip': '203.0.113.5',
+        'ai.cloud.role': 'web', // benign tag — should be preserved
+      },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    expect(envelope.tags).toEqual({ 'ai.cloud.role': 'web' });
+  });
+
+  it('clears uri, refUri, and url fields on baseData', () => {
+    const envelope = makeEnvelope({
+      data: {
+        baseData: {
+          uri: 'https://example.test/c/prod/namespaces/payments/pods/secret',
+          refUri: 'https://example.test/login',
+          url: 'https://example.test/api',
+          name: 'page-name', // unrelated field — should be preserved
+        },
+      },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    const baseData = envelope.data!.baseData as Record<string, unknown>;
+    expect(baseData.uri).toBe('');
+    expect(baseData.refUri).toBe('');
+    expect(baseData.url).toBe('');
+    expect(baseData.name).toBe('page-name');
+  });
+
+  it('handles envelopes without tags or baseData', () => {
+    const envelope = makeEnvelope();
+    expect(() => privacyTelemetryInitializer(envelope)).not.toThrow();
+    expect(envelope.tags).toEqual({});
+  });
+
+  it('does not add fields that were not already present on baseData', () => {
+    const envelope = makeEnvelope({
+      data: { baseData: { name: 'evt' } },
+    });
+
+    privacyTelemetryInitializer(envelope);
+
+    const baseData = envelope.data!.baseData as Record<string, unknown>;
+    expect('uri' in baseData).toBe(false);
+    expect('refUri' in baseData).toBe(false);
+    expect('url' in baseData).toBe(false);
+  });
+});
+
+describe('trackException', () => {
+  let trackEventSpy: ReturnType<typeof vi.fn>;
+  const originalAppInsights = window.appInsights;
+
+  beforeEach(() => {
+    trackEventSpy = vi.fn();
+    window.appInsights = { trackEvent: trackEventSpy } as unknown as ApplicationInsights;
+  });
+
+  afterEach(() => {
+    window.appInsights = originalAppInsights;
+  });
+
+  it('forwards only the constructor name — never the message or stack', () => {
+    const err = new TypeError('something secret with PII');
+    err.stack = 'Error: secret\n    at /home/user/secret/path.ts:1:1';
+
+    trackException(err);
+
+    expect(trackEventSpy).toHaveBeenCalledTimes(1);
+    const payload = trackEventSpy.mock.calls[0][0];
+    expect(payload).toEqual({
+      name: 'exception',
+      properties: { errorName: 'TypeError' },
+    });
+    // Defense in depth: serialize and confirm the secret message and stack
+    // are absent from the wire payload.
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('path.ts');
+  });
+
+  it('falls back to "Error" when error.name is missing', () => {
+    trackException({ name: '' } as Error);
+    expect(trackEventSpy).toHaveBeenCalledWith({
+      name: 'exception',
+      properties: { errorName: 'Error' },
+    });
+  });
+
+  it('is a no-op when appInsights is not initialized', () => {
+    window.appInsights = undefined;
+    expect(() => trackException(new Error('boom'))).not.toThrow();
+    expect(trackEventSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -16,7 +16,7 @@
 
 import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
 import { describe, expect, it } from 'vitest';
-import { privacyTelemetryInitializer } from '../analyticsSetup';
+import { privacyTelemetryInitializer } from './analyticsPrivacy';
 
 function makeEnvelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
   return {

--- a/frontend/src/lib/analytics.tsx
+++ b/frontend/src/lib/analytics.tsx
@@ -38,20 +38,3 @@ export const trackEvent = (name: string, properties?: Record<string, string>) =>
     console.error('Failed to track event', e);
   }
 };
-
-/**
- * Track error. Only works if app insights is initialized
- *
- * @param error - Error object
- * @param properties - any custom properties
- * @returns
- */
-export const trackException = (error: Error, properties?: Record<string, string>) => {
-  const appInsights = window.appInsights;
-  if (!appInsights) return;
-  try {
-    appInsights.trackException({ exception: error, properties });
-  } catch (e) {
-    console.error('Failed to track exception', e);
-  }
-};

--- a/frontend/src/lib/analytics.tsx
+++ b/frontend/src/lib/analytics.tsx
@@ -40,17 +40,30 @@ export const trackEvent = (name: string, properties?: Record<string, string>) =>
 };
 
 /**
- * Track error. Only works if app insights is initialized
+ * Track an exception. Forwards only the constructor name (e.g. `TypeError`,
+ * `KubeApiError`) — never the message, stack, or `Error` object itself.
  *
- * @param error - Error object
- * @param properties - any custom properties
- * @returns
+ * @deprecated Prefer `trackEvent('exception', { errorName: error.name })`.
+ * Retained as a backwards-compatible wrapper for plugins that consume
+ * `window.pluginLib.analytics.trackException`.
+ *
+ * @param error - the error to record
+ * @param _properties - ignored; retained only so existing callers that pass
+ *   custom properties still type-check. Properties are intentionally dropped
+ *   to enforce the privacy constraint that only `errorName` is forwarded.
  */
-export const trackException = (error: Error, properties?: Record<string, string>) => {
+export const trackException = (
+  error: Error,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  _properties?: Record<string, string>
+) => {
   const appInsights = window.appInsights;
   if (!appInsights) return;
   try {
-    appInsights.trackException({ exception: error, properties });
+    appInsights.trackEvent({
+      name: 'exception',
+      properties: { errorName: error?.name || 'Error' },
+    });
   } catch (e) {
     console.error('Failed to track exception', e);
   }

--- a/frontend/src/lib/analyticsPrivacy.ts
+++ b/frontend/src/lib/analyticsPrivacy.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
+
+/**
+ * Strip identifying tags and URL fields from every outgoing telemetry envelope.
+ *
+ * This runs on the SDK's send pipeline and is the catch-all that protects us
+ * if a future SDK upgrade re-enables auto-collection or if a new call site
+ * forgets the "no identifiers" rule. It is intentionally aggressive.
+ *
+ * Mutates the provided `envelope` in place (as required by the
+ * `ITelemetryItem` initializer contract). Deterministic and free of external
+ * side effects — it touches only the envelope it is given, so it can be
+ * unit-tested without dragging the AppInsights bootstrap into the test's
+ * module graph.
+ */
+export function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
+  envelope.tags = envelope.tags ?? {};
+  delete envelope.tags['ai.user.id'];
+  delete envelope.tags['ai.user.authUserId'];
+  delete envelope.tags['ai.user.accountId'];
+  delete envelope.tags['ai.session.id'];
+  delete envelope.tags['ai.location.ip'];
+
+  const baseData = envelope.data?.baseData as Record<string, unknown> | undefined;
+  if (baseData) {
+    if ('uri' in baseData) baseData.uri = '';
+    if ('refUri' in baseData) baseData.refUri = '';
+    if ('url' in baseData) baseData.url = '';
+  }
+}

--- a/frontend/src/lib/analyticsPrivacy.ts
+++ b/frontend/src/lib/analyticsPrivacy.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
+
+/**
+ * Strip identifying tags and URL fields from every outgoing telemetry envelope.
+ *
+ * This runs on the SDK's send pipeline and is the catch-all that protects us
+ * if a future SDK upgrade re-enables auto-collection or if a new call site
+ * forgets the "no identifiers" rule. It is intentionally aggressive.
+ *
+ * Pure function — kept in a side-effect-free module so it can be unit-tested
+ * without dragging the AppInsights bootstrap into the test's module graph.
+ */
+export function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
+  envelope.tags = envelope.tags ?? {};
+  delete envelope.tags['ai.user.id'];
+  delete envelope.tags['ai.user.authUserId'];
+  delete envelope.tags['ai.user.accountId'];
+  delete envelope.tags['ai.session.id'];
+  delete envelope.tags['ai.location.ip'];
+
+  const baseData = envelope.data?.baseData as Record<string, unknown> | undefined;
+  if (baseData) {
+    if ('uri' in baseData) baseData.uri = '';
+    if ('refUri' in baseData) baseData.refUri = '';
+    if ('url' in baseData) baseData.url = '';
+  }
+}

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -495,7 +495,6 @@
   },
   "analytics": {
     "trackEvent": [Function],
-    "trackException": [Function],
   },
   "clusterAction": [Function],
   "default": [Function],

--- a/frontend/src/redux/headlampEventSlice.test.tsx
+++ b/frontend/src/redux/headlampEventSlice.test.tsx
@@ -92,12 +92,12 @@ describe('eventsSlice', () => {
 
       store.dispatch(
         eventAction({
-          type: 'test-event-type',
+          type: 'headlamp.list-view',
           data: {},
         })
       );
 
-      expect(trackEventSpy).toHaveBeenCalledWith('test-event-type');
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.list-view');
 
       delete window.appInsights;
       trackEventSpy.mockRestore();
@@ -111,15 +111,51 @@ describe('eventsSlice', () => {
 
       store.dispatch(
         eventAction({
-          type: 'test-event-type',
+          type: 'headlamp.list-view',
           data: {},
         })
       );
 
-      expect(trackEventSpy).toHaveBeenCalledWith('test-event-type');
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.list-view');
       expect(window.appInsights).toBeUndefined();
 
       window.appInsights = originalAppInsights;
+      trackEventSpy.mockRestore();
+    });
+
+    it('does not call trackEvent for an event type outside the allowlist', () => {
+      const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+      store.dispatch(
+        eventAction({
+          type: 'not-on-allowlist',
+          data: {},
+        })
+      );
+
+      expect(trackEventSpy).not.toHaveBeenCalled();
+
+      trackEventSpy.mockRestore();
+    });
+
+    it('calls trackEvent with only the type for an allowlisted event with a populated data field', () => {
+      const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+      store.dispatch(
+        eventAction({
+          type: 'headlamp.delete-resource',
+          data: {
+            resource: { metadata: { name: 'secret-loader', namespace: 'payments' } },
+            status: 'confirmed',
+          } as any,
+        })
+      );
+
+      expect(trackEventSpy).toHaveBeenCalledTimes(1);
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.delete-resource');
+      // Crucially, it must not have been called with the data payload.
+      expect(trackEventSpy).not.toHaveBeenCalledWith('headlamp.delete-resource', expect.anything());
+
       trackEventSpy.mockRestore();
     });
   });

--- a/frontend/src/redux/headlampEventSlice.test.tsx
+++ b/frontend/src/redux/headlampEventSlice.test.tsx
@@ -92,12 +92,12 @@ describe('eventsSlice', () => {
 
       store.dispatch(
         eventAction({
-          type: 'test-event-type',
+          type: 'headlamp.list-view',
           data: {},
         })
       );
 
-      expect(trackEventSpy).toHaveBeenCalledWith('test-event-type');
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.list-view');
 
       delete window.appInsights;
       trackEventSpy.mockRestore();
@@ -111,15 +111,66 @@ describe('eventsSlice', () => {
 
       store.dispatch(
         eventAction({
-          type: 'test-event-type',
+          type: 'headlamp.list-view',
           data: {},
         })
       );
 
-      expect(trackEventSpy).toHaveBeenCalledWith('test-event-type');
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.list-view');
       expect(window.appInsights).toBeUndefined();
 
       window.appInsights = originalAppInsights;
+      trackEventSpy.mockRestore();
+    });
+
+    it('does not call trackEvent for an event type outside the allowlist', () => {
+      const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+      store.dispatch(
+        eventAction({
+          type: 'not-on-allowlist',
+          data: {},
+        })
+      );
+
+      expect(trackEventSpy).not.toHaveBeenCalled();
+
+      trackEventSpy.mockRestore();
+    });
+
+    it('does not call trackEvent for ERROR_BOUNDARY (ErrorBoundary emits a direct exception event)', () => {
+      const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+      store.dispatch(
+        eventAction({
+          type: 'headlamp.error-boundary',
+          data: new Error('boom') as any,
+        })
+      );
+
+      expect(trackEventSpy).not.toHaveBeenCalled();
+
+      trackEventSpy.mockRestore();
+    });
+
+    it('calls trackEvent with only the type for an allowlisted event with a populated data field', () => {
+      const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+      store.dispatch(
+        eventAction({
+          type: 'headlamp.delete-resource',
+          data: {
+            resource: { metadata: { name: 'secret-loader', namespace: 'payments' } },
+            status: 'confirmed',
+          } as any,
+        })
+      );
+
+      expect(trackEventSpy).toHaveBeenCalledTimes(1);
+      expect(trackEventSpy).toHaveBeenCalledWith('headlamp.delete-resource');
+      // Crucially, it must not have been called with the data payload.
+      expect(trackEventSpy).not.toHaveBeenCalledWith('headlamp.delete-resource', expect.anything());
+
       trackEventSpy.mockRestore();
     });
   });

--- a/frontend/src/redux/headlampEventSlice.ts
+++ b/frontend/src/redux/headlampEventSlice.ts
@@ -358,8 +358,11 @@ export const eventAction = createAction<HeadlampEvent>('headlamp/event');
  * a HeadlampEventType because it is not dispatched through the redux event
  * action — it is a direct trackEvent call. It is allowlisted here for
  * symmetry and to document the full set of names that may reach the wire.
+ *
+ * The set is module-private and only reachable through
+ * `isTelemetryEventAllowlisted` so it cannot be mutated at runtime.
  */
-export const TELEMETRY_EVENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+const TELEMETRY_EVENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   HeadlampEventType.ERROR_BOUNDARY,
   HeadlampEventType.DELETE_RESOURCE,
   HeadlampEventType.DELETE_RESOURCES,
@@ -380,6 +383,14 @@ export const TELEMETRY_EVENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'exception',
 ]);
 
+/**
+ * Whether a given event type is allowed to be forwarded to App Insights.
+ * Exposed as a predicate so the underlying set cannot be mutated.
+ */
+export function isTelemetryEventAllowlisted(type: string): boolean {
+  return TELEMETRY_EVENT_ALLOWLIST.has(type);
+}
+
 export const listenerMiddleware =
   createListenerMiddleware<Pick<RootState, 'eventCallbackReducer'>>();
 listenerMiddleware.startListening({
@@ -389,7 +400,7 @@ listenerMiddleware.startListening({
     // Forward only the event type — never action.payload.data, which can
     // contain KubeObjects, resource names/namespaces, errors, or plugin
     // metadata. The allowlist drops any type-string we have not vetted.
-    if (TELEMETRY_EVENT_ALLOWLIST.has(action.payload.type)) {
+    if (isTelemetryEventAllowlisted(action.payload.type)) {
       trackEvent(action.payload.type);
     }
     for (const trackerFunc of trackerFuncs) {

--- a/frontend/src/redux/headlampEventSlice.ts
+++ b/frontend/src/redux/headlampEventSlice.ts
@@ -345,13 +345,53 @@ const initialState: {
 
 export const eventAction = createAction<HeadlampEvent>('headlamp/event');
 
+/**
+ * Event types that may be forwarded to App Insights. Any dispatched event
+ * whose type is not in this set is dropped before reaching trackEvent.
+ *
+ * This is an allowlist (not a denylist) by design: a new event type must be
+ * explicitly opted in to telemetry, and a future enum addition that
+ * accidentally encodes user data in its name (e.g. `cluster:my-prod`) cannot
+ * leak.
+ *
+ * `'exception'` is the synthetic type emitted from ErrorBoundary; it is not
+ * a HeadlampEventType because it is not dispatched through the redux event
+ * action — it is a direct trackEvent call. It is allowlisted here for
+ * symmetry and to document the full set of names that may reach the wire.
+ */
+export const TELEMETRY_EVENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  HeadlampEventType.ERROR_BOUNDARY,
+  HeadlampEventType.DELETE_RESOURCE,
+  HeadlampEventType.DELETE_RESOURCES,
+  HeadlampEventType.CREATE_RESOURCE,
+  HeadlampEventType.EDIT_RESOURCE,
+  HeadlampEventType.SCALE_RESOURCE,
+  HeadlampEventType.RESTART_RESOURCE,
+  HeadlampEventType.RESTART_RESOURCES,
+  HeadlampEventType.ROLLBACK_RESOURCE,
+  HeadlampEventType.LOGS,
+  HeadlampEventType.TERMINAL,
+  HeadlampEventType.POD_ATTACH,
+  HeadlampEventType.PLUGIN_LOADING_ERROR,
+  HeadlampEventType.PLUGINS_LOADED,
+  HeadlampEventType.DETAILS_VIEW,
+  HeadlampEventType.LIST_VIEW,
+  HeadlampEventType.OBJECT_EVENTS,
+  'exception',
+]);
+
 export const listenerMiddleware =
   createListenerMiddleware<Pick<RootState, 'eventCallbackReducer'>>();
 listenerMiddleware.startListening({
   actionCreator: eventAction,
   effect: async (action, listernerApi) => {
     const trackerFuncs = listernerApi.getState()?.eventCallbackReducer?.trackerFuncs;
-    trackEvent(action.payload.type);
+    // Forward only the event type — never action.payload.data, which can
+    // contain KubeObjects, resource names/namespaces, errors, or plugin
+    // metadata. The allowlist drops any type-string we have not vetted.
+    if (TELEMETRY_EVENT_ALLOWLIST.has(action.payload.type)) {
+      trackEvent(action.payload.type);
+    }
     for (const trackerFunc of trackerFuncs) {
       try {
         trackerFunc(action.payload);

--- a/frontend/src/redux/headlampEventSlice.ts
+++ b/frontend/src/redux/headlampEventSlice.ts
@@ -345,13 +345,69 @@ const initialState: {
 
 export const eventAction = createAction<HeadlampEvent>('headlamp/event');
 
+/**
+ * Event types that may be forwarded to App Insights. Any dispatched event
+ * whose type is not in this set is dropped before reaching trackEvent.
+ *
+ * This is an allowlist (not a denylist) by design: a new event type must be
+ * explicitly opted in to telemetry, and a future enum addition that
+ * accidentally encodes user data in its name (e.g. `cluster:my-prod`) cannot
+ * leak.
+ *
+ * `'exception'` is the synthetic type emitted from ErrorBoundary; it is not
+ * a HeadlampEventType because it is not dispatched through the redux event
+ * action — it is a direct trackEvent call. It is allowlisted here for
+ * symmetry and to document the full set of names that may reach the wire.
+ *
+ * The set is module-private — only the `isTelemetryEventAllowlisted`
+ * predicate is exported — and typed as `ReadonlySet<string>`, so neither
+ * external callers nor code inside this module can add or remove entries
+ * at runtime. New event types must be opted into telemetry explicitly by
+ * editing this list.
+ */
+const TELEMETRY_EVENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  // ERROR_BOUNDARY is intentionally omitted: ErrorBoundary.componentDidCatch
+  // calls trackEvent('exception', { errorName }) directly, so allowlisting
+  // the redux event here would emit a duplicate envelope on each error.
+  HeadlampEventType.DELETE_RESOURCE,
+  HeadlampEventType.DELETE_RESOURCES,
+  HeadlampEventType.CREATE_RESOURCE,
+  HeadlampEventType.EDIT_RESOURCE,
+  HeadlampEventType.SCALE_RESOURCE,
+  HeadlampEventType.RESTART_RESOURCE,
+  HeadlampEventType.RESTART_RESOURCES,
+  HeadlampEventType.ROLLBACK_RESOURCE,
+  HeadlampEventType.LOGS,
+  HeadlampEventType.TERMINAL,
+  HeadlampEventType.POD_ATTACH,
+  HeadlampEventType.PLUGIN_LOADING_ERROR,
+  HeadlampEventType.PLUGINS_LOADED,
+  HeadlampEventType.DETAILS_VIEW,
+  HeadlampEventType.LIST_VIEW,
+  HeadlampEventType.OBJECT_EVENTS,
+  'exception',
+]);
+
+/**
+ * Whether a given event type is allowed to be forwarded to App Insights.
+ * Exposed as a predicate so the underlying set cannot be mutated.
+ */
+export function isTelemetryEventAllowlisted(type: string): boolean {
+  return TELEMETRY_EVENT_ALLOWLIST.has(type);
+}
+
 export const listenerMiddleware =
   createListenerMiddleware<Pick<RootState, 'eventCallbackReducer'>>();
 listenerMiddleware.startListening({
   actionCreator: eventAction,
   effect: async (action, listernerApi) => {
     const trackerFuncs = listernerApi.getState()?.eventCallbackReducer?.trackerFuncs;
-    trackEvent(action.payload.type);
+    // Forward only the event type — never action.payload.data, which can
+    // contain KubeObjects, resource names/namespaces, errors, or plugin
+    // metadata. The allowlist drops any type-string we have not vetted.
+    if (isTelemetryEventAllowlisted(action.payload.type)) {
+      trackEvent(action.payload.type);
+    }
     for (const trackerFunc of trackerFuncs) {
       try {
         trackerFunc(action.payload);

--- a/plugins/pluginctl/src/multi-plugin-management.test.js
+++ b/plugins/pluginctl/src/multi-plugin-management.test.js
@@ -26,19 +26,19 @@ describe('MultiPluginManagement', () => {
   let installer;
   const PLUGIN_DATA = [
     {
-      name: 'appcatalog_headlamp_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
-      version: '0.0.3',
+      name: 'headlamp_opencost',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
+      version: '0.1.3',
     },
     {
-      name: 'ai_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/ai_plugin',
-      version: '0.0.2',
+      name: 'headlamp_kompose',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_kompose',
+      version: '0.1.1-beta',
     },
     {
-      name: 'prometheus_headlamp_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin',
-      version: '0.0.3',
+      name: 'headlamp_flux',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_flux',
+      version: '0.6.0',
     },
   ];
   beforeEach(async () => {

--- a/plugins/pluginctl/src/plugin-management.e2e.js
+++ b/plugins/pluginctl/src/plugin-management.e2e.js
@@ -52,12 +52,12 @@ let plugins = JSON.parse(output);
 console.log('Initial plugins:', plugins);
 
 // Ensure the plugin is not installed
-const pluginName = 'prometheus';
+const pluginName = '@headlamp-k8s/minikube';
 let pluginExists = plugins.some(plugin => plugin.pluginName === pluginName);
 assert.strictEqual(pluginExists, false, 'Plugin should not be initially installed');
 
 // Install the plugin
-const pluginURL = 'https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin';
+const pluginURL = 'https://artifacthub.io/packages/headlamp/test-123/headlamp_minikube';
 output = runCommand(`node ../bin/pluginctl.js install ${pluginURL}`);
 console.log('Install output:', output);
 

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -49,7 +49,7 @@ describe('PluginManager Test Cases', () => {
 
   test('Install Plugin', async () => {
     await PluginManager.install(
-      'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
+      'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
       tempDir,
       '',
       mockProgressCallback
@@ -71,8 +71,8 @@ describe('PluginManager Test Cases', () => {
   });
 
   test('No Update available for Plugin', async () => {
-    // No updates available for "app-catalog" plugin
-    await PluginManager.update('app-catalog', tempDir, '', mockProgressCallback);
+    // No updates available for "opencost" plugin
+    await PluginManager.update('@headlamp-k8s/opencost', tempDir, '', mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'error',
       message: 'No updates available',
@@ -80,18 +80,17 @@ describe('PluginManager Test Cases', () => {
   });
 
   test('Update Plugin', async () => {
-    // update the "app-catalog" plugin package.json with lower state
-    const packageJSONPath = `${tempDir}/appcatalog_headlamp_plugin/package.json`;
+    // update the "opencost" plugin package.json with lower version
+    const packageJSONPath = `${tempDir}/headlamp_opencost/package.json`;
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
     packageJSON.artifacthub.version = `${semver.major(
       packageJSON.artifacthub.version
-    )}.${semver.minor(packageJSON.artifacthub.version)}.${
-      semver.patch(packageJSON.artifacthub.version) - 1
-    }`; // Reduce the version using semver
+    )}.${semver.minor(packageJSON.artifacthub.version)}.${semver.patch(packageJSON.artifacthub.version) - 1
+      }`; // Reduce the version using semver
     // Write the updated package.json back to the file
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 
-    await PluginManager.update('app-catalog', tempDir, '', mockProgressCallback);
+    await PluginManager.update('@headlamp-k8s/opencost', tempDir, '', mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'success',
       message: 'Plugin Updated',
@@ -102,7 +101,7 @@ describe('PluginManager Test Cases', () => {
     const tempDir = tmp.dirSync({ unsafeCleanup: true }).name;
 
     await PluginManager.install(
-      'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
+      'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
       tempDir,
       '',
       mockProgressCallback
@@ -112,7 +111,7 @@ describe('PluginManager Test Cases', () => {
       message: 'Plugin Installed',
     });
 
-    PluginManager.uninstall('app-catalog', tempDir, mockProgressCallback);
+    PluginManager.uninstall('@headlamp-k8s/opencost', tempDir, mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'success',
       message: 'Plugin Uninstalled',

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -23,10 +23,10 @@ This tests unpublished @headlamp-k8s/pluginctl package in repo.
 
 Assumes being run within the plugins/pluginctl folder
 `;
-const PACKAGE_NAME = "appcatalog_headlamp_plugin";
+const PACKAGE_NAME = "headlamp_opencost";
 const PACKAGE_URL =
-  "https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin";
-const PACKAGE_NAME_TO_UNINSTALL = "app-catalog";
+  "https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost";
+const PACKAGE_NAME_TO_UNINSTALL = "@headlamp-k8s/opencost";
 
 function testPluginctl() {
   // remove some temporary files.


### PR DESCRIPTION
## Summary

Reduce App Insights telemetry shipped from the Headlamp frontend to anonymous app-usage counts only. An external review flagged the previous implementation as too liberal.

- **Lock down SDK config:** disable AJAX/fetch/exception/cookies/storage/auto-route auto-collection. Drop the unconditional `trackPageView()` call (URLs in Headlamp encode cluster, namespace, and resource names).
- **Allowlist event types** in the redux listener middleware. A future `HeadlampEventType` addition that accidentally encodes user data in its name string cannot leak — it must be opted into telemetry explicitly. `action.payload.data` is still never forwarded.
- **Replace `trackException`** (which shipped the full `Error` including message and stack) with `trackEvent('exception', { errorName: error.name })`. Ships only the constructor name (e.g. `TypeError`, `KubeApiError`) — no message, no stack.
- **Telemetry initializer** as defense-in-depth: strips `ai.user.*` / `ai.session.id` / `ai.location.ip` envelope tags and clears `uri` / `refUri` / `url` fields on every outgoing envelope, regardless of how they got there.

Net result: each outgoing telemetry envelope contains an allowlisted event name (`headlamp.list-view`, `headlamp.delete-resource`, …) and, for `'exception'`, `errorName`. No URL, user id, session id, IP, cluster, namespace, resource name, error message, or stack.

## Test plan

- [x] `npm run tsc` clean
- [x] `npm run lint` clean
- [x] New unit tests pass (13 total across `analytics.test.ts`, `headlampEventSlice.test.tsx`, `ErrorBoundary.test.tsx`)
- [ ] Manual smoke: run with `REACT_APP_APPINSIGHTS_CONNECTION_STRING` set; confirm in browser devtools (Network → `track`) that envelopes contain no `ai.user.*` / `ai.session.id` / `ai.location.ip` tags, no `uri` / `refUri` / `url`, no `PageView`, no `RemoteDependencyData`, and that triggering an error in an `ErrorBoundary` produces a single `EventData` envelope with `name: 'exception'` and `properties: { errorName: ... }` only.

