### PR TITLE
insights-plugin: bump to v0.2.6

### DIFF
--- a/plugins/insights-plugin/package-lock.json
+++ b/plugins/insights-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insights-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insights-plugin",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.13.1"
       }

--- a/plugins/insights-plugin/package.json
+++ b/plugins/insights-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insights-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Insights plugin for eBPF-based Observability (based on Inspektor Gadget) (Preview)",
   "scripts": {
     "build": "bash scripts/download-artifacts.sh",


### PR DESCRIPTION
[v0.2.6](https://github.com/inspektor-gadget/insights-plugin/releases/tag/v0.2.6) adds localization support and improved a11y coverage as well as two more gadgets to the Insights tab (CUDA Profile + CUDA Memory).