### PR TITLE
Fix deploy manifest being cut off

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.tsx
@@ -161,10 +161,13 @@ export default function DeployPure({
               borderColor: 'divider',
               borderRadius: 1,
               overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+              display: 'flex',
             }}
           >
             <MonacoEditor
-              height="60vh"
+              height="100%"
               language="yaml"
               value={containerPreviewYaml}
               onChange={() => {}}


### PR DESCRIPTION
## Description

The manifest editor on the Deploy step was hardcoded to 60vh, larger than the 55vh component it resided in, resulting in final content being cut off.

Switched to flex layout & modified height to ensure editor content is fully expanded & contained within the view.

Fixes issue:

- https://github.com/Azure/aks-desktop/issues/625

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #625

## Changes Made

- Changed `MonacoEditor` `height` from 60vh -> 100%
- Added `flex:1`, `minHeight:0` & `display:flex` properties to parent `Box`

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

Manual Testing:

1. Go through the deployment wizard, until the final step.
2. Observe the deployment manifest is fully visible.

## Screenshots/Videos

If applicable, add screenshots or videos to demonstrate the changes.