### PR TITLE
InfoTab: Require namespace context

### DIFF
--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -45,7 +45,11 @@ import ScalingTab from './components/Scaling/ScalingTab';
 import type { ProjectDefinition } from './types/project';
 import { getLoginStatus } from './utils/azure/az-auth';
 import { AZURE_ACCOUNT_POLL_INTERVAL_MS } from './utils/constants/timing';
-import { isAksProject, isArmManagedProject } from './utils/shared/isAksProject';
+import {
+  isAksProject,
+  isAksProjectWithResourceGroup,
+  isArmManagedProject,
+} from './utils/shared/isAksProject';
 import { azureTheme } from './utils/shared/theme';
 
 Headlamp.setAppMenu(menus => {
@@ -341,7 +345,7 @@ registerProjectDetailsTab({
   id: 'info',
   label: 'Info',
   icon: 'mdi:information',
-  isEnabled: isAksProject,
+  isEnabled: isAksProjectWithResourceGroup,
   component: ({ project }) => <InfoTab project={project} />,
 });
 

--- a/plugins/aks-desktop/src/utils/shared/isAksProject.ts
+++ b/plugins/aks-desktop/src/utils/shared/isAksProject.ts
@@ -2,20 +2,40 @@
 // Licensed under the Apache 2.0.
 
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
+import { clusterRequest } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
 import type { ApiClient } from '@kinvolk/headlamp-plugin/lib/lib/k8s/api/v1/factories';
 import type { KubeNamespace } from '@kinvolk/headlamp-plugin/lib/lib/k8s/namespace';
 import {
   MANAGED_BY_ARM_LABEL,
   PROJECT_MANAGED_BY_LABEL,
   PROJECT_MANAGED_BY_VALUE,
+  RESOURCE_GROUP_LABEL,
 } from '../constants/projectLabels';
 
+type ProjectRef = { namespaces: string[]; clusters: string[] };
+
+/**
+ * Fetches namespace labels via a direct HTTP request (no streaming/WebSocket).
+ * This avoids stale data from the streaming API when the same namespace name
+ * exists across multiple clusters.
+ */
+async function getNamespaceLabels(
+  namespaceName: string,
+  cluster: string
+): Promise<Record<string, string> | null> {
+  try {
+    const ns = (await clusterRequest(`/api/v1/namespaces/${encodeURIComponent(namespaceName)}`, {
+      cluster,
+      method: 'GET',
+    })) as KubeNamespace;
+    return ns.metadata?.labels ?? {};
+  } catch {
+    return null;
+  }
+}
+
 /** Checks if the given project is an AKS Desktop project (managed-by: aks-desktop). */
-export const isAksProject = ({
-  project,
-}: {
-  project: { namespaces: string[]; clusters: string[] };
-}): Promise<boolean> =>
+export const isAksProject = ({ project }: { project: ProjectRef }): Promise<boolean> =>
   new Promise<boolean>(resolve => {
     const cancelFn = (K8s.ResourceClasses.Namespace.apiEndpoint as ApiClient<KubeNamespace>).get(
       project.namespaces[0],
@@ -32,12 +52,23 @@ export const isAksProject = ({
     );
   });
 
-/** Checks if the given project is an AKS Desktop + ARM-managed namespace. */
-export const isArmManagedProject = ({
+/** Checks if the given single-cluster, single-namespace project has AKS Desktop resource group context. */
+export const isAksProjectWithResourceGroup = async ({
   project,
 }: {
-  project: { namespaces: string[]; clusters: string[] };
-}): Promise<boolean> =>
+  project: ProjectRef;
+}): Promise<boolean> => {
+  if (project.namespaces.length !== 1 || project.clusters.length !== 1) return false;
+
+  const labels = await getNamespaceLabels(project.namespaces[0], project.clusters[0]);
+  if (!labels) return false;
+  return (
+    labels[PROJECT_MANAGED_BY_LABEL] === PROJECT_MANAGED_BY_VALUE && !!labels[RESOURCE_GROUP_LABEL]
+  );
+};
+
+/** Checks if the given project is an AKS Desktop + ARM-managed namespace. */
+export const isArmManagedProject = ({ project }: { project: ProjectRef }): Promise<boolean> =>
   new Promise<boolean>(resolve => {
     const cancelFn = (K8s.ResourceClasses.Namespace.apiEndpoint as ApiClient<KubeNamespace>).get(
       project.namespaces[0],


### PR DESCRIPTION
These changes prevent the InfoTab from appearing from projects that do not have the managed namespace metadata required for the tab to load and update settings.

Related: #634 

### Summary

- Updates InfoTab eligibility to require the AKS namespace context needed by the tab
- Avoids showing a blank or unusable Infotab for projects taht cannot be managed by the InfoTab
- Keeps InfoTab behavior unchanged for projects with the required metadata

### Testing
- [x] Manually verified the InfoTab appears for eligible projects
- [x] Manually verified the InfoTab is hidden for projects missing the required context
- [x] Manually verified the InfoTab does not reappear after navigating between eligible and ineligible projects