### PR TITLE
app: frontend: Add runCmd support and plugin identification

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1482,6 +1482,7 @@ async function startElectron() {
   console.info('App starting...');
   // add run cmd consent for aks-desktop to avoid consent dialogs for the aks-desktop plugin
   addRunCmdConsent({ name: 'aks-desktop' });
+  addRunCmdConsent({ name: 'ai-assistant' });
 
   // Increase max listeners to prevent false positive warnings
   // The app legitimately needs multiple IPC listeners (currently 11)

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -215,6 +215,17 @@ describe('validateCommandData', () => {
     ).toBe(true);
   });
 
+  it('returns true for valid gh command', () => {
+    expect(
+      validateCommandData({
+        command: 'gh',
+        args: ['auth', 'token'],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(true);
+  });
+
   it('returns true for valid scriptjs command', () => {
     expect(
       validateCommandData({

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -165,6 +165,7 @@ const COMMANDS_WITH_CONSENT = {
     'kubectl top',
     'kubectl config',
   ],
+  ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
 };
 
 /**
@@ -195,6 +196,11 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
     commands = COMMANDS_WITH_CONSENT.aks_desktop;
   }
 
+  const pluginIsAiAssistant = pluginInfo.name === 'ai-assistant';
+  if (pluginIsAiAssistant) {
+    commands = COMMANDS_WITH_CONSENT.ai_assistant;
+  }
+
   for (const command of commands) {
     if (!settings.confirmedCommands[command]) {
       settings.confirmedCommands[command] = true;
@@ -220,6 +226,9 @@ export function removeRunCmdConsent(pluginName: string): void {
     pluginName === '@headlamp-k8s/minikube'
   ) {
     commands = COMMANDS_WITH_CONSENT.headlamp_minikube;
+  }
+  if (pluginName === 'ai-assistant') {
+    commands = COMMANDS_WITH_CONSENT.ai_assistant;
   }
   for (const command of commands) {
     delete settings.confirmedCommands[command];
@@ -483,6 +492,7 @@ export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: E
     'runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js': cryptoRandom(),
     'runCmd-az': cryptoRandom(),
     'runCmd-kubectl': cryptoRandom(),
+    'runCmd-gh': cryptoRandom(),
   };
 
   ipcMain.on('request-plugin-permission-secrets', function giveSecrets() {
@@ -540,7 +550,7 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
   }
 
   // Added 'kubectl' for AKS desktop downstream integration (aks-desktop patch)
-  const validCommands = ['minikube', 'az', 'kubectl', 'scriptjs', 'kubelogin'];
+  const validCommands = ['minikube', 'az', 'kubectl', 'scriptjs', 'kubelogin', 'gh'];
 
   if (!validCommands.includes(eventData.command)) {
     return [

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -50,7 +50,7 @@
  * ```
  */
 export function runCommand(
-  command: 'minikube' | 'az' | 'kubectl' | 'kubelogin' | 'scriptjs',
+  command: 'minikube' | 'az' | 'kubectl' | 'kubelogin' | 'scriptjs' | 'gh',
   args: string[],
   options: {},
   permissionSecrets?: Record<string, number>,

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -625,6 +625,11 @@ export async function fetchAndExecutePlugins(
             secretsToReturn['runCmd-kubectl'] = secrets['runCmd-kubectl'];
           }
 
+          if (isPackage['ai-assistant']) {
+            secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
+            secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
+          }
+
           return secretsToReturn;
         },
         getArgValues: (pluginName, pluginPath, allowedPermissions) => {
@@ -657,6 +662,27 @@ export async function fetchAndExecutePlugins(
           if (isPackage['aks-desktop']) {
             function pluginRunCommand(
               command: 'az' | 'kubectl' | 'kubelogin',
+              args: string[],
+              options: {}
+            ): ReturnType<typeof internalRunCommand> {
+              return internalRunCommand(
+                command,
+                args,
+                options,
+                allowedPermissions,
+                pluginDesktopApiSend,
+                pluginDesktopApiReceive
+              );
+            }
+            return [
+              ['pluginRunCommand', 'pluginPath'],
+              [pluginRunCommand, pluginPath],
+            ];
+          }
+
+          if (isPackage['ai-assistant']) {
+            function pluginRunCommand(
+              command: 'gh' | 'az',
               args: string[],
               options: {}
             ): ReturnType<typeof internalRunCommand> {

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -333,7 +333,11 @@ describe('runPlugin', () => {
 describe('identifyPackages', () => {
   test('should identify package by path and name in production mode', () => {
     const result = identifyPackages('plugins/headlamp_minikube', '@headlamp-k8s/minikube', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify package by prerelease path and name in production mode', () => {
@@ -342,7 +346,11 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikubeprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify package by static-plugins path and name in production mode', () => {
@@ -351,7 +359,11 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify package by static-plugins prerelease path and name in production mode', () => {
@@ -360,37 +372,65 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikubeprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify package if path does not match', () => {
     const result = identifyPackages('plugins/other_plugin', '@headlamp-k8s/minikube', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify package if name does not match', () => {
     const result = identifyPackages('plugins/headlamp_minikube', '@other/package', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify package by dev path in development mode', () => {
     const result = identifyPackages('plugins/minikube', '@headlamp-k8s/minikube', true);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify package by dev path if not in development mode', () => {
     const result = identifyPackages('plugins/minikube', '@headlamp-k8s/minikube', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify package if neither path nor name match', () => {
     const result = identifyPackages('plugins/unknown', '@unknown', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths correctly', () => {
     const result = identifyPackages('plugins\\headlamp_minikube', '@headlamp-k8s/minikube', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths with prerelease', () => {
@@ -399,7 +439,11 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikubeprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths for static-plugins', () => {
@@ -408,53 +452,157 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths in development mode', () => {
     const result = identifyPackages('plugins\\minikube', '@headlamp-k8s/minikube', true);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': true, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': true,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths not in development mode', () => {
     const result = identifyPackages('plugins\\minikube', '@headlamp-k8s/minikube', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   // Tests for aks-desktop package
   test('should identify aks-desktop package by path and name in production mode', () => {
     const result = identifyPackages('plugins/aks-desktop', 'aks-desktop', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': true,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify aks-desktop package by static path and name in production mode', () => {
     const result = identifyPackages('static-plugins/aks-desktop', 'aks-desktop', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': true,
+      'ai-assistant': false,
+    });
   });
 
   test('should identify aks-desktop package by dev path in development mode', () => {
     const result = identifyPackages('plugins/aks-desktop', 'aks-desktop', true);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': true,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify aks-desktop package if path does not match', () => {
     const result = identifyPackages('plugins/other_plugin', 'aks-desktop', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should not identify aks-desktop package if name does not match', () => {
     const result = identifyPackages('plugins/aks-desktop', '@other/package', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': false });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows paths for aks-desktop correctly', () => {
     const result = identifyPackages('plugins\\aks-desktop', 'aks-desktop', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': true,
+      'ai-assistant': false,
+    });
   });
 
   test('should handle windows static paths for aks-desktop correctly', () => {
     const result = identifyPackages('static-plugins\\aks-desktop', 'aks-desktop', false);
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, 'aks-desktop': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': true,
+      'ai-assistant': false,
+    });
+  });
+
+  // Tests for ai-assistant package
+  test('should identify ai-assistant package by path and name in production mode', () => {
+    const result = identifyPackages('plugins/ai-assistant', 'ai-assistant', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': true,
+    });
+  });
+
+  test('should identify ai-assistant package by static path and name in production mode', () => {
+    const result = identifyPackages('static-plugins/ai-assistant', 'ai-assistant', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': true,
+    });
+  });
+
+  test('should identify ai-assistant package by dev path in development mode', () => {
+    const result = identifyPackages('plugins/ai-assistant', 'ai-assistant', true);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': true,
+    });
+  });
+
+  test('should not identify ai-assistant package if path does not match', () => {
+    const result = identifyPackages('plugins/other_plugin', 'ai-assistant', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
+  });
+
+  test('should not identify ai-assistant package if name does not match', () => {
+    const result = identifyPackages('plugins/ai-assistant', '@other/package', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': false,
+    });
+  });
+
+  test('should handle windows paths for ai-assistant correctly', () => {
+    const result = identifyPackages('plugins\\ai-assistant', 'ai-assistant', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': true,
+    });
+  });
+
+  test('should handle windows static paths for ai-assistant correctly', () => {
+    const result = identifyPackages('static-plugins\\ai-assistant', 'ai-assistant', false);
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      'aks-desktop': false,
+      'ai-assistant': true,
+    });
   });
 });
 

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -246,16 +246,19 @@ export function identifyPackages(
       'static-plugins/headlamp_minikubeprerelease',
     ],
     'aks-desktop': ['plugins/aks-desktop', 'static-plugins/aks-desktop'],
+    'ai-assistant': ['plugins/ai-assistant', 'static-plugins/ai-assistant'],
   };
 
   if (isDevelopmentMode) {
     pluginPaths['@headlamp-k8s/minikube'][pluginPaths['@headlamp-k8s/minikube'].length] =
       'plugins/minikube';
     pluginPaths['aks-desktop'][pluginPaths['aks-desktop'].length] = 'plugins/aks-desktop';
+    pluginPaths['ai-assistant'][pluginPaths['ai-assistant'].length] = 'plugins/ai-assistant';
   }
   const pluginPackageNames: Record<string, string[]> = {
     '@headlamp-k8s/minikube': ['@headlamp-k8s/minikube', '@headlamp-k8s/minikubeprerelease'],
     'aks-desktop': ['aks-desktop'],
+    'ai-assistant': ['ai-assistant'],
   };
   const isPackage: Record<string, boolean> = {};
   for (const key in pluginPaths) {


### PR DESCRIPTION
## Description

So the plugin can detect AI providers like GitHub Copilot, and azure models.

## Related Issues

- this PR is required by this one: https://github.com/Azure/aks-desktop/pull/692

## Changes Made


- Consent handling for gh and az commands
- New COMMANDS_WITH_CONSENT.ai_assistant entry
- Support for runCmd-gh and runCmd-az secrets
- Plugin-level runCommand wrapper for ai-assistant
- Recognition of ai-assistant in identifyPackages
- Updated tests across runCmd, plugin execution, and package detection


## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)
