### PR TITLE
backend: Update AppName and User Agent value to AKS-desktop

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	Version = "unknown"
-	AppName = "Headlamp"
+	AppName = "AKS-desktop"
 )
 
 // userAgentRoundTripper wraps an http.RoundTripper and adds a Headlamp User-Agent header.


### PR DESCRIPTION
Updates headlamp AppName to AKS-desktop (which is used in User-Agent header)
