### PR TITLE
aksd: identify backend as aks-desktop in k8s API User-Agent

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -864,6 +864,12 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   // Pass a token to the backend that can be used for auth on some routes
   process.env.HEADLAMP_BACKEND_TOKEN = backendToken;
 
+  // Identify this client to the Kubernetes API server as aks-desktop.
+  // The backend reads HEADLAMP_APP_NAME at startup and uses it in the
+  // User-Agent for all proxied k8s requests. See
+  // headlamp/backend/pkg/kubeconfig/kubeconfig.go (applyAppNameOverride).
+  process.env.HEADLAMP_APP_NAME = 'aks-desktop';
+
   // Set the bundled plugins in addition to the the user's plugins.
   try {
     const stat = await fsPromises.stat(bundledPlugins);

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -867,7 +867,7 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   // Identify this client to the Kubernetes API server as aks-desktop.
   // The backend reads HEADLAMP_APP_NAME at startup and uses it in the
   // User-Agent for all proxied k8s requests. See
-  // headlamp/backend/pkg/kubeconfig/kubeconfig.go (applyAppNameOverride).
+  // backend/pkg/kubeconfig/kubeconfig.go (applyAppNameOverride).
   process.env.HEADLAMP_APP_NAME = 'aks-desktop';
 
   // Set the bundled plugins in addition to the the user's plugins.

--- a/backend/pkg/kubeconfig/appname_override_test.go
+++ b/backend/pkg/kubeconfig/appname_override_test.go
@@ -1,0 +1,59 @@
+package kubeconfig_test
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyAppNameOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		envSet   bool
+		want     string
+	}{
+		{
+			name:     "env unset keeps default",
+			envValue: "",
+			envSet:   false,
+			want:     "Headlamp",
+		},
+		{
+			name:     "env empty string keeps default",
+			envValue: "",
+			envSet:   true,
+			want:     "Headlamp",
+		},
+		{
+			name:     "env set overrides",
+			envValue: "aks-desktop",
+			envSet:   true,
+			want:     "aks-desktop",
+		},
+		{
+			name:     "env with whitespace is preserved verbatim",
+			envValue: "My App",
+			envSet:   true,
+			want:     "My App",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string {
+				if key != "HEADLAMP_APP_NAME" {
+					t.Fatalf("unexpected env key requested: %q", key)
+				}
+				if !tt.envSet {
+					return ""
+				}
+				return tt.envValue
+			}
+
+			got := kubeconfig.ApplyAppNameOverride(getenv)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/backend/pkg/kubeconfig/appname_override_test.go
+++ b/backend/pkg/kubeconfig/appname_override_test.go
@@ -15,19 +15,19 @@ func TestApplyAppNameOverride(t *testing.T) {
 		want     string
 	}{
 		{
-			name:     "env unset keeps default",
+			name:     "env unset returns empty string",
 			envValue: "",
 			envSet:   false,
-			want:     "Headlamp",
+			want:     "",
 		},
 		{
-			name:     "env empty string keeps default",
+			name:     "env empty string returns empty string",
 			envValue: "",
 			envSet:   true,
-			want:     "Headlamp",
+			want:     "",
 		},
 		{
-			name:     "env set overrides",
+			name:     "env set returns the value",
 			envValue: "aks-desktop",
 			envSet:   true,
 			want:     "aks-desktop",

--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -8,6 +8,9 @@ import "net/http"
 // BuildUserAgent is exported for testing.
 var BuildUserAgent = buildUserAgent
 
+// ApplyAppNameOverride is exported for testing.
+var ApplyAppNameOverride = applyAppNameOverride
+
 // UserAgentRoundTripper is exported for testing.
 type UserAgentRoundTripper struct {
 	Base      roundTripperInterface

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -30,20 +30,20 @@ var (
 	AppName = "Headlamp"
 )
 
-// applyAppNameOverride returns the configured app name, honoring the
-// HEADLAMP_APP_NAME environment variable when set to a non-empty value.
-// It is exported via export_test.go for unit testing; production callers
-// should use the package-level AppName variable which is set in init().
+// applyAppNameOverride returns the value of the HEADLAMP_APP_NAME
+// environment variable, or "" when it is unset or empty. The caller
+// decides what default to use when no override is present. Exported
+// via export_test.go for unit testing; production callers should use
+// the package-level AppName variable which init() updates from this
+// helper.
 func applyAppNameOverride(getenv func(string) string) string {
-	if v := getenv("HEADLAMP_APP_NAME"); v != "" {
-		return v
-	}
-
-	return "Headlamp"
+	return getenv("HEADLAMP_APP_NAME")
 }
 
 func init() {
-	AppName = applyAppNameOverride(os.Getenv)
+	if override := applyAppNameOverride(os.Getenv); override != "" {
+		AppName = override
+	}
 }
 
 // userAgentRoundTripper wraps an http.RoundTripper and adds a Headlamp User-Agent header.

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -30,6 +30,22 @@ var (
 	AppName = "Headlamp"
 )
 
+// applyAppNameOverride returns the configured app name, honoring the
+// HEADLAMP_APP_NAME environment variable when set to a non-empty value.
+// It is exported via export_test.go for unit testing; production callers
+// should use the package-level AppName variable which is set in init().
+func applyAppNameOverride(getenv func(string) string) string {
+	if v := getenv("HEADLAMP_APP_NAME"); v != "" {
+		return v
+	}
+
+	return "Headlamp"
+}
+
+func init() {
+	AppName = applyAppNameOverride(os.Getenv)
+}
+
 // userAgentRoundTripper wraps an http.RoundTripper and adds a Headlamp User-Agent header.
 type userAgentRoundTripper struct {
 	base      http.RoundTripper


### PR DESCRIPTION
## Summary
- Add `applyAppNameOverride` helper + `init()` in `backend/pkg/kubeconfig/kubeconfig.go` that reads `HEADLAMP_APP_NAME` from the process environment and overrides the package-level `AppName` (default still `Headlamp`). Unit-tested via an injected env getter.
- Set `HEADLAMP_APP_NAME=aks-desktop` when the Electron shell spawns the bundled backend, so all proxied Kubernetes API requests carry \`User-Agent: aks-desktop <version> (<os>/<arch>)\` instead of \`Headlamp ...\`. Azure-side audit logs and telemetry can now attribute traffic to AKS Desktop.

Two commits:
1. \`upstreamable: allow overriding backend AppName via HEADLAMP_APP_NAME\` — generic env-var hook, useful to anyone white-labeling Headlamp.
2. \`upstreamable: separate AppName default from env-override helper\` — polish: keep the \"Headlamp\" default in one place (the var declaration), let the helper return only the env value.
3. \`aksd: identify backend as aks-desktop to the k8s API server\` — Electron launcher sets the env var.
4. \`aksd: correct kubeconfig.go path in HEADLAMP_APP_NAME comment\` — comment polish.

The submodule pointer bump in \`Azure/aks-desktop\` is a separate PR.

## Test plan
- [x] \`go test ./pkg/kubeconfig/...\` — \`TestApplyAppNameOverride\` (4 sub-tests), \`TestBuildUserAgent\`, \`TestUserAgentRoundTripper_RoundTrip\`, \`TestUserAgentIntegration\` all pass.
- [x] \`go vet ./pkg/kubeconfig/...\` clean.
- [x] \`npm run lint\` clean in \`app/\`.
- [ ] Manual: launch AKS Desktop against a test cluster; confirm audit log \`userAgent\` begins with \`aks-desktop\`.
- [ ] Manual: run the Headlamp backend standalone without \`HEADLAMP_APP_NAME\` set; confirm User-Agent still reads \`Headlamp ...\`.