### PR TITLE
Pass azureContext to DeployWizard to enable Azure Workload Identity Step

### DIFF
--- a/plugins/aks-desktop/src/components/Deploy/DeployButton.test.tsx
+++ b/plugins/aks-desktop/src/components/Deploy/DeployButton.test.tsx
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const telemetryMocks = vi.hoisted(() => ({ trackFeature: vi.fn() }));
 const dialogMocks = vi.hoisted(() => ({
+  open: false,
+  initialApplicationName: undefined as string | undefined,
   openDialog: vi.fn(),
   closeDialog: vi.fn(),
 }));
@@ -16,13 +18,27 @@ const deployUrlState = vi.hoisted(() => ({
   initialApplicationName: undefined as string | undefined,
   clearUrlTrigger: vi.fn(),
 }));
+const azureHookMocks = vi.hoisted(() => ({
+  useAzureContext: vi.fn(),
+  useNamespaceCapabilities: vi.fn(),
+}));
+const deployWizardMocks = vi.hoisted(() => ({ render: vi.fn() }));
 
 vi.mock('../../telemetry', () => telemetryMocks);
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
+vi.mock('../../hooks/useAzureContext', () => ({
+  useAzureContext: azureHookMocks.useAzureContext,
+}));
+vi.mock('../../hooks/useNamespaceCapabilities', () => ({
+  useNamespaceCapabilities: azureHookMocks.useNamespaceCapabilities,
+}));
 vi.mock('../DeployWizard/DeployWizard', () => ({
-  default: () => <div>Deploy wizard</div>,
+  default: (props: Record<string, unknown>) => {
+    deployWizardMocks.render(props);
+    return <div>Deploy wizard</div>;
+  },
 }));
 vi.mock('./hooks/useDeployUrlParams', () => ({
   useDeployUrlParams: () => ({
@@ -33,8 +49,8 @@ vi.mock('./hooks/useDeployUrlParams', () => ({
 }));
 vi.mock('./hooks/useDialogState', () => ({
   useDialogState: () => ({
-    open: false,
-    initialApplicationName: undefined,
+    open: dialogMocks.open,
+    initialApplicationName: dialogMocks.initialApplicationName,
     openDialog: dialogMocks.openDialog,
     closeDialog: dialogMocks.closeDialog,
   }),
@@ -47,9 +63,23 @@ describe('DeployButton telemetry', () => {
     vi.clearAllMocks();
     deployUrlState.shouldOpenDialog = false;
     deployUrlState.initialApplicationName = undefined;
+    dialogMocks.open = false;
+    dialogMocks.initialApplicationName = undefined;
+    azureHookMocks.useAzureContext.mockReturnValue({ azureContext: null, error: null });
+    azureHookMocks.useNamespaceCapabilities.mockReturnValue({
+      isManagedNamespace: false,
+      azureRbacEnabled: false,
+    });
   });
 
   afterEach(() => cleanup());
+
+  it('does not resolve Azure context while the deploy dialog is closed', () => {
+    render(<DeployButton project={{ id: 'project', clusters: ['cluster-1'], namespaces: [] }} />);
+
+    expect(azureHookMocks.useAzureContext).not.toHaveBeenCalled();
+    expect(azureHookMocks.useNamespaceCapabilities).not.toHaveBeenCalled();
+  });
 
   it('reports the deploy workflow opening from the user action', () => {
     render(<DeployButton project={{ id: 'project', clusters: [], namespaces: [] }} />);
@@ -91,5 +121,44 @@ describe('DeployButton telemetry', () => {
     expect(telemetryMocks.trackFeature).toHaveBeenCalledTimes(1);
     expect(dialogMocks.openDialog).toHaveBeenCalledTimes(1);
     expect(deployUrlState.clearUrlTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards Azure context and default namespace capabilities to the deploy wizard', () => {
+    dialogMocks.open = true;
+    azureHookMocks.useAzureContext.mockReturnValue({
+      azureContext: {
+        subscriptionId: 'subscription-1',
+        resourceGroup: 'resource-group-1',
+        tenantId: 'tenant-1',
+      },
+      error: 'Azure context warning',
+    });
+    azureHookMocks.useNamespaceCapabilities.mockReturnValue({
+      isManagedNamespace: true,
+      azureRbacEnabled: true,
+    });
+
+    render(<DeployButton project={{ id: 'project', clusters: ['cluster-1'], namespaces: [] }} />);
+
+    expect(azureHookMocks.useAzureContext).toHaveBeenCalledWith('cluster-1');
+    expect(azureHookMocks.useNamespaceCapabilities).toHaveBeenCalledWith({
+      subscriptionId: 'subscription-1',
+      resourceGroup: 'resource-group-1',
+      clusterName: 'cluster-1',
+      namespace: 'default',
+    });
+    expect(deployWizardMocks.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cluster: 'cluster-1',
+        azureContext: {
+          subscriptionId: 'subscription-1',
+          resourceGroup: 'resource-group-1',
+          clusterName: 'cluster-1',
+          isManagedNamespace: true,
+          azureRbacEnabled: true,
+        },
+        azureContextError: 'Azure context warning',
+      })
+    );
   });
 });

--- a/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
+++ b/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
@@ -5,6 +5,8 @@ import { Icon } from '@iconify/react';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Button, Dialog } from '@mui/material';
 import React, { useEffect } from 'react';
+import { useAzureContext } from '../../hooks/useAzureContext';
+import { useNamespaceCapabilities } from '../../hooks/useNamespaceCapabilities';
 import DeployWizard from '../DeployWizard/DeployWizard';
 import { useDeployUrlParams } from './hooks/useDeployUrlParams';
 import { useDialogState } from './hooks/useDialogState';
@@ -41,6 +43,15 @@ function DeployButton({ project }: DeployButtonProps) {
   const { t } = useTranslation();
   const urlParams = useDeployUrlParams();
   const dialogState = useDialogState();
+  const cluster = project.clusters?.[0] || undefined;
+  const namespace = project.namespaces?.[0] || undefined;
+  const { azureContext, error: azureContextError } = useAzureContext(cluster);
+  const { isManagedNamespace, azureRbacEnabled } = useNamespaceCapabilities({
+    subscriptionId: azureContext?.subscriptionId,
+    resourceGroup: azureContext?.resourceGroup,
+    clusterName: cluster,
+    namespace: namespace ?? '',
+  });
 
   // Open dialog when URL parameters indicate we should
   useEffect(() => {
@@ -91,10 +102,22 @@ function DeployButton({ project }: DeployButtonProps) {
         }}
       >
         <DeployWizard
-          cluster={project.clusters?.[0] || undefined}
-          namespace={project.namespaces?.[0] || undefined}
+          cluster={cluster}
+          namespace={namespace}
           initialApplicationName={dialogState.initialApplicationName}
           onClose={handleClose}
+          azureContext={
+            azureContext && cluster
+              ? {
+                  subscriptionId: azureContext.subscriptionId,
+                  resourceGroup: azureContext.resourceGroup,
+                  clusterName: cluster,
+                  isManagedNamespace,
+                  azureRbacEnabled,
+                }
+              : undefined
+          }
+          azureContextError={azureContextError ?? undefined}
         />
       </Dialog>
     </>

--- a/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
+++ b/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
@@ -5,6 +5,8 @@ import { Icon } from '@iconify/react';
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
 import { Button, Dialog } from '@mui/material';
 import React, { useEffect, useRef } from 'react';
+import { useAzureContext } from '../../hooks/useAzureContext';
+import { useNamespaceCapabilities } from '../../hooks/useNamespaceCapabilities';
 import { trackFeature } from '../../telemetry';
 import DeployWizard from '../DeployWizard/DeployWizard';
 import { useDeployUrlParams } from './hooks/useDeployUrlParams';
@@ -39,6 +41,49 @@ interface DeployButtonProps {
   project: Project;
 }
 
+interface DeployDialogContentProps {
+  cluster?: string;
+  namespace?: string;
+  initialApplicationName?: string;
+  onClose: () => void;
+}
+
+function DeployDialogContent({
+  cluster,
+  namespace,
+  initialApplicationName,
+  onClose,
+}: DeployDialogContentProps) {
+  const { azureContext, error: azureContextError } = useAzureContext(cluster);
+  const { isManagedNamespace, azureRbacEnabled } = useNamespaceCapabilities({
+    subscriptionId: azureContext?.subscriptionId,
+    resourceGroup: azureContext?.resourceGroup,
+    clusterName: cluster,
+    namespace: namespace ?? 'default',
+  });
+
+  return (
+    <DeployWizard
+      cluster={cluster}
+      namespace={namespace}
+      initialApplicationName={initialApplicationName}
+      onClose={onClose}
+      azureContext={
+        azureContext && cluster
+          ? {
+              subscriptionId: azureContext.subscriptionId,
+              resourceGroup: azureContext.resourceGroup,
+              clusterName: cluster,
+              isManagedNamespace,
+              azureRbacEnabled,
+            }
+          : undefined
+      }
+      azureContextError={azureContextError ?? undefined}
+    />
+  );
+}
+
 /**
  * Renders a button that opens the deploy wizard dialog.
  *
@@ -49,6 +94,8 @@ function DeployButton({ project }: DeployButtonProps) {
   const urlParams = useDeployUrlParams();
   const dialogState = useDialogState();
   const handledUrlOpenRef = useRef(false);
+  const cluster = project.clusters?.[0] || undefined;
+  const namespace = project.namespaces?.[0] || undefined;
 
   // Open dialog when URL parameters indicate we should
   useEffect(() => {
@@ -105,12 +152,14 @@ function DeployButton({ project }: DeployButtonProps) {
           },
         }}
       >
-        <DeployWizard
-          cluster={project.clusters?.[0] || undefined}
-          namespace={project.namespaces?.[0] || undefined}
-          initialApplicationName={dialogState.initialApplicationName}
-          onClose={handleClose}
-        />
+        {dialogState.open && (
+          <DeployDialogContent
+            cluster={cluster}
+            namespace={namespace}
+            initialApplicationName={dialogState.initialApplicationName}
+            onClose={handleClose}
+          />
+        )}
       </Dialog>
     </>
   );

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
@@ -24,6 +24,8 @@ type DeployWizardProps = {
   onClose?: () => void;
   /** Azure context for workload identity setup */
   azureContext?: DeployAzureContext;
+  /** Error message from resolving the Azure context, if any. */
+  azureContextError?: string;
 };
 
 /**
@@ -71,6 +73,7 @@ export default function DeployWizard(props: DeployWizardProps) {
               <ConfigureContainer
                 containerConfig={containerConfig}
                 azureContext={props.azureContext}
+                azureContextError={props.azureContextError}
                 namespace={props.namespace}
               />
             )}

--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
@@ -22,8 +22,9 @@ interface ConfigureContainerProps {
   };
   /** When false, containerImage is not required to proceed past the Basics step. Default: true. */
   requireContainerImage?: boolean;
-  /** Azure context needed for workload identity setup */
   azureContext?: DeployAzureContext;
+  /** Error message from resolving the Azure context, if any. */
+  azureContextError?: string;
   /** Target namespace for workload identity setup */
   namespace?: string;
 }
@@ -32,6 +33,7 @@ export default function ConfigureContainer({
   containerConfig,
   requireContainerImage = true,
   azureContext,
+  azureContextError,
   namespace,
 }: ConfigureContainerProps) {
   const { t } = useTranslation();
@@ -93,6 +95,7 @@ export default function ConfigureContainer({
             <WorkloadIdentityStep
               containerConfig={containerConfig}
               azureContext={azureContext}
+              azureContextError={azureContextError}
               namespace={namespace}
             />
           </StepContent>

--- a/plugins/aks-desktop/src/components/DeployWizard/components/WorkloadIdentityStep.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/WorkloadIdentityStep.tsx
@@ -34,12 +34,15 @@ import {
 interface WorkloadIdentityStepProps {
   containerConfig: ContainerConfigProp;
   azureContext?: DeployAzureContext;
+  /** Error message from resolving the Azure context, if any. */
+  azureContextError?: string;
   namespace?: string;
 }
 
 export default function WorkloadIdentityStep({
   containerConfig,
   azureContext,
+  azureContextError,
   namespace,
 }: WorkloadIdentityStepProps) {
   const { t } = useTranslation();
@@ -116,7 +119,7 @@ export default function WorkloadIdentityStep({
       />
       {!azureContext && (
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', ml: 5 }}>
-          {t('Azure sign-in is required to configure workload identity.')}
+          {azureContextError ?? t('Azure sign-in is required to configure workload identity.')}
         </Typography>
       )}
       {containerConfig.config.enableWorkloadIdentity && azureContext && (


### PR DESCRIPTION
## Description

Currently our `WorkloadIdentityStep` is gated by the presence of `azureContext`, and it appears we aren't passing that into the `DeployWizard`, thus it's always disabled. 

This PR gets and passes the `azureContext` into `DeployWizard` via `DeployButton`, which re-enables this option & provides the context for it's operations.

Fixes issue:

- https://github.com/Azure/aks-desktop/issues/617

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #617 

## Changes Made

- Added `azureContext`, fetched via `useAzureContext`
- Added `isManagedNamespace` & `azureRbacenabled`, fetched via `useNamespaceCapabilities`
- Passed new `azureContext`, `isManagedNamespace` & `azureRbacenabled` into `DeployWizard` (to satisfy `DeployAzureContext` interface)
- Added `azureContextError` to surface detailed errors if caught

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

Manual Testing:

1. Click 'Deploy Application` 
2. Navigate to the Workload Identity Step
3. Observe that the step is now enabled & interactable.