### PR TITLE
app: aks-cluster: main: runCmd: preload: Add aksarc cluster type support

### DIFF
--- a/app/electron/aks-cluster.ts
+++ b/app/electron/aks-cluster.ts
@@ -228,11 +228,11 @@ function mergeKubeconfig(existingConfig: string, newConfig: string): KubeConfig 
 }
 
 /**
- * Register an AKS cluster by running az aks get-credentials and configuring authentication.
+ * Register an AKS or Arc cluster by running the appropriate az get-credentials command and configuring authentication.
  *
  * @param subscriptionId - Azure subscription ID
  * @param resourceGroup - Azure resource group name
- * @param clusterName - AKS cluster name
+ * @param clusterName - AKS or Arc cluster name
  * @param isDev - Whether running in development mode
  * @param resourcesPath - Path to resources directory
  * @param managedNamespace - Optional managed namespace name to use for scoped credentials
@@ -242,19 +242,33 @@ export async function registerAKSCluster(
   subscriptionId: string,
   resourceGroup: string,
   clusterName: string,
-  isAzureRBACEnabled: boolean,
+  _isAzureRBACEnabled: boolean,
   isDev: boolean,
   resourcesPath: string,
-  managedNamespace?: string
+  managedNamespace?: string,
+  clusterType: 'aks' | 'aksarc' = 'aks'
 ): Promise<RegisterAKSClusterResult> {
   const tempKubeconfigPath = path.join(os.tmpdir(), `kubeconfig-${Date.now()}.yaml`);
 
   try {
     // Step 1: Get the kubeconfig to a temporary file
-    // Use namespace get-credentials if a managed namespace is provided
-    const args: string[] = ['aks'];
+    const args: string[] = [];
 
-    if (managedNamespace) {
+    if (clusterType === 'aksarc') {
+      console.log('[AKS ARC] Getting credentials for cluster:', clusterName);
+      args.push(
+        'aksarc',
+        'get-credentials',
+        '--subscription',
+        subscriptionId,
+        '--resource-group',
+        resourceGroup,
+        '--name',
+        clusterName
+      );
+    } else if (managedNamespace) {
+      // Use namespace get-credentials if a managed namespace is provided
+      args.push('aks');
       console.log(
         '[AKS] Getting namespace credentials for cluster:',
         clusterName,
@@ -275,6 +289,7 @@ export async function registerAKSCluster(
       );
     } else {
       console.log('[AKS] Getting credentials for cluster:', clusterName);
+      args.push('aks');
       args.push(
         'get-credentials',
         '--subscription',

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1910,6 +1910,7 @@ async function startElectron() {
           clusterName: string;
           isAzureRBACEnabled: boolean;
           managedNamespace?: string;
+          clusterType?: 'aks' | 'aksarc';
         }
       ) => {
         const { registerAKSCluster } = await import('./aks-cluster');
@@ -1923,7 +1924,8 @@ async function startElectron() {
           data.isAzureRBACEnabled,
           isDev,
           resourcesDir,
-          data.managedNamespace
+          data.managedNamespace,
+          data.clusterType === 'aksarc' ? 'aksarc' : 'aks'
         );
       }
     );

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -84,7 +84,8 @@ contextBridge.exposeInMainWorld('desktopApi', {
     resourceGroup: string,
     clusterName: string,
     isAzureRBACEnabled: boolean,
-    managedNamespace?: string
+    managedNamespace?: string,
+    clusterType?: 'aks' | 'aksarc'
   ): Promise<{ success: boolean; message: string }> => {
     return ipcRenderer.invoke('register-aks-cluster', {
       subscriptionId,
@@ -92,6 +93,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       clusterName,
       isAzureRBACEnabled,
       managedNamespace,
+      clusterType,
     });
   },
 

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -150,6 +150,8 @@ const COMMANDS_WITH_CONSENT = {
     'az logout',
     'az config',
     'az aks',
+    'az connectedk8s',
+    'az aksarc',
     'az extension',
     'az feature',
     'az provider',

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -420,6 +420,11 @@ export async function handleRunCommand(
     event.sender.send('command-stderr', commandData.id, data.toString());
   });
 
+  child.on('error', (err: Error) => {
+    event.sender.send('command-stderr', commandData.id, err.message);
+    event.sender.send('command-exit', commandData.id, -1);
+  });
+
   child.on('close', (code: number | null) => {
     event.sender.send('command-exit', commandData.id, code);
   });


### PR DESCRIPTION
## Summary

This PR adds Arc cluster (`aksarc`) support to `registerAKSCluster` by introducing a `clusterType` parameter that routes `az aksarc get-credentials` instead of `az aks get-credentials` when connecting to an Arc-enabled cluster.

## Related Issue

For:
- https://github.com/Azure/aks-desktop/issues/645

This is a requirement for the aka-desktop side changes in this PR:
- https://github.com/Azure/aks-desktop/pull/711


## Changes

- `aks-cluster.ts`: Added `clusterType: 'aks' | 'aksarc'` parameter (default `'aks'`); routes `az aksarc get-credentials` for Arc clusters; refactored `args` initialization so `'aks'` is only pushed in the AKS branches
- `main.ts`: Validates and passes `clusterType` through the IPC `register-aks-cluster` handler; unexpected values fall back to `'aks'`
- `preload.ts`: Exposes optional `clusterType?: 'aks' | 'aksarc'` in the `desktopApi.registerAKSCluster` bridge
- `runCmd.ts`: Added `'az connectedk8s'` and `'az aksarc'` to the `COMMANDS_WITH_CONSENT` allowlist

## Steps to Test

Best to check with the related [aka-desktop side pr](https://github.com/Azure/aks-desktop/pull/711). Make sure this is in headlamp/ (fetch this branch, and then checkout this commit in headlamp folder).

## Screenshots (if applicable)

N/A — no UI changes

## Notes for the Reviewer

- `isAzureRBACEnabled` is now prefixed `_isAzureRBACEnabled` as it is unused in the Arc code path; can be wired up later when Arc RBAC is supported
- `clusterType` from the IPC payload is explicitly whitelisted (`=== 'aksarc'` check) before being passed to `registerAKSCluster`, so unexpected truthy values fall back to `'aks'`