### PR TITLE
Fix: Map diagram showing resources from other namespaces

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -69,6 +69,15 @@ const makeRelation = <From extends KubeObjectClass, To extends KubeObjectClass>(
     const fromObject = fromNode.kubeObject as InstanceType<From>;
     const toObject = toNode.kubeObject as InstanceType<To>;
 
+    // If both resources are namespace-scoped, they must be in the same namespace
+    if (
+      fromObject.isNamespaced &&
+      toObject.isNamespaced &&
+      fromObject.getNamespace() !== toObject.getNamespace()
+    ) {
+      return false;
+    }
+
     return fromObject.cluster === toObject.cluster && Boolean(selector(fromObject, toObject));
   },
 });


### PR DESCRIPTION
## Description

This PR adds a namespace guard to `makeRelation` so that for namespace-scoped resources, edges are only drawn if they're in the same namespace. Previously we only matched by name/label, causing resources with identical names in different namespaces to be merged and shown under one namespace component in the view.

Resolves issue 
- https://github.com/Azure/aks-desktop/issues/621

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #621

## Changes Made

- Added namespace equality check in `makeRelation` to prevent cross-namespace edges being drawn for identically named resources. 

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

Describe the test cases that were run:

1. Create 2 deployments/resources with identical names. 
2. Open the Map view & observe that the deployments for one namespace don't appear in another.