### PR TITLE
upstreamable: frontend: ProjectDetails: Fix stale custom tabs

### DIFF
--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -98,46 +98,38 @@ export function ClusterNameEditor({
     setCustomNameInUse(nameInUse);
   }
 
-  function ClusterErrorDialog() {
-    return (
-      <ConfirmDialog
-        onConfirm={() => {
-          setClusterErrorDialogOpen(false);
-        }}
-        handleClose={() => {
-          setClusterErrorDialogOpen(false);
-        }}
-        hideCancelButton
-        open={clusterErrorDialogOpen}
-        title={t('translation|Error')}
-        description={clusterErrorDialogMessage}
-        confirmLabel={t('translation|Okay')}
-      ></ConfirmDialog>
-    );
-  }
+  const clusterErrorDialog = (
+    <ConfirmDialog
+      onConfirm={() => {
+        setClusterErrorDialogOpen(false);
+      }}
+      handleClose={() => {
+        setClusterErrorDialogOpen(false);
+      }}
+      hideCancelButton
+      open={clusterErrorDialogOpen}
+      title={t('translation|Error')}
+      description={clusterErrorDialogMessage}
+      confirmLabel={t('translation|Okay')}
+    ></ConfirmDialog>
+  );
 
   // Display the original name of the cluster if it was loaded from a kubeconfig file.
-  function ClusterName() {
-    const currentName = clusterInfo?.name;
-    const originalName = clusterInfo?.meta_data?.originalName;
-    const source = clusterInfo?.meta_data?.source;
-    // Note: display original name is currently only supported for non dynamic clusters from kubeconfig sources.
-    const displayOriginalName = source === 'kubeconfig' && originalName;
-
-    return (
-      <>
-        {clusterErrorDialogOpen && <ClusterErrorDialog />}
-        <Typography>{t('translation|Name')}</Typography>
-        {displayOriginalName && currentName !== displayOriginalName && (
-          <Typography variant="body2" color="textSecondary">
-            {t('translation|Original name: {{ displayName }}', {
-              displayName: displayName,
-            })}
-          </Typography>
-        )}
-      </>
-    );
-  }
+  // Note: display original name is currently only supported for non dynamic clusters from kubeconfig sources.
+  const displayOriginalName = source === 'kubeconfig' && originalName;
+  const clusterNameContent = (
+    <>
+      {clusterErrorDialogOpen && clusterErrorDialog}
+      <Typography>{t('translation|Name')}</Typography>
+      {displayOriginalName && clusterInfo?.name !== displayOriginalName && (
+        <Typography variant="body2" color="textSecondary">
+          {t('translation|Original name: {{ displayName }}', {
+            displayName: displayName,
+          })}
+        </Typography>
+      )}
+    </>
+  );
 
   function storeNewClusterName(name: string) {
     let actualName = name;

--- a/frontend/src/components/App/VersionDialog.tsx
+++ b/frontend/src/components/App/VersionDialog.tsx
@@ -87,9 +87,9 @@ export default function VersionDialog(props: {
     }
   };
 
-  const AboutTab = () => <NameValueTable rows={rows} />;
+  const aboutTab = <NameValueTable rows={rows} />;
 
-  const LegalTab = () => (
+  const legalTab = (
     <Box sx={{ p: 2 }}>
       <Typography variant="body1" paragraph>
         As installed, this program contains software and functionality that is either open source or

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -87,6 +87,15 @@ const DEFAULT_TABS: Record<string, ProjectDetailsTab> = {
   },
 };
 
+function getProjectKey(project: ProjectDefinition, routeName?: string) {
+  return JSON.stringify({
+    routeName: routeName ?? project.id,
+    id: project.id,
+    clusters: [...project.clusters].sort(),
+    namespaces: [...project.namespaces].sort(),
+  });
+}
+
 export default function ProjectDetails() {
   const { t } = useTranslation();
   const { name } = useParams<ProjectDetailsParams>();
@@ -97,10 +106,14 @@ export default function ProjectDetails() {
   if (isProjectLoading || !project || !name) {
     return <Loader title={t('Loading')} />;
   }
-  // Key forces remount when project name or plugin resource list changes,
-  // which is required because useProjectItems → useKubeLists calls hooks
-  // per resource in a loop (the array length must stay stable per mount).
-  return <ProjectDetailsContent key={`${name}-${pluginApiResources.length}`} project={project} />;
+  // Remount when the route or resolved project identity changes.
+  // The plugin resource list length is included in the key because
+  // useProjectItems → useKubeLists calls hooks per resource in a loop
+  // (the array length must stay stable per mount).
+  const projectKey = getProjectKey(project, name);
+  return (
+    <ProjectDetailsContent key={`${projectKey}-${pluginApiResources.length}`} project={project} />
+  );
 }
 
 function ProjectOverview({
@@ -499,9 +512,11 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
 
   const { items, isLoading } = useProjectItems(project);
 
-  const [allTabs, setAllTabs] = useState<Record<string, ProjectDetailsTab>>(DEFAULT_TABS);
+  const [customTabs, setCustomTabs] = useState<Record<string, ProjectDetailsTab>>({});
 
   useEffect(() => {
+    let isCurrent = true;
+
     async function loadTabs() {
       const registeredTabsList = Object.values(registeredTabs);
       // Get a list of enabled Tabs
@@ -524,28 +539,36 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
         )
       ).filter(Boolean) as ProjectDetailsTab[];
 
+      if (!isCurrent) return;
+
       const enabledTabsById = Object.fromEntries(enabledTabs.map(tab => [tab.id, tab]));
-
-      // Merge default tabs with custom tabs
-      const allTabs: Record<string, ProjectDetailsTab> = {
-        ...DEFAULT_TABS,
-        ...enabledTabsById,
-      };
-
-      setAllTabs(allTabs);
+      setCustomTabs(enabledTabsById);
     }
 
     loadTabs();
+
+    return () => {
+      isCurrent = false;
+    };
   }, [registeredTabs, project]);
 
-  // Set initial selected tab to the first available tab
-  const tabIds = Object.keys(allTabs);
-  if (tabIds.length > 0 && !selectedTab) {
-    setSelectedTab(tabIds[0]);
-  }
+  const allTabs = useMemo(
+    () => ({
+      ...DEFAULT_TABS,
+      ...customTabs,
+    }),
+    [customTabs]
+  );
 
-  // Get the definition for the currently selected tab
-  const selectedTabData = selectedTab ? allTabs[selectedTab] : undefined;
+  // Only tabs with a component can be rendered, so selection must be based
+  // on the same filter used when rendering the tab list below.
+  const firstTabId = Object.keys(allTabs).find(id => allTabs[id].component);
+
+  // Derive the active tab, falling back to the first renderable tab when the
+  // selected tab is missing or no longer renderable. Deriving during render
+  // (instead of syncing via an effect) avoids stale/blank tab content.
+  const activeTab = selectedTab && allTabs[selectedTab]?.component ? selectedTab : firstTabId;
+  const selectedTabData = activeTab ? allTabs[activeTab] : undefined;
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
     setSelectedTab(newValue);
@@ -598,7 +621,7 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
         >
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tabs
-              value={selectedTab}
+              value={activeTab}
               onChange={handleTabChange}
               variant="scrollable"
               scrollButtons="auto"


### PR DESCRIPTION
These changes fix stale custom project detail tabs by scoping plugin tab state to the current route and resolved project identity.

Related: #634

### Summary

- Adds a project identity key from the route name, project id, clusters, and namespaces
- Remounts `ProjectDetailsContent` when the route or resolved project identity changes
- Stores custom/plugin tabs separately from default tabs and tags them with the current project key
- Clears project-specific plugin tabs while async `isEnabled` checks reload for the current project
- Ignores stale async tab eligibility results after the project changes
- Prevents blank tab content by resetting the selected tab when the previous tab no longer exists
- Keeps default project tabs visible while custom links are being reevaluated

### Testing

- [x] Manually verified navigating from a project with a custom Info tab to a project without that tab no longer leaves the stale Info tab visible
- [x] Manually verified hard reload on a project without an eligible info does not show stale tab content
- [x] Confirmed `frontend/src/components/project/ProjectDetails.tsx` has no TS errors