### PR TITLE
aksd: restore App Insights usage telemetry without PII

### DIFF
--- a/plugins/aks-desktop/locales/en/translation.json
+++ b/plugins/aks-desktop/locales/en/translation.json
@@ -715,5 +715,8 @@
   "{{weeks}}w ago": "{{weeks}}w ago",
   "Tenant": "Tenant",
   "{{count}} nodes_one": "{{count}} node",
-  "{{count}} nodes_other": "{{count}} nodes"
+  "{{count}} nodes_other": "{{count}} nodes",
+  "Telemetry": "Telemetry",
+  "AKS Desktop sends anonymous usage data (feature usage, app version, OS, error classes) to help us improve the product. No cluster names, namespaces, resource names, error messages, or stack traces are ever sent. Telemetry changes take effect on next launch.": "AKS Desktop sends anonymous usage data (feature usage, app version, OS, error classes) to help us improve the product. No cluster names, namespaces, resource names, error messages, or stack traces are ever sent. Telemetry changes take effect on next launch.",
+  "Send anonymous usage data": "Send anonymous usage data"
 }

--- a/plugins/aks-desktop/make-telemetry-env.js
+++ b/plugins/aks-desktop/make-telemetry-env.js
@@ -5,12 +5,10 @@
 // substitutes REACT_APP_* vars as `import.meta.env.*` in the plugin
 // bundle. Runs as a prebuild/prestart hook from package.json.
 //
-// REACT_APP_APPINSIGHTS_CONNECTION_STRING defaults to the public AKS
-// Desktop production App Insights instance. The connection string is
-// not a credential (App Insights connection strings are addresses, not
-// auth tokens) and was previously hardcoded in
-// headlamp/frontend/make-env.js. To send to a different instance (e.g.
-// the dev App Insights), set the env var before running the build.
+// The default REACT_APP_APPINSIGHTS_CONNECTION_STRING points at the AKS
+// Desktop production App Insights instance. Connection strings are
+// addresses (not credentials). Set the env var before running the build
+// to send to a different instance (e.g. a dev App Insights).
 
 const fs = require('fs');
 const path = require('path');

--- a/plugins/aks-desktop/make-telemetry-env.js
+++ b/plugins/aks-desktop/make-telemetry-env.js
@@ -1,14 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-// CI/release pipeline MUST set REACT_APP_APPINSIGHTS_CONNECTION_STRING
-// before invoking the plugin build. If unset, the plugin runs with
-// telemetry disabled (fail-closed).
+// Writes a .env file consumed by the headlamp-plugin Vite build, which
+// substitutes REACT_APP_* vars as `import.meta.env.*` in the plugin
+// bundle. Runs as a prebuild/prestart hook from package.json.
+//
+// REACT_APP_APPINSIGHTS_CONNECTION_STRING defaults to the public AKS
+// Desktop production App Insights instance. The connection string is
+// not a credential (App Insights connection strings are addresses, not
+// auth tokens) and was previously hardcoded in
+// headlamp/frontend/make-env.js. To send to a different instance (e.g.
+// the dev App Insights), set the env var before running the build.
 
 const fs = require('fs');
 const path = require('path');
 
-const CONNECTION_STRING = process.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING || '';
+const DEFAULT_CONNECTION_STRING =
+  'InstrumentationKey=5f8e9ae9-1e90-4ab7-8aeb-429b5a3bf73b;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=e50d3436-371c-4165-bd66-c17b1f551dfe';
+
+const CONNECTION_STRING =
+  process.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING || DEFAULT_CONNECTION_STRING;
 
 const fileName = process.argv[2] || '.env';
 const out = `REACT_APP_APPINSIGHTS_CONNECTION_STRING=${CONNECTION_STRING}\n`;

--- a/plugins/aks-desktop/make-telemetry-env.js
+++ b/plugins/aks-desktop/make-telemetry-env.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// CI/release pipeline MUST set REACT_APP_APPINSIGHTS_CONNECTION_STRING
+// before invoking the plugin build. If unset, the plugin runs with
+// telemetry disabled (fail-closed).
+
+const fs = require('fs');
+const path = require('path');
+
+const CONNECTION_STRING = process.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING || '';
+
+const fileName = process.argv[2] || '.env';
+const out = `REACT_APP_APPINSIGHTS_CONNECTION_STRING=${CONNECTION_STRING}\n`;
+fs.writeFileSync(path.join(__dirname, fileName), out);

--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -11,6 +11,7 @@
         "@azure/arm-resourcegraph": "^4.2.1",
         "@azure/arm-subscriptions": "^5.1.0",
         "@azure/identity": "^4.12.0",
+        "@microsoft/applicationinsights-web": "^3.4.1",
         "@octokit/rest": "^22.0.0",
         "libsodium-wrappers": "^0.8.2",
         "recharts": "^3.1.2",
@@ -2343,6 +2344,138 @@
         "react": ">=16"
       }
     },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.4.1.tgz",
+      "integrity": "sha512-zdxZzu50/gsE2JWrzeviHloFZu9r5/x2+OLD0TIYHhvrod321AKkStmKlDoep1JAsSephjxBfwTjciKiFXXyGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.1.tgz",
+      "integrity": "sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.1.tgz",
+      "integrity": "sha512-cnjVVTxSeavmwCoOwXi/ZQuCcjo7SnYYRWyS+GsMCrTRTItVHZlVj6NHgmFEQZWNybrM+U1RgwZE2wXn1/Liyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.4.1.tgz",
+      "integrity": "sha512-s2cUuknjazaoCbh9i6ljymeZqeQqpyAE8v2ZUxCkAwRuxbonAvZWQtEr4QQmEHWJIdbWgn0Ge+OOlMtMkh+Ixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.1.tgz",
+      "integrity": "sha512-gdYLIYkP11D+V71nNCupYsmWE8LAL9EpIR2Q7+B3n6dpck7tgaYMXFN3S5ZrOh3yxLAwt7GVXZoDcN2mGkagxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "3.4.1",
+        "@microsoft/applicationinsights-cfgsync-js": "3.4.1",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-dependencies-js": "3.4.1",
+        "@microsoft/applicationinsights-properties-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.5.tgz",
+      "integrity": "sha512-V+Zr7PDKIEaItVwF/OyWQlKeugNRYg7KJJ+RhEIL2FMW6NlG8FN2l4XA9Z42hNtsjwJFlcUiF38pmM/AaXsF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
@@ -2813,6 +2946,41 @@
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.6.1.tgz",
+      "integrity": "sha512-W2kFiT5oPuxTrB3NrxUId/U+1AuAhIaiDQkLC4HcxkjNc+85GfELYdPQXnsDWDG8yji24F5qk6QpBDxZX3/0+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/nevware21"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.15.0 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
+      "integrity": "sha512-+bUMKIiKAgoW5uNEb5xxzBzdwdLS9SKRcOy8SxLE+KqSlIdUYV5O9nxJVq1RUYcO2DtL5DlrK1GbgcVEHv6GVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "other",
+          "url": "https://buymeacoffee.com/nevware21"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -74,6 +74,7 @@
     "@azure/arm-resourcegraph": "^4.2.1",
     "@azure/arm-subscriptions": "^5.1.0",
     "@azure/identity": "^4.12.0",
+    "@microsoft/applicationinsights-web": "^3.4.1",
     "@octokit/rest": "^22.0.0",
     "libsodium-wrappers": "^0.8.2",
     "recharts": "^3.1.2",

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -3,7 +3,9 @@
   "version": "0.3.0-beta",
   "description": "AKS Headlamp plugin",
   "scripts": {
+    "prestart": "node make-telemetry-env.js",
     "start": "headlamp-plugin start",
+    "prebuild": "node make-telemetry-env.js",
     "build": "headlamp-plugin build",
     "format": "headlamp-plugin format",
     "lint": "headlamp-plugin lint",

--- a/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.test.tsx
+++ b/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.test.tsx
@@ -8,11 +8,21 @@ import type { ClusterCapabilities } from '../../types/ClusterCapabilities';
 
 // Mock K8s.ResourceClasses.Namespace.useGet
 const mockUseGet = vi.fn();
+const mockNodeUseList = vi.fn(function nodeList(): any {
+  return [null, null];
+});
+const mockNamespaceUseList = vi.fn(function nsList(): any {
+  return [null, null];
+});
 vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
   K8s: {
     ResourceClasses: {
       Namespace: {
         useGet: (...args: any[]) => mockUseGet(...args),
+        useList: () => mockNamespaceUseList(),
+      },
+      Node: {
+        useList: () => mockNodeUseList(),
       },
     },
   },
@@ -45,6 +55,9 @@ function makeCapabilities(overrides: Partial<ClusterCapabilities> = {}): Cluster
     containerInsightsEnabled: true,
     kedaEnabled: true,
     vpaEnabled: true,
+    location: 'eastus',
+    tier: 'Standard',
+    kubernetesVersion: '1.29.4',
     ...overrides,
   };
 }

--- a/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.tsx
+++ b/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.tsx
@@ -11,8 +11,14 @@ import { useClusterCapabilities } from '../CreateAKSProject/hooks/useClusterCapa
 
 // Dedupe `headlamp.cluster-shape` emission per Azure resource ID so
 // re-renders/refetches do not re-emit. The key is the AKS resource id —
-// an Azure-generated path string, not customer data.
+// not customer data because the value is never sent in any envelope,
+// only used as an in-memory dedupe key for the current page load.
 const emittedShapeFor = new Set<string>();
+
+/** Test-only: reset the per-page dedupe set so suites don't leak state. */
+export function __resetEmittedShapeForTests(): void {
+  emittedShapeFor.clear();
+}
 
 interface ClusterCapabilityCardProps {
   project: {
@@ -52,17 +58,17 @@ function ClusterCapabilityCard({ project }: ClusterCapabilityCardProps) {
     if (subscription && resourceGroup && cluster) {
       fetchCapabilities(subscription, resourceGroup, cluster);
     }
-  }, [subscription, resourceGroup, cluster]);
+  }, [subscription, resourceGroup, cluster, fetchCapabilities]);
 
-  // Fetch live k8s counts so we can fire `headlamp.cluster-shape` with
-  // a fully-populated envelope. We never ship half-populated events.
+  // Live k8s counts so we can fire `headlamp.cluster-shape` with a
+  // fully-populated envelope; the gate against half-populated emission
+  // lives in emitClusterShapeIfReady.
   const [nodes] = K8s.ResourceClasses.Node.useList({ cluster });
   const [namespaces] = K8s.ResourceClasses.Namespace.useList({ cluster });
 
   useEffect(() => {
     if (!capabilities || !subscription || !resourceGroup || !cluster) return;
     if (!nodes || !namespaces) return;
-    // Azure resource ID is the canonical dedupe key — Azure-generated string.
     const azureResourceId = `/subscriptions/${subscription}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${cluster}`;
     if (emittedShapeFor.has(azureResourceId)) return;
     const fired = emitClusterShapeIfReady({

--- a/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.tsx
+++ b/plugins/aks-desktop/src/components/ClusterCapabilityCard/ClusterCapabilityCard.tsx
@@ -4,9 +4,15 @@
 import { K8s } from '@kinvolk/headlamp-plugin/lib';
 import { Alert, Box, Typography } from '@mui/material';
 import React, { useEffect } from 'react';
+import { emitClusterShapeIfReady } from '../../telemetry/clusterShape';
 import type { ClusterCapabilities } from '../../types/ClusterCapabilities';
 import { ClusterConfigurePanel } from '../CreateAKSProject/components/ClusterConfigurePanel';
 import { useClusterCapabilities } from '../CreateAKSProject/hooks/useClusterCapabilities';
+
+// Dedupe `headlamp.cluster-shape` emission per Azure resource ID so
+// re-renders/refetches do not re-emit. The key is the AKS resource id —
+// an Azure-generated path string, not customer data.
+const emittedShapeFor = new Set<string>();
 
 interface ClusterCapabilityCardProps {
   project: {
@@ -47,6 +53,27 @@ function ClusterCapabilityCard({ project }: ClusterCapabilityCardProps) {
       fetchCapabilities(subscription, resourceGroup, cluster);
     }
   }, [subscription, resourceGroup, cluster]);
+
+  // Fetch live k8s counts so we can fire `headlamp.cluster-shape` with
+  // a fully-populated envelope. We never ship half-populated events.
+  const [nodes] = K8s.ResourceClasses.Node.useList({ cluster });
+  const [namespaces] = K8s.ResourceClasses.Namespace.useList({ cluster });
+
+  useEffect(() => {
+    if (!capabilities || !subscription || !resourceGroup || !cluster) return;
+    if (!nodes || !namespaces) return;
+    // Azure resource ID is the canonical dedupe key — Azure-generated string.
+    const azureResourceId = `/subscriptions/${subscription}/resourceGroups/${resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${cluster}`;
+    if (emittedShapeFor.has(azureResourceId)) return;
+    const fired = emitClusterShapeIfReady({
+      kubernetesVersion: capabilities.kubernetesVersion ?? undefined,
+      nodeCount: nodes.length,
+      namespaceCount: namespaces.length,
+      region: capabilities.location ?? undefined,
+      aksTier: capabilities.tier ?? undefined,
+    });
+    if (fired) emittedShapeFor.add(azureResourceId);
+  }, [capabilities, nodes, namespaces, subscription, resourceGroup, cluster]);
 
   // Don't show anything while loading or if we don't have data yet
   if (loading) return null;

--- a/plugins/aks-desktop/src/components/PluginSettings/TelemetrySettings.tsx
+++ b/plugins/aks-desktop/src/components/PluginSettings/TelemetrySettings.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { Box, FormControlLabel, Switch, Typography } from '@mui/material';
+import React from 'react';
+import { useTelemetrySettings } from '../../hooks/useTelemetrySettings';
+import { telemetrySettingsStore } from './telemetrySettingsStore';
+
+export default function TelemetrySettings() {
+  const { t } = useTranslation();
+  const config = useTelemetrySettings();
+
+  function handleToggle(checked: boolean) {
+    telemetrySettingsStore.update({ enabled: checked });
+  }
+
+  return (
+    <Box sx={{ maxWidth: 600 }}>
+      <Typography variant="h6">{t('Telemetry')}</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {t(
+          'AKS Desktop sends anonymous usage data (feature usage, app version, OS, error classes) to help us improve the product. No cluster names, namespaces, resource names, error messages, or stack traces are ever sent. Telemetry changes take effect on next launch.'
+        )}
+      </Typography>
+
+      <FormControlLabel
+        control={
+          <Switch checked={config.enabled} onChange={(_e, checked) => handleToggle(checked)} />
+        }
+        label={
+          <Box>
+            <Typography variant="body1">{t('Send anonymous usage data')}</Typography>
+          </Box>
+        }
+        sx={{ alignItems: 'flex-start', ml: 0, mt: 1 }}
+      />
+    </Box>
+  );
+}

--- a/plugins/aks-desktop/src/components/PluginSettings/telemetrySettingsStore.ts
+++ b/plugins/aks-desktop/src/components/PluginSettings/telemetrySettingsStore.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { ConfigStore } from '@kinvolk/headlamp-plugin/lib';
+
+export interface TelemetrySettingsConfig {
+  enabled: boolean;
+}
+
+export const TELEMETRY_SETTINGS_DEFAULTS: TelemetrySettingsConfig = {
+  enabled: true,
+};
+
+/**
+ * Persisted via Headlamp's ConfigStore (renderer-side, localStorage).
+ *
+ * Key is namespaced separately from `previewFeaturesStore` so the two
+ * stores don't collide.
+ */
+export const telemetrySettingsStore = new ConfigStore<TelemetrySettingsConfig>(
+  'aks-desktop.telemetry'
+);
+
+/**
+ * Read the current telemetry-enabled flag synchronously, defaulting to
+ * true when no persisted value exists. Used at plugin load time to
+ * decide whether to initialize App Insights.
+ */
+export function isTelemetryEnabled(): boolean {
+  const stored = telemetrySettingsStore.get()?.enabled;
+  return stored ?? TELEMETRY_SETTINGS_DEFAULTS.enabled;
+}

--- a/plugins/aks-desktop/src/components/TelemetryBoot.tsx
+++ b/plugins/aks-desktop/src/components/TelemetryBoot.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import React, { useEffect, useRef } from 'react';
+import { getAppInfo } from '../telemetry/appInfo';
+import { getInstallId } from '../telemetry/installId';
+import { enableTelemetry } from '../telemetry/setup';
+import { isTelemetryEnabled } from './PluginSettings/telemetrySettingsStore';
+
+const CONNECTION_STRING = import.meta.env.REACT_APP_APPINSIGHTS_CONNECTION_STRING as
+  | string
+  | undefined;
+
+/**
+ * Boots App Insights telemetry exactly once on first mount when:
+ *   - the opt-out toggle is enabled (default true)
+ *   - a connection string was substituted at plugin build time
+ *   - the install-id and app-info bridges are available
+ *
+ * Renders nothing. Mount this from a registration point that's always
+ * present (e.g. `registerAppBarAction`).
+ */
+export default function TelemetryBoot(): React.ReactElement | null {
+  const booted = useRef(false);
+
+  useEffect(() => {
+    if (booted.current) return;
+    booted.current = true;
+
+    if (!isTelemetryEnabled()) return;
+    if (!CONNECTION_STRING) return;
+
+    (async () => {
+      const [installId, appInfo] = await Promise.all([getInstallId(), getAppInfo()]);
+      if (!installId || !appInfo) return;
+
+      enableTelemetry({
+        connectionString: CONNECTION_STRING,
+        installId,
+        sessionProps: {
+          installId,
+          appVersion:
+            (import.meta.env.REACT_APP_AKS_DESKTOP_VERSION as string | undefined) ?? 'unknown',
+          headlampVersion:
+            (import.meta.env.REACT_APP_HEADLAMP_VERSION as string | undefined) ?? 'unknown',
+          electronVersion: appInfo.electronVersion,
+          os: appInfo.os,
+          osMajor: appInfo.osMajor,
+          arch: appInfo.arch,
+          locale: navigator.language || 'unknown',
+        },
+      });
+    })();
+  }, []);
+
+  return null;
+}

--- a/plugins/aks-desktop/src/components/TelemetryBoot.tsx
+++ b/plugins/aks-desktop/src/components/TelemetryBoot.tsx
@@ -31,25 +31,34 @@ export default function TelemetryBoot(): React.ReactElement | null {
     if (!CONNECTION_STRING) return;
 
     (async () => {
-      const [installId, appInfo] = await Promise.all([getInstallId(), getAppInfo()]);
-      if (!installId || !appInfo) return;
+      try {
+        const [installId, appInfo] = await Promise.all([getInstallId(), getAppInfo()]);
+        if (!installId || !appInfo) return;
 
-      enableTelemetry({
-        connectionString: CONNECTION_STRING,
-        installId,
-        sessionProps: {
+        enableTelemetry({
+          connectionString: CONNECTION_STRING,
           installId,
-          appVersion:
-            (import.meta.env.REACT_APP_AKS_DESKTOP_VERSION as string | undefined) ?? 'unknown',
-          headlampVersion:
-            (import.meta.env.REACT_APP_HEADLAMP_VERSION as string | undefined) ?? 'unknown',
-          electronVersion: appInfo.electronVersion,
-          os: appInfo.os,
-          osMajor: appInfo.osMajor,
-          arch: appInfo.arch,
-          locale: navigator.language || 'unknown',
-        },
-      });
+          sessionProps: {
+            installId,
+            appVersion:
+              (import.meta.env.REACT_APP_AKS_DESKTOP_VERSION as string | undefined) ?? 'unknown',
+            headlampVersion:
+              (import.meta.env.REACT_APP_HEADLAMP_VERSION as string | undefined) ?? 'unknown',
+            electronVersion: appInfo.electronVersion,
+            os: appInfo.os,
+            osMajor: appInfo.osMajor,
+            arch: appInfo.arch,
+            locale: navigator.language || 'unknown',
+          },
+        });
+      } catch (e) {
+        // ApplicationInsights init can throw synchronously on a malformed
+        // connection string. Swallow so a bad operator override doesn't
+        // surface as an unhandled rejection, but log so the failure is
+        // diagnosable.
+        // eslint-disable-next-line no-console
+        console.error('Telemetry init failed', e);
+      }
     })();
   }, []);
 

--- a/plugins/aks-desktop/src/hooks/useTelemetrySettings.ts
+++ b/plugins/aks-desktop/src/hooks/useTelemetrySettings.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import {
+  TELEMETRY_SETTINGS_DEFAULTS,
+  type TelemetrySettingsConfig,
+  telemetrySettingsStore,
+} from '../components/PluginSettings/telemetrySettingsStore';
+
+const useStoreConfig = telemetrySettingsStore.useConfig();
+
+export function useTelemetrySettings(): TelemetrySettingsConfig {
+  const stored = useStoreConfig();
+  return { ...TELEMETRY_SETTINGS_DEFAULTS, ...stored };
+}

--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -40,6 +40,7 @@ import MetricsCard from './components/Metrics/MetricsCard';
 import MetricsTab from './components/Metrics/MetricsTab';
 import PreviewFeaturesSettings from './components/PluginSettings/PreviewFeaturesSettings';
 import { previewFeaturesStore } from './components/PluginSettings/previewFeaturesStore';
+import TelemetrySettings from './components/PluginSettings/TelemetrySettings';
 import ScalingCard from './components/Scaling/ScalingCard';
 import ScalingTab from './components/Scaling/ScalingTab';
 import type { ProjectDefinition } from './types/project';
@@ -303,6 +304,7 @@ if (Headlamp.isRunningAsApp()) {
 }
 
 registerPluginSettings('aks-desktop', PreviewFeaturesSettings, false);
+registerPluginSettings('aks-desktop-telemetry', TelemetrySettings, false);
 
 registerProjectOverviewSection({
   id: 'cluster-capabilities',

--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -4,6 +4,7 @@
 import {
   Headlamp,
   registerAddClusterProvider,
+  registerAppBarAction,
   registerAppLogo,
   registerAppTheme,
   registerCustomCreateProject,
@@ -43,6 +44,7 @@ import { previewFeaturesStore } from './components/PluginSettings/previewFeature
 import TelemetrySettings from './components/PluginSettings/TelemetrySettings';
 import ScalingCard from './components/Scaling/ScalingCard';
 import ScalingTab from './components/Scaling/ScalingTab';
+import TelemetryBoot from './components/TelemetryBoot';
 import type { ProjectDefinition } from './types/project';
 import { getLoginStatus } from './utils/azure/az-auth';
 import { AZURE_ACCOUNT_POLL_INTERVAL_MS } from './utils/constants/timing';
@@ -84,6 +86,9 @@ Headlamp.setAppMenu(menus => {
 
 // add azure related components only if running as app
 if (Headlamp.isRunningAsApp()) {
+  // boot App Insights telemetry once on first render
+  registerAppBarAction(() => <TelemetryBoot />);
+
   // register azure logo
   registerAppLogo(AzureLogo);
 

--- a/plugins/aks-desktop/src/telemetry/appInfo.test.ts
+++ b/plugins/aks-desktop/src/telemetry/appInfo.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAppInfo } from './appInfo';
+
+const sample = {
+  os: 'linux' as const,
+  osMajor: '6.5.0',
+  arch: 'x64' as const,
+  electronVersion: '31.0.0',
+};
+
+afterEach(() => {
+  delete (window as any).desktopApi;
+});
+
+describe('getAppInfo', () => {
+  it('returns the AppInfo provided by desktopApi.getAppInfo', async () => {
+    (window as any).desktopApi = {
+      getAppInfo: vi.fn().mockResolvedValue(sample),
+    };
+    expect(await getAppInfo()).toEqual(sample);
+  });
+
+  it('returns undefined when desktopApi is absent (web mode)', async () => {
+    expect(await getAppInfo()).toBeUndefined();
+  });
+
+  it('returns undefined when desktopApi.getAppInfo is absent', async () => {
+    (window as any).desktopApi = {};
+    expect(await getAppInfo()).toBeUndefined();
+  });
+
+  it('returns undefined and does not throw when the IPC call fails', async () => {
+    (window as any).desktopApi = {
+      getAppInfo: vi.fn().mockRejectedValue(new Error('IPC failed')),
+    };
+    expect(await getAppInfo()).toBeUndefined();
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/appInfo.ts
+++ b/plugins/aks-desktop/src/telemetry/appInfo.ts
@@ -12,16 +12,29 @@ interface DesktopApi {
   getAppInfo?: () => Promise<AppInfo>;
 }
 
+function isAppInfo(value: unknown): value is AppInfo {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    (v.os === 'win32' || v.os === 'darwin' || v.os === 'linux') &&
+    typeof v.osMajor === 'string' &&
+    (v.arch === 'x64' || v.arch === 'arm64' || v.arch === 'ia32') &&
+    typeof v.electronVersion === 'string'
+  );
+}
+
 /**
- * Fetch host info over IPC. Returns `undefined` when the bridge is
- * absent (web mode) or when the IPC call fails. Used by TelemetryBoot
- * to populate the `headlamp.session-start` event.
+ * Fetch host info over the Electron preload bridge. Returns `undefined`
+ * when the bridge is absent, when the IPC call fails, or when the
+ * returned object doesn't match the expected shape — matching the
+ * fail-closed posture in `getInstallId`.
  */
 export async function getAppInfo(): Promise<AppInfo | undefined> {
-  const desktopApi = (window as unknown as { desktopApi?: DesktopApi }).desktopApi;
+  const desktopApi = (window as { desktopApi?: DesktopApi }).desktopApi;
   if (!desktopApi?.getAppInfo) return undefined;
   try {
-    return await desktopApi.getAppInfo();
+    const result = await desktopApi.getAppInfo();
+    return isAppInfo(result) ? result : undefined;
   } catch {
     return undefined;
   }

--- a/plugins/aks-desktop/src/telemetry/appInfo.ts
+++ b/plugins/aks-desktop/src/telemetry/appInfo.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+export interface AppInfo {
+  os: 'win32' | 'darwin' | 'linux';
+  osMajor: string;
+  arch: 'x64' | 'arm64' | 'ia32';
+  electronVersion: string;
+}
+
+interface DesktopApi {
+  getAppInfo?: () => Promise<AppInfo>;
+}
+
+/**
+ * Fetch host info over IPC. Returns `undefined` when the bridge is
+ * absent (web mode) or when the IPC call fails. Used by TelemetryBoot
+ * to populate the `headlamp.session-start` event.
+ */
+export async function getAppInfo(): Promise<AppInfo | undefined> {
+  const desktopApi = (window as unknown as { desktopApi?: DesktopApi }).desktopApi;
+  if (!desktopApi?.getAppInfo) return undefined;
+  try {
+    return await desktopApi.getAppInfo();
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/aks-desktop/src/telemetry/clusterShape.test.ts
+++ b/plugins/aks-desktop/src/telemetry/clusterShape.test.ts
@@ -63,11 +63,13 @@ describe('emitClusterShapeIfReady', () => {
 
   it('sanitizes unknown region to Other', () => {
     emitClusterShapeIfReady({ ...full, region: 'madeup' });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
     expect(trackEventMock.mock.calls[0][0].properties.region).toBe('Other');
   });
 
   it('sanitizes unknown aksTier to Unknown', () => {
     emitClusterShapeIfReady({ ...full, aksTier: 'NewTierName' });
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
     expect(trackEventMock.mock.calls[0][0].properties.aksTier).toBe('Unknown');
   });
 });

--- a/plugins/aks-desktop/src/telemetry/clusterShape.test.ts
+++ b/plugins/aks-desktop/src/telemetry/clusterShape.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitClusterShapeIfReady } from './clusterShape';
+
+let trackEventMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  trackEventMock = vi.fn();
+  window.appInsights = { trackEvent: trackEventMock } as unknown as ApplicationInsights;
+});
+
+afterEach(() => {
+  window.appInsights = undefined;
+});
+
+describe('emitClusterShapeIfReady', () => {
+  const full = {
+    kubernetesVersion: 'v1.29.4',
+    nodeCount: 12,
+    namespaceCount: 30,
+    region: 'eastus',
+    aksTier: 'Standard',
+  };
+
+  it('emits when all fields present', () => {
+    expect(emitClusterShapeIfReady(full)).toBe(true);
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: 'headlamp.cluster-shape',
+      properties: {
+        provider: 'AKS',
+        kubernetesMinor: '1.29',
+        nodeCountBucket: '6-20',
+        namespaceCountBucket: '11-50',
+        region: 'eastus',
+        aksTier: 'Standard',
+      },
+    });
+  });
+
+  it('returns false (no emission) when kubernetesVersion missing', () => {
+    expect(emitClusterShapeIfReady({ ...full, kubernetesVersion: undefined })).toBe(false);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false when nodeCount missing', () => {
+    expect(emitClusterShapeIfReady({ ...full, nodeCount: undefined })).toBe(false);
+  });
+
+  it('returns false when namespaceCount missing', () => {
+    expect(emitClusterShapeIfReady({ ...full, namespaceCount: undefined })).toBe(false);
+  });
+
+  it('returns false when region missing', () => {
+    expect(emitClusterShapeIfReady({ ...full, region: undefined })).toBe(false);
+  });
+
+  it('returns false when aksTier missing', () => {
+    expect(emitClusterShapeIfReady({ ...full, aksTier: undefined })).toBe(false);
+  });
+
+  it('sanitizes unknown region to Other', () => {
+    emitClusterShapeIfReady({ ...full, region: 'madeup' });
+    expect(trackEventMock.mock.calls[0][0].properties.region).toBe('Other');
+  });
+
+  it('sanitizes unknown aksTier to Unknown', () => {
+    emitClusterShapeIfReady({ ...full, aksTier: 'NewTierName' });
+    expect(trackEventMock.mock.calls[0][0].properties.aksTier).toBe('Unknown');
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/clusterShape.ts
+++ b/plugins/aks-desktop/src/telemetry/clusterShape.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { bucketNamespaceCount, bucketNodeCount, kubernetesMinor, sanitizeRegion } from './schema';
+import { trackClusterShape } from './track';
+
+const VALID_TIERS = new Set(['Free', 'Standard', 'Premium']);
+
+function sanitizeTier(tier: string | undefined): 'Free' | 'Standard' | 'Premium' | 'Unknown' {
+  return tier && VALID_TIERS.has(tier) ? (tier as 'Free' | 'Standard' | 'Premium') : 'Unknown';
+}
+
+export interface ClusterShapeInput {
+  kubernetesVersion: string | undefined;
+  nodeCount: number | undefined;
+  namespaceCount: number | undefined;
+  region: string | undefined;
+  aksTier: string | undefined;
+}
+
+/**
+ * Fire `headlamp.cluster-shape` only when every field is available. We
+ * never ship half-populated envelopes — it's better to lose the signal
+ * than mix dimensions that mean "unknown" with dimensions that mean
+ * "real value".
+ */
+export function emitClusterShapeIfReady(input: ClusterShapeInput): boolean {
+  if (
+    input.kubernetesVersion === undefined ||
+    input.nodeCount === undefined ||
+    input.namespaceCount === undefined ||
+    input.region === undefined ||
+    input.aksTier === undefined
+  ) {
+    return false;
+  }
+
+  trackClusterShape({
+    provider: 'AKS',
+    kubernetesMinor: kubernetesMinor(input.kubernetesVersion),
+    nodeCountBucket: bucketNodeCount(input.nodeCount),
+    namespaceCountBucket: bucketNamespaceCount(input.namespaceCount),
+    region: sanitizeRegion(input.region),
+    aksTier: sanitizeTier(input.aksTier),
+  });
+  return true;
+}

--- a/plugins/aks-desktop/src/telemetry/extractKind.test.ts
+++ b/plugins/aks-desktop/src/telemetry/extractKind.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { HeadlampEventType } from '@kinvolk/headlamp-plugin/lib/redux/headlampEventSlice';
+import { describe, expect, it } from 'vitest';
+import { extractKindFromPayload } from './extractKind';
+
+const podResource = { kind: 'Pod' } as any;
+const deploymentResource = { kind: 'Deployment' } as any;
+const crdResource = { kind: 'ArgoApplication' } as any;
+
+describe('extractKindFromPayload', () => {
+  it('returns "Pod" for LOGS/TERMINAL/POD_ATTACH unconditionally', () => {
+    expect(extractKindFromPayload({ type: HeadlampEventType.LOGS, data: {} })).toBe('Pod');
+    expect(extractKindFromPayload({ type: HeadlampEventType.TERMINAL, data: {} })).toBe('Pod');
+    expect(extractKindFromPayload({ type: HeadlampEventType.POD_ATTACH, data: {} })).toBe('Pod');
+  });
+
+  it('returns sanitized kind from data.resource for single-resource events', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.DELETE_RESOURCE,
+        data: { resource: deploymentResource, status: 'confirmed' },
+      })
+    ).toBe('Deployment');
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.EDIT_RESOURCE,
+        data: { resource: crdResource, status: 'open' },
+      })
+    ).toBe('CustomResource');
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.SCALE_RESOURCE,
+        data: { resource: podResource, status: 'confirmed' },
+      })
+    ).toBe('Pod');
+  });
+
+  it('returns sanitized kind from data.resourceKind for LIST_VIEW', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.LIST_VIEW,
+        data: { resources: [], resourceKind: 'Pod' },
+      })
+    ).toBe('Pod');
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.LIST_VIEW,
+        data: { resources: [], resourceKind: 'CustomThing' },
+      })
+    ).toBe('CustomResource');
+  });
+
+  it('returns homogeneous kind for plural events when all elements match', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.DELETE_RESOURCES,
+        data: { resources: [podResource, podResource, podResource], status: 'confirmed' },
+      })
+    ).toBe('Pod');
+  });
+
+  it('returns "Multiple" for plural events with mixed kinds', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.DELETE_RESOURCES,
+        data: { resources: [podResource, deploymentResource], status: 'confirmed' },
+      })
+    ).toBe('Multiple');
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.RESTART_RESOURCES,
+        data: { resources: [podResource, deploymentResource], status: 'confirmed' },
+      })
+    ).toBe('Multiple');
+  });
+
+  it('returns undefined for events with no resource (CREATE_RESOURCE, PLUGINS_LOADED, etc.)', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.CREATE_RESOURCE,
+        data: { status: 'confirmed' },
+      })
+    ).toBeUndefined();
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.PLUGINS_LOADED,
+        data: { plugins: [] },
+      })
+    ).toBeUndefined();
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.PLUGIN_LOADING_ERROR,
+        data: { pluginInfo: { name: 'x', version: '1' }, error: new Error('x') },
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for OBJECT_EVENTS when resource missing, sanitized kind when present', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.OBJECT_EVENTS,
+        data: { events: [] },
+      })
+    ).toBeUndefined();
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.OBJECT_EVENTS,
+        data: { events: [], resource: podResource },
+      })
+    ).toBe('Pod');
+  });
+
+  it('returns undefined for unknown event types', () => {
+    expect(extractKindFromPayload({ type: 'not-a-real-event', data: {} } as any)).toBeUndefined();
+  });
+
+  it('returns "Unknown" when single-resource event has missing resource', () => {
+    expect(
+      extractKindFromPayload({
+        type: HeadlampEventType.DELETE_RESOURCE,
+        data: { status: 'confirmed' } as any,
+      })
+    ).toBe('Unknown');
+  });
+
+  it('returns sanitized kind for rollback-resource (string literal — type lag in installed plugin pkg)', () => {
+    expect(
+      extractKindFromPayload({
+        type: 'headlamp.rollback-resource',
+        data: { resource: { kind: 'Deployment' }, status: 'confirmed' },
+      } as any)
+    ).toBe('Deployment');
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/extractKind.ts
+++ b/plugins/aks-desktop/src/telemetry/extractKind.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { HeadlampEventType } from '@kinvolk/headlamp-plugin/lib/redux/headlampEventSlice';
+import { sanitizeKind } from './schema';
+
+/**
+ * Extract a sanitized resourceKind from a HeadlampEvent payload.
+ *
+ * Returns `undefined` when the event has no resource — callers omit the
+ * property from the envelope rather than sending an empty string.
+ *
+ * Plural-resource events return the single kind when every element shares
+ * it, otherwise `"Multiple"`. We never enumerate the kinds — `Multiple` is
+ * a fixed-vocabulary value.
+ */
+export function extractKindFromPayload(event: { type: string; data?: any }): string | undefined {
+  const { type, data } = event;
+
+  switch (type) {
+    case HeadlampEventType.LOGS:
+    case HeadlampEventType.TERMINAL:
+    case HeadlampEventType.POD_ATTACH:
+      return 'Pod';
+
+    case HeadlampEventType.LIST_VIEW:
+      return sanitizeKind(data?.resourceKind);
+
+    case HeadlampEventType.DELETE_RESOURCE:
+    case HeadlampEventType.EDIT_RESOURCE:
+    case HeadlampEventType.SCALE_RESOURCE:
+    case HeadlampEventType.RESTART_RESOURCE:
+    case 'headlamp.rollback-resource': // enum member missing in installed type, dispatched at runtime by the fork
+    case HeadlampEventType.DETAILS_VIEW:
+      return sanitizeKind(data?.resource?.kind);
+
+    case HeadlampEventType.DELETE_RESOURCES:
+    case HeadlampEventType.RESTART_RESOURCES: {
+      const resources = data?.resources;
+      if (!Array.isArray(resources) || resources.length === 0) return undefined;
+      const first = sanitizeKind(resources[0]?.kind);
+      const homogeneous = resources.every((r: any) => sanitizeKind(r?.kind) === first);
+      return homogeneous ? first : 'Multiple';
+    }
+
+    case HeadlampEventType.OBJECT_EVENTS:
+      return data?.resource ? sanitizeKind(data.resource.kind) : undefined;
+
+    case HeadlampEventType.ERROR_BOUNDARY:
+    case HeadlampEventType.CREATE_RESOURCE:
+    case HeadlampEventType.PLUGINS_LOADED:
+    case HeadlampEventType.PLUGIN_LOADING_ERROR:
+      return undefined;
+
+    default:
+      return undefined;
+  }
+}

--- a/plugins/aks-desktop/src/telemetry/installId.test.ts
+++ b/plugins/aks-desktop/src/telemetry/installId.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getInstallId } from './installId';
+
+afterEach(() => {
+  delete (window as any).desktopApi;
+});
+
+describe('getInstallId', () => {
+  it('returns the UUID provided by desktopApi.getInstallId', async () => {
+    (window as any).desktopApi = {
+      getInstallId: vi.fn().mockResolvedValue('11111111-1111-4111-8111-111111111111'),
+    };
+    const id = await getInstallId();
+    expect(id).toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('returns undefined when desktopApi is absent (web mode)', async () => {
+    expect(await getInstallId()).toBeUndefined();
+  });
+
+  it('returns undefined when desktopApi.getInstallId is absent', async () => {
+    (window as any).desktopApi = {};
+    expect(await getInstallId()).toBeUndefined();
+  });
+
+  it('returns undefined and does not throw when the IPC call fails', async () => {
+    (window as any).desktopApi = {
+      getInstallId: vi.fn().mockRejectedValue(new Error('IPC failed')),
+    };
+    expect(await getInstallId()).toBeUndefined();
+  });
+
+  it('returns undefined when the IPC returns a non-UUID value', async () => {
+    (window as any).desktopApi = {
+      getInstallId: vi.fn().mockResolvedValue('not-a-uuid'),
+    };
+    expect(await getInstallId()).toBeUndefined();
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/installId.ts
+++ b/plugins/aks-desktop/src/telemetry/installId.ts
@@ -8,15 +8,14 @@ interface DesktopApi {
 }
 
 /**
- * Fetch the per-install UUID over IPC. Returns `undefined` on web mode,
- * when the bridge isn't available, when the IPC fails, or when the value
- * returned doesn't look like a v4 UUID.
- *
- * Telemetry initialization treats `undefined` as "do not initialize" — we
- * never fall back to a session ID or device-derived value.
+ * Fetch the per-install UUID over the Electron preload bridge. Returns
+ * `undefined` on web mode, when the bridge is absent, when the IPC fails,
+ * or when the returned value doesn't match the UUID shape. Telemetry
+ * initialization treats `undefined` as "do not initialize" — we never
+ * fall back to a session ID or device-derived value.
  */
 export async function getInstallId(): Promise<string | undefined> {
-  const desktopApi = (window as unknown as { desktopApi?: DesktopApi }).desktopApi;
+  const desktopApi = (window as { desktopApi?: DesktopApi }).desktopApi;
   if (!desktopApi?.getInstallId) return undefined;
   try {
     const id = await desktopApi.getInstallId();

--- a/plugins/aks-desktop/src/telemetry/installId.ts
+++ b/plugins/aks-desktop/src/telemetry/installId.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface DesktopApi {
+  getInstallId?: () => Promise<string>;
+}
+
+/**
+ * Fetch the per-install UUID over IPC. Returns `undefined` on web mode,
+ * when the bridge isn't available, when the IPC fails, or when the value
+ * returned doesn't look like a v4 UUID.
+ *
+ * Telemetry initialization treats `undefined` as "do not initialize" — we
+ * never fall back to a session ID or device-derived value.
+ */
+export async function getInstallId(): Promise<string | undefined> {
+  const desktopApi = (window as unknown as { desktopApi?: DesktopApi }).desktopApi;
+  if (!desktopApi?.getInstallId) return undefined;
+  try {
+    const id = await desktopApi.getInstallId();
+    return typeof id === 'string' && UUID_RE.test(id) ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/aks-desktop/src/telemetry/privacy.test.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.test.ts
@@ -7,8 +7,29 @@ import { makePrivacyInitializer } from './privacy';
 
 const VALID_INSTALL_ID = '11111111-1111-4111-8111-111111111111';
 
-function envelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
-  return { name: 'headlamp.feature', ...overrides } as ITelemetryItem;
+// `envelope.name` is the SDK-internal envelope-type identifier (e.g.
+// `Microsoft.ApplicationInsights.<ikey>.Event`), NOT the caller-controlled
+// custom event name passed to `trackEvent({ name })`. The custom name
+// lives at `envelope.data.baseData.name`. The test fixtures mirror real
+// SDK shape: a sentinel SDK type at the top level, and the caller's name
+// nested under baseData.
+const SDK_EVENT_TYPE = 'Microsoft.ApplicationInsights.fakeikey.Event';
+
+function envelope(overrides: {
+  tags?: ITelemetryItem['tags'];
+  baseData?: Record<string, unknown>;
+}) {
+  const out: ITelemetryItem = {
+    name: SDK_EVENT_TYPE,
+    baseType: 'EventData',
+    tags: overrides.tags,
+    data: overrides.baseData ? { baseData: overrides.baseData } : undefined,
+  } as ITelemetryItem;
+  return out;
+}
+
+function baseDataWithName(name: string, extra: Record<string, unknown> = {}) {
+  return { name, ...extra };
 }
 
 describe('privacy initializer', () => {
@@ -21,6 +42,7 @@ describe('privacy initializer', () => {
         'ai.session.id': 'sess-xyz',
         'ai.location.ip': '198.51.100.1',
       },
+      baseData: baseDataWithName('headlamp.feature'),
     });
     init(e);
     expect(e.tags).not.toHaveProperty('ai.user.authUserId');
@@ -31,28 +53,37 @@ describe('privacy initializer', () => {
 
   it('keeps ai.user.id when it equals the install UUID', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e = envelope({ tags: { 'ai.user.id': VALID_INSTALL_ID } });
+    const e = envelope({
+      tags: { 'ai.user.id': VALID_INSTALL_ID },
+      baseData: baseDataWithName('headlamp.feature'),
+    });
     init(e);
     expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
   });
 
   it('stamps install UUID into ai.user.id when missing', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e = envelope();
+    const e = envelope({ baseData: baseDataWithName('headlamp.feature') });
     init(e);
     expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
   });
 
   it('replaces non-UUID ai.user.id with the install UUID', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e = envelope({ tags: { 'ai.user.id': 'jdoe@example.com' } });
+    const e = envelope({
+      tags: { 'ai.user.id': 'jdoe@example.com' },
+      baseData: baseDataWithName('headlamp.feature'),
+    });
     init(e);
     expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
   });
 
   it('strips ai.user.id entirely when no install UUID provided', () => {
     const init = makePrivacyInitializer(undefined);
-    const e = envelope({ tags: { 'ai.user.id': 'something' } });
+    const e = envelope({
+      tags: { 'ai.user.id': 'something' },
+      baseData: baseDataWithName('headlamp.feature'),
+    });
     init(e);
     expect(e.tags).not.toHaveProperty('ai.user.id');
   });
@@ -60,12 +91,11 @@ describe('privacy initializer', () => {
   it('clears uri/refUri/url on baseData', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
     const e = envelope({
-      data: {
-        baseData: {
-          uri: 'https://x/clusters/prod/pods/secret-thing',
-          refUri: 'https://x/anywhere',
-          url: 'https://y',
-        },
+      baseData: {
+        name: 'headlamp.feature',
+        uri: 'https://x/clusters/prod/pods/secret-thing',
+        refUri: 'https://x/anywhere',
+        url: 'https://y',
       },
     });
     init(e);
@@ -78,33 +108,32 @@ describe('privacy initializer', () => {
   it('drops properties whose keys are not in KNOWN_PROPERTY_KEYS', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
     const e = envelope({
-      data: {
-        baseData: {
-          properties: {
-            installId: VALID_INSTALL_ID,
-            errorName: 'TypeError',
-            attackerInjected: 'secret value',
-            anotherBadKey: '12345',
-          },
+      baseData: {
+        name: 'headlamp.feature',
+        properties: {
+          installId: VALID_INSTALL_ID,
+          errorName: 'TypeError',
+          attackerInjected: 'secret value',
+          anotherBadKey: '12345',
         },
       },
     });
     init(e);
-    const props = (e.data?.baseData as any).properties;
+    const props = (e.data?.baseData as { properties: Record<string, unknown> }).properties;
     expect(props).toHaveProperty('installId');
     expect(props).toHaveProperty('errorName');
     expect(props).not.toHaveProperty('attackerInjected');
     expect(props).not.toHaveProperty('anotherBadKey');
   });
 
-  it('is a no-op when envelope has neither tags nor baseData', () => {
+  it('does not throw when envelope has no baseData', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e: ITelemetryItem = { name: 'headlamp.feature' } as ITelemetryItem;
+    const e: ITelemetryItem = { name: SDK_EVENT_TYPE } as ITelemetryItem;
     expect(() => init(e)).not.toThrow();
     expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
   });
 
-  it('keeps envelope name when it is in KNOWN_EVENT_NAMES', () => {
+  it('keeps baseData.name (the custom event name) when it is in KNOWN_EVENT_NAMES', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
     for (const name of [
       'headlamp.session-start',
@@ -114,16 +143,27 @@ describe('privacy initializer', () => {
       'headlamp.plugins-loaded',
       'exception',
     ]) {
-      const e: ITelemetryItem = { name } as ITelemetryItem;
+      const e = envelope({ baseData: baseDataWithName(name) });
       init(e);
-      expect(e.name).toBe(name);
+      expect((e.data?.baseData as { name: string }).name).toBe(name);
+      // SDK-internal envelope type is left untouched.
+      expect(e.name).toBe(SDK_EVENT_TYPE);
     }
   });
 
-  it('replaces envelope name with "unknown" when not in KNOWN_EVENT_NAMES', () => {
+  it('replaces baseData.name with "unknown" when not in KNOWN_EVENT_NAMES', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e: ITelemetryItem = { name: 'leak:secret-value' } as ITelemetryItem;
+    const e = envelope({ baseData: baseDataWithName('leak:secret-value') });
     init(e);
-    expect(e.name).toBe('unknown');
+    expect((e.data?.baseData as { name: string }).name).toBe('unknown');
+    // SDK-internal envelope type is left untouched.
+    expect(e.name).toBe(SDK_EVENT_TYPE);
+  });
+
+  it('replaces baseData.name with "unknown" when missing', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({ baseData: { properties: { errorName: 'TypeError' } } });
+    init(e);
+    expect((e.data?.baseData as { name: string }).name).toBe('unknown');
   });
 });

--- a/plugins/aks-desktop/src/telemetry/privacy.test.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
+import { describe, expect, it } from 'vitest';
+import { makePrivacyInitializer } from './privacy';
+
+const VALID_INSTALL_ID = '11111111-1111-4111-8111-111111111111';
+
+function envelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
+  return { name: 'x', ...overrides } as ITelemetryItem;
+}
+
+describe('privacy initializer', () => {
+  it('strips ai.user.authUserId, ai.user.accountId, ai.session.id, ai.location.ip', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({
+      tags: {
+        'ai.user.authUserId': 'jdoe@example.com',
+        'ai.user.accountId': 'acct-123',
+        'ai.session.id': 'sess-xyz',
+        'ai.location.ip': '198.51.100.1',
+      },
+    });
+    init(e);
+    expect(e.tags).not.toHaveProperty('ai.user.authUserId');
+    expect(e.tags).not.toHaveProperty('ai.user.accountId');
+    expect(e.tags).not.toHaveProperty('ai.session.id');
+    expect(e.tags).not.toHaveProperty('ai.location.ip');
+  });
+
+  it('keeps ai.user.id when it equals the install UUID', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({ tags: { 'ai.user.id': VALID_INSTALL_ID } });
+    init(e);
+    expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
+  });
+
+  it('stamps install UUID into ai.user.id when missing', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope();
+    init(e);
+    expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
+  });
+
+  it('replaces non-UUID ai.user.id with the install UUID', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({ tags: { 'ai.user.id': 'jdoe@example.com' } });
+    init(e);
+    expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
+  });
+
+  it('strips ai.user.id entirely when no install UUID provided', () => {
+    const init = makePrivacyInitializer(undefined);
+    const e = envelope({ tags: { 'ai.user.id': 'something' } });
+    init(e);
+    expect(e.tags).not.toHaveProperty('ai.user.id');
+  });
+
+  it('clears uri/refUri/url on baseData', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({
+      data: {
+        baseData: {
+          uri: 'https://x/clusters/prod/pods/secret-thing',
+          refUri: 'https://x/anywhere',
+          url: 'https://y',
+        },
+      },
+    });
+    init(e);
+    const bd = (e.data?.baseData ?? {}) as Record<string, unknown>;
+    expect(bd.uri).toBe('');
+    expect(bd.refUri).toBe('');
+    expect(bd.url).toBe('');
+  });
+
+  it('drops properties whose keys are not in KNOWN_PROPERTY_KEYS', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e = envelope({
+      data: {
+        baseData: {
+          properties: {
+            installId: VALID_INSTALL_ID,
+            errorName: 'TypeError',
+            attackerInjected: 'secret value',
+            anotherBadKey: '12345',
+          },
+        },
+      },
+    });
+    init(e);
+    const props = (e.data?.baseData as any).properties;
+    expect(props).toHaveProperty('installId');
+    expect(props).toHaveProperty('errorName');
+    expect(props).not.toHaveProperty('attackerInjected');
+    expect(props).not.toHaveProperty('anotherBadKey');
+  });
+
+  it('is a no-op when envelope has neither tags nor baseData', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e: ITelemetryItem = { name: 'x' } as ITelemetryItem;
+    expect(() => init(e)).not.toThrow();
+    expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/privacy.test.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.test.ts
@@ -8,7 +8,7 @@ import { makePrivacyInitializer } from './privacy';
 const VALID_INSTALL_ID = '11111111-1111-4111-8111-111111111111';
 
 function envelope(overrides: Partial<ITelemetryItem> = {}): ITelemetryItem {
-  return { name: 'x', ...overrides } as ITelemetryItem;
+  return { name: 'headlamp.feature', ...overrides } as ITelemetryItem;
 }
 
 describe('privacy initializer', () => {
@@ -99,8 +99,31 @@ describe('privacy initializer', () => {
 
   it('is a no-op when envelope has neither tags nor baseData', () => {
     const init = makePrivacyInitializer(VALID_INSTALL_ID);
-    const e: ITelemetryItem = { name: 'x' } as ITelemetryItem;
+    const e: ITelemetryItem = { name: 'headlamp.feature' } as ITelemetryItem;
     expect(() => init(e)).not.toThrow();
     expect(e.tags?.['ai.user.id']).toBe(VALID_INSTALL_ID);
+  });
+
+  it('keeps envelope name when it is in KNOWN_EVENT_NAMES', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    for (const name of [
+      'headlamp.session-start',
+      'headlamp.cluster-shape',
+      'headlamp.feature',
+      'headlamp.exception',
+      'headlamp.plugins-loaded',
+      'exception',
+    ]) {
+      const e: ITelemetryItem = { name } as ITelemetryItem;
+      init(e);
+      expect(e.name).toBe(name);
+    }
+  });
+
+  it('replaces envelope name with "unknown" when not in KNOWN_EVENT_NAMES', () => {
+    const init = makePrivacyInitializer(VALID_INSTALL_ID);
+    const e: ITelemetryItem = { name: 'leak:secret-value' } as ITelemetryItem;
+    init(e);
+    expect(e.name).toBe('unknown');
   });
 });

--- a/plugins/aks-desktop/src/telemetry/privacy.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.ts
@@ -11,16 +11,16 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * (or `undefined` if telemetry is configured without one — e.g. web
  * fallback).
  *
- * For every outgoing envelope, this is the LAST line of defense:
+ * For every outgoing envelope, this is the last line of defense:
  *
- *   1. Strip the unconditional fields (auth/account/session/IP).
- *   2. Replace `ai.user.id` with the install UUID if we have one and the
- *      current value doesn't match; strip it entirely if we don't.
- *   3. Clear URL fields on baseData.
- *   4. Drop any property key not in KNOWN_PROPERTY_KEYS.
- *   5. Replace the envelope name with `'unknown'` if it isn't in
+ *   1. Replace the envelope name with `'unknown'` if it isn't in
  *      KNOWN_EVENT_NAMES. Prevents a caller bypassing the typed helpers
  *      from smuggling data through the event name itself.
+ *   2. Strip the unconditional identity tags (auth/account/session/IP).
+ *   3. Replace `ai.user.id` with the install UUID if we have one and the
+ *      current value doesn't match; strip it entirely if we don't.
+ *   4. Clear URL fields on baseData.
+ *   5. Drop any property key not in KNOWN_PROPERTY_KEYS.
  *
  * Mutates `envelope` in place (initializer contract).
  */

--- a/plugins/aks-desktop/src/telemetry/privacy.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
+import { KNOWN_PROPERTY_KEYS } from './schema';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Build the privacy telemetry initializer, closing over the install UUID
+ * (or `undefined` if telemetry is configured without one — e.g. web
+ * fallback).
+ *
+ * For every outgoing envelope, this is the LAST line of defense:
+ *
+ *   1. Strip the unconditional fields (auth/account/session/IP).
+ *   2. Replace `ai.user.id` with the install UUID if we have one and the
+ *      current value doesn't match; strip it entirely if we don't.
+ *   3. Clear URL fields on baseData.
+ *   4. Drop any property key not in KNOWN_PROPERTY_KEYS.
+ *
+ * Mutates `envelope` in place (initializer contract).
+ */
+export function makePrivacyInitializer(installId: string | undefined) {
+  return function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
+    envelope.tags = envelope.tags ?? {};
+    delete envelope.tags['ai.user.authUserId'];
+    delete envelope.tags['ai.user.accountId'];
+    delete envelope.tags['ai.session.id'];
+    delete envelope.tags['ai.location.ip'];
+
+    const currentUserId = envelope.tags['ai.user.id'];
+    if (installId) {
+      if (typeof currentUserId !== 'string' || !UUID_RE.test(currentUserId)) {
+        envelope.tags['ai.user.id'] = installId;
+      }
+    } else {
+      delete envelope.tags['ai.user.id'];
+    }
+
+    const baseData = envelope.data?.baseData as Record<string, unknown> | undefined;
+    if (baseData) {
+      if ('uri' in baseData) baseData.uri = '';
+      if ('refUri' in baseData) baseData.refUri = '';
+      if ('url' in baseData) baseData.url = '';
+
+      const props = baseData.properties as Record<string, unknown> | undefined;
+      if (props) {
+        for (const key of Object.keys(props)) {
+          if (!KNOWN_PROPERTY_KEYS.has(key)) {
+            delete props[key];
+          }
+        }
+      }
+    }
+  };
+}

--- a/plugins/aks-desktop/src/telemetry/privacy.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0.
 
 import type { ITelemetryItem } from '@microsoft/applicationinsights-web';
-import { KNOWN_PROPERTY_KEYS } from './schema';
+import { KNOWN_EVENT_NAMES, KNOWN_PROPERTY_KEYS } from './schema';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -18,11 +18,17 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  *      current value doesn't match; strip it entirely if we don't.
  *   3. Clear URL fields on baseData.
  *   4. Drop any property key not in KNOWN_PROPERTY_KEYS.
+ *   5. Replace the envelope name with `'unknown'` if it isn't in
+ *      KNOWN_EVENT_NAMES. Prevents a caller bypassing the typed helpers
+ *      from smuggling data through the event name itself.
  *
  * Mutates `envelope` in place (initializer contract).
  */
 export function makePrivacyInitializer(installId: string | undefined) {
   return function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
+    if (typeof envelope.name !== 'string' || !KNOWN_EVENT_NAMES.has(envelope.name)) {
+      envelope.name = 'unknown';
+    }
     envelope.tags = envelope.tags ?? {};
     delete envelope.tags['ai.user.authUserId'];
     delete envelope.tags['ai.user.accountId'];

--- a/plugins/aks-desktop/src/telemetry/privacy.ts
+++ b/plugins/aks-desktop/src/telemetry/privacy.ts
@@ -13,22 +13,23 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  *
  * For every outgoing envelope, this is the last line of defense:
  *
- *   1. Replace the envelope name with `'unknown'` if it isn't in
- *      KNOWN_EVENT_NAMES. Prevents a caller bypassing the typed helpers
- *      from smuggling data through the event name itself.
- *   2. Strip the unconditional identity tags (auth/account/session/IP).
- *   3. Replace `ai.user.id` with the install UUID if we have one and the
+ *   1. Strip the unconditional identity tags (auth/account/session/IP).
+ *   2. Replace `ai.user.id` with the install UUID if we have one and the
  *      current value doesn't match; strip it entirely if we don't.
- *   4. Clear URL fields on baseData.
+ *   3. Clear URL fields on baseData.
+ *   4. Replace `baseData.name` (the custom event name passed to
+ *      `trackEvent({ name })`) with `'unknown'` if it isn't in
+ *      KNOWN_EVENT_NAMES. Prevents a caller bypassing the typed helpers
+ *      from smuggling data through the event name itself. (Note:
+ *      `envelope.name` itself is the SDK-internal envelope-type string
+ *      such as `Microsoft.ApplicationInsights.{ikey}.Event`, NOT the
+ *      caller-controlled custom name.)
  *   5. Drop any property key not in KNOWN_PROPERTY_KEYS.
  *
  * Mutates `envelope` in place (initializer contract).
  */
 export function makePrivacyInitializer(installId: string | undefined) {
   return function privacyTelemetryInitializer(envelope: ITelemetryItem): void {
-    if (typeof envelope.name !== 'string' || !KNOWN_EVENT_NAMES.has(envelope.name)) {
-      envelope.name = 'unknown';
-    }
     envelope.tags = envelope.tags ?? {};
     delete envelope.tags['ai.user.authUserId'];
     delete envelope.tags['ai.user.accountId'];
@@ -49,6 +50,11 @@ export function makePrivacyInitializer(installId: string | undefined) {
       if ('uri' in baseData) baseData.uri = '';
       if ('refUri' in baseData) baseData.refUri = '';
       if ('url' in baseData) baseData.url = '';
+
+      const customName = baseData.name;
+      if (typeof customName !== 'string' || !KNOWN_EVENT_NAMES.has(customName)) {
+        baseData.name = 'unknown';
+      }
 
       const props = baseData.properties as Record<string, unknown> | undefined;
       if (props) {

--- a/plugins/aks-desktop/src/telemetry/schema.test.ts
+++ b/plugins/aks-desktop/src/telemetry/schema.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { describe, expect, it } from 'vitest';
+import {
+  bucketNamespaceCount,
+  bucketNodeCount,
+  BUILTIN_K8S_KINDS,
+  KNOWN_ERROR_NAMES,
+  KNOWN_PROPERTY_KEYS,
+  kubernetesMinor,
+  localeLanguage,
+  osMajor,
+  sanitizeErrorName,
+  sanitizeKind,
+  sanitizeRegion,
+} from './schema';
+
+describe('sanitizeKind', () => {
+  it('returns built-in kinds verbatim', () => {
+    expect(sanitizeKind('Pod')).toBe('Pod');
+    expect(sanitizeKind('Deployment')).toBe('Deployment');
+  });
+  it('collapses unknown kinds to CustomResource', () => {
+    expect(sanitizeKind('ArgoApplication')).toBe('CustomResource');
+    expect(sanitizeKind('MyCRD')).toBe('CustomResource');
+  });
+  it('returns Unknown for undefined/empty', () => {
+    expect(sanitizeKind(undefined)).toBe('Unknown');
+    expect(sanitizeKind('')).toBe('Unknown');
+  });
+});
+
+describe('sanitizeErrorName', () => {
+  it('returns allowlisted names verbatim', () => {
+    expect(sanitizeErrorName('TypeError')).toBe('TypeError');
+    expect(sanitizeErrorName('KubeApiError')).toBe('KubeApiError');
+  });
+  it('collapses unknown to Other', () => {
+    expect(sanitizeErrorName('WeirdCustomError')).toBe('Other');
+  });
+  it('returns Other for undefined/empty', () => {
+    expect(sanitizeErrorName(undefined)).toBe('Other');
+    expect(sanitizeErrorName('')).toBe('Other');
+  });
+});
+
+describe('sanitizeRegion', () => {
+  it('returns allowlisted regions verbatim', () => {
+    expect(sanitizeRegion('eastus')).toBe('eastus');
+    expect(sanitizeRegion('westeurope')).toBe('westeurope');
+  });
+  it('collapses unknown to Other', () => {
+    expect(sanitizeRegion('madeupregion')).toBe('Other');
+    expect(sanitizeRegion(undefined)).toBe('Other');
+  });
+});
+
+describe('bucketNodeCount', () => {
+  it.each([
+    [0, '1-5'],
+    [1, '1-5'],
+    [5, '1-5'],
+    [6, '6-20'],
+    [20, '6-20'],
+    [21, '21-100'],
+    [100, '21-100'],
+    [101, '100+'],
+    [5000, '100+'],
+  ])('%d → %s', (n, expected) => {
+    expect(bucketNodeCount(n)).toBe(expected);
+  });
+});
+
+describe('bucketNamespaceCount', () => {
+  it.each([
+    [0, '1-10'],
+    [10, '1-10'],
+    [11, '11-50'],
+    [50, '11-50'],
+    [51, '51-200'],
+    [200, '51-200'],
+    [201, '200+'],
+  ])('%d → %s', (n, expected) => {
+    expect(bucketNamespaceCount(n)).toBe(expected);
+  });
+});
+
+describe('kubernetesMinor', () => {
+  it.each([
+    ['v1.29.4', '1.29'],
+    ['1.30.0', '1.30'],
+    ['v1.28', '1.28'],
+  ])('%s → %s', (v, expected) => {
+    expect(kubernetesMinor(v)).toBe(expected);
+  });
+  it('returns "unknown" for malformed input', () => {
+    expect(kubernetesMinor('')).toBe('unknown');
+    expect(kubernetesMinor('garbage')).toBe('unknown');
+  });
+});
+
+describe('localeLanguage', () => {
+  it.each([
+    ['en-US', 'en'],
+    ['en', 'en'],
+    ['pt-BR', 'pt'],
+    ['ja-JP', 'ja'],
+  ])('%s → %s', (l, expected) => {
+    expect(localeLanguage(l)).toBe(expected);
+  });
+  it('returns "unknown" for empty', () => {
+    expect(localeLanguage('')).toBe('unknown');
+  });
+});
+
+describe('osMajor', () => {
+  it.each([
+    ['14.0.1', '14'],
+    ['10.0.22631', '10'],
+    ['6.5.0-15-generic', '6'],
+  ])('%s → %s', (r, expected) => {
+    expect(osMajor(r)).toBe(expected);
+  });
+  it('returns "unknown" for non-numeric leading component', () => {
+    expect(osMajor('abc')).toBe('unknown');
+    expect(osMajor('')).toBe('unknown');
+  });
+});
+
+describe('vocabulary sets', () => {
+  it('BUILTIN_K8S_KINDS contains expected staples', () => {
+    expect(BUILTIN_K8S_KINDS.has('Pod')).toBe(true);
+    expect(BUILTIN_K8S_KINDS.has('Deployment')).toBe(true);
+    expect(BUILTIN_K8S_KINDS.has('Service')).toBe(true);
+    expect(BUILTIN_K8S_KINDS.has('Namespace')).toBe(true);
+    expect(BUILTIN_K8S_KINDS.has('Node')).toBe(true);
+  });
+  it('KNOWN_ERROR_NAMES contains expected staples', () => {
+    expect(KNOWN_ERROR_NAMES.has('TypeError')).toBe(true);
+    expect(KNOWN_ERROR_NAMES.has('KubeApiError')).toBe(true);
+  });
+  it('KNOWN_PROPERTY_KEYS is the exact union of event property keys', () => {
+    // This is the drift guardrail. If you add a property to any helper,
+    // update KNOWN_PROPERTY_KEYS at the same time or this test breaks.
+    const expected = new Set([
+      'installId',
+      'appVersion',
+      'headlampVersion',
+      'electronVersion',
+      'os',
+      'osMajor',
+      'arch',
+      'locale',
+      'provider',
+      'kubernetesMinor',
+      'nodeCountBucket',
+      'namespaceCountBucket',
+      'region',
+      'aksTier',
+      'feature',
+      'status',
+      'resourceKind',
+      'errorName',
+      'totalCount',
+      'enabledCount',
+      'knownEnabledIds',
+      'thirdPartyCount',
+    ]);
+    expect(new Set(KNOWN_PROPERTY_KEYS)).toEqual(expected);
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/schema.test.ts
+++ b/plugins/aks-desktop/src/telemetry/schema.test.ts
@@ -7,6 +7,7 @@ import {
   bucketNodeCount,
   BUILTIN_K8S_KINDS,
   KNOWN_ERROR_NAMES,
+  KNOWN_EVENT_NAMES,
   KNOWN_PROPERTY_KEYS,
   kubernetesMinor,
   localeLanguage,
@@ -139,6 +140,18 @@ describe('vocabulary sets', () => {
   it('KNOWN_ERROR_NAMES contains expected staples', () => {
     expect(KNOWN_ERROR_NAMES.has('TypeError')).toBe(true);
     expect(KNOWN_ERROR_NAMES.has('KubeApiError')).toBe(true);
+  });
+  it('KNOWN_EVENT_NAMES contains the five headlamp.* names plus the "exception" shim', () => {
+    expect(new Set(KNOWN_EVENT_NAMES)).toEqual(
+      new Set([
+        'headlamp.session-start',
+        'headlamp.cluster-shape',
+        'headlamp.feature',
+        'headlamp.exception',
+        'headlamp.plugins-loaded',
+        'exception',
+      ])
+    );
   });
   it('KNOWN_PROPERTY_KEYS is the exact union of event property keys', () => {
     // This is the drift guardrail. If you add a property to any helper,

--- a/plugins/aks-desktop/src/telemetry/schema.ts
+++ b/plugins/aks-desktop/src/telemetry/schema.ts
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+/**
+ * Vocabularies and sanitizers gating every value before it reaches a
+ * telemetry envelope. No runtime side effects.
+ *
+ * See: docs/superpowers/specs/2026-06-02-app-insights-usage-telemetry-design.md
+ */
+
+export const BUILTIN_K8S_KINDS: ReadonlySet<string> = new Set([
+  // Core
+  'Pod',
+  'Service',
+  'Namespace',
+  'Node',
+  'ConfigMap',
+  'Secret',
+  'PersistentVolume',
+  'PersistentVolumeClaim',
+  'ServiceAccount',
+  'Endpoints',
+  'EndpointSlice',
+  'Event',
+  'LimitRange',
+  'ResourceQuota',
+  // Apps
+  'Deployment',
+  'StatefulSet',
+  'DaemonSet',
+  'ReplicaSet',
+  'ReplicationController',
+  // Batch
+  'Job',
+  'CronJob',
+  // Networking
+  'Ingress',
+  'IngressClass',
+  'NetworkPolicy',
+  'Gateway',
+  'HTTPRoute',
+  'GRPCRoute',
+  // Storage
+  'StorageClass',
+  'VolumeAttachment',
+  'CSIDriver',
+  'CSINode',
+  // RBAC
+  'Role',
+  'RoleBinding',
+  'ClusterRole',
+  'ClusterRoleBinding',
+  // Autoscaling
+  'HorizontalPodAutoscaler',
+  'VerticalPodAutoscaler',
+  'PodDisruptionBudget',
+  // Admission
+  'MutatingWebhookConfiguration',
+  'ValidatingWebhookConfiguration',
+  // API
+  'CustomResourceDefinition',
+  'APIService',
+  // Lease
+  'Lease',
+]);
+
+export const KNOWN_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'Error',
+  'TypeError',
+  'RangeError',
+  'SyntaxError',
+  'ReferenceError',
+  'URIError',
+  'EvalError',
+  'KubeApiError',
+  'ApiError',
+  'NetworkError',
+  'AbortError',
+  'TimeoutError',
+]);
+
+export const KNOWN_PLUGIN_IDS: ReadonlySet<string> = new Set(['aks-desktop']);
+
+/**
+ * Azure public cloud regions (Microsoft-defined vocabulary, not customer
+ * data). Sourced from `az account list-locations` for public cloud only;
+ * sovereign clouds are intentionally excluded.
+ */
+export const AZURE_REGIONS: ReadonlySet<string> = new Set([
+  'eastus',
+  'eastus2',
+  'southcentralus',
+  'westus',
+  'westus2',
+  'westus3',
+  'centralus',
+  'northcentralus',
+  'westcentralus',
+  'canadacentral',
+  'canadaeast',
+  'brazilsouth',
+  'brazilsoutheast',
+  'northeurope',
+  'westeurope',
+  'uksouth',
+  'ukwest',
+  'francecentral',
+  'francesouth',
+  'germanywestcentral',
+  'germanynorth',
+  'norwayeast',
+  'norwaywest',
+  'switzerlandnorth',
+  'switzerlandwest',
+  'swedencentral',
+  'swedensouth',
+  'polandcentral',
+  'italynorth',
+  'spaincentral',
+  'uaenorth',
+  'uaecentral',
+  'southafricanorth',
+  'southafricawest',
+  'australiaeast',
+  'australiasoutheast',
+  'australiacentral',
+  'australiacentral2',
+  'eastasia',
+  'southeastasia',
+  'japaneast',
+  'japanwest',
+  'koreacentral',
+  'koreasouth',
+  'centralindia',
+  'southindia',
+  'westindia',
+  'jioindiawest',
+  'jioindiacentral',
+  'qatarcentral',
+  'israelcentral',
+  'mexicocentral',
+]);
+
+export const KNOWN_PROPERTY_KEYS: ReadonlySet<string> = new Set([
+  // session-start
+  'installId',
+  'appVersion',
+  'headlampVersion',
+  'electronVersion',
+  'os',
+  'osMajor',
+  'arch',
+  'locale',
+  // cluster-shape
+  'provider',
+  'kubernetesMinor',
+  'nodeCountBucket',
+  'namespaceCountBucket',
+  'region',
+  'aksTier',
+  // feature
+  'feature',
+  'status',
+  'resourceKind',
+  // exception
+  'errorName',
+  // plugins-loaded
+  'totalCount',
+  'enabledCount',
+  'knownEnabledIds',
+  'thirdPartyCount',
+]);
+
+export function sanitizeKind(kind: string | undefined): string {
+  if (!kind) return 'Unknown';
+  return BUILTIN_K8S_KINDS.has(kind) ? kind : 'CustomResource';
+}
+
+export function sanitizeErrorName(name: string | undefined): string {
+  if (!name) return 'Other';
+  return KNOWN_ERROR_NAMES.has(name) ? name : 'Other';
+}
+
+export function sanitizeRegion(region: string | undefined): string {
+  if (!region) return 'Other';
+  return AZURE_REGIONS.has(region) ? region : 'Other';
+}
+
+export type NodeCountBucket = '1-5' | '6-20' | '21-100' | '100+';
+export function bucketNodeCount(n: number): NodeCountBucket {
+  if (n <= 5) return '1-5';
+  if (n <= 20) return '6-20';
+  if (n <= 100) return '21-100';
+  return '100+';
+}
+
+export type NamespaceCountBucket = '1-10' | '11-50' | '51-200' | '200+';
+export function bucketNamespaceCount(n: number): NamespaceCountBucket {
+  if (n <= 10) return '1-10';
+  if (n <= 50) return '11-50';
+  if (n <= 200) return '51-200';
+  return '200+';
+}
+
+export function kubernetesMinor(version: string): string {
+  // Accepts "v1.29.4", "1.29.4", "v1.28", etc. Returns "1.29".
+  const m = /^v?(\d+)\.(\d+)/.exec(version);
+  return m ? `${m[1]}.${m[2]}` : 'unknown';
+}
+
+export function localeLanguage(locale: string): string {
+  if (!locale) return 'unknown';
+  return locale.split(/[-_]/)[0].toLowerCase();
+}
+
+export function osMajor(release: string): string {
+  const m = /^(\d+)/.exec(release);
+  return m ? m[1] : 'unknown';
+}

--- a/plugins/aks-desktop/src/telemetry/schema.ts
+++ b/plugins/aks-desktop/src/telemetry/schema.ts
@@ -4,8 +4,6 @@
 /**
  * Vocabularies and sanitizers gating every value before it reaches a
  * telemetry envelope. No runtime side effects.
- *
- * See: docs/superpowers/specs/2026-06-02-app-insights-usage-telemetry-design.md
  */
 
 export const BUILTIN_K8S_KINDS: ReadonlySet<string> = new Set([
@@ -158,6 +156,49 @@ export const KNOWN_EVENT_NAMES: ReadonlySet<string> = new Set([
   // allowlist its bare name so the existing path keeps working.
   'exception',
 ]);
+
+/**
+ * The set of HeadlampEventType string values that we forward into the
+ * `feature` property of `headlamp.feature` envelopes. We allowlist this
+ * (rather than passing `event.type` through) so a future upstream change
+ * that encodes data in an event type string (e.g. `cluster:my-prod`)
+ * cannot leak through the `feature` property.
+ *
+ * Includes the string literal `'headlamp.rollback-resource'` because
+ * the corresponding `HeadlampEventType.ROLLBACK_RESOURCE` is missing
+ * from the installed `@kinvolk/headlamp-plugin` typedef even though the
+ * fork dispatches it at runtime.
+ */
+export const KNOWN_FEATURE_TYPES: ReadonlySet<string> = new Set([
+  'headlamp.delete-resource',
+  'headlamp.delete-resources',
+  'headlamp.create-resource',
+  'headlamp.edit-resource',
+  'headlamp.scale-resource',
+  'headlamp.restart-resource',
+  'headlamp.restart-resources',
+  'headlamp.rollback-resource',
+  'headlamp.logs',
+  'headlamp.terminal',
+  'headlamp.pod-attach',
+  'headlamp.plugin-loading-error',
+  'headlamp.details-view',
+  'headlamp.list-view',
+  'headlamp.object-events',
+  // PLUGINS_LOADED and ERROR_BOUNDARY are intentionally omitted:
+  // PLUGINS_LOADED routes to trackPluginsLoaded (not a feature event);
+  // ERROR_BOUNDARY is handled by the fork's existing trackEvent('exception',…)
+  // path.
+]);
+
+/**
+ * Sanitize an arbitrary feature-name string against KNOWN_FEATURE_TYPES.
+ * Returns the input verbatim if allowlisted, else `undefined` so the
+ * caller can decide whether to drop the event entirely.
+ */
+export function sanitizeFeatureType(type: string | undefined): string | undefined {
+  return type && KNOWN_FEATURE_TYPES.has(type) ? type : undefined;
+}
 
 export const KNOWN_PROPERTY_KEYS: ReadonlySet<string> = new Set([
   // session-start

--- a/plugins/aks-desktop/src/telemetry/schema.ts
+++ b/plugins/aks-desktop/src/telemetry/schema.ts
@@ -141,6 +141,24 @@ export const AZURE_REGIONS: ReadonlySet<string> = new Set([
   'mexicocentral',
 ]);
 
+/**
+ * Event names allowed to leave the renderer. The privacy initializer
+ * replaces the envelope `name` field with `'unknown'` for anything not in
+ * this set, so a caller that bypasses the typed helpers (e.g. by calling
+ * `window.appInsights.trackEvent` directly) cannot smuggle data through
+ * the event name itself.
+ */
+export const KNOWN_EVENT_NAMES: ReadonlySet<string> = new Set([
+  'headlamp.session-start',
+  'headlamp.cluster-shape',
+  'headlamp.feature',
+  'headlamp.exception',
+  'headlamp.plugins-loaded',
+  // ErrorBoundary in the fork still calls trackEvent('exception', ...);
+  // allowlist its bare name so the existing path keeps working.
+  'exception',
+]);
+
 export const KNOWN_PROPERTY_KEYS: ReadonlySet<string> = new Set([
   // session-start
   'installId',

--- a/plugins/aks-desktop/src/telemetry/setup.test.ts
+++ b/plugins/aks-desktop/src/telemetry/setup.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@microsoft/applicationinsights-web', () => {
+  const loadAppInsights = vi.fn();
+  const addTelemetryInitializer = vi.fn();
+  const trackEvent = vi.fn();
+  return {
+    ApplicationInsights: vi.fn().mockImplementation(() => ({
+      loadAppInsights,
+      addTelemetryInitializer,
+      trackEvent,
+    })),
+    __mock: { loadAppInsights, addTelemetryInitializer, trackEvent },
+  };
+});
+
+// Mock the headlamp-plugin export so we don't need a real store.
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  registerHeadlampEventCallback: vi.fn(),
+}));
+
+import * as ai from '@microsoft/applicationinsights-web';
+import { enableTelemetry } from './setup';
+
+const VALID_INSTALL_ID = '11111111-1111-4111-8111-111111111111';
+const sessionProps = {
+  installId: VALID_INSTALL_ID,
+  appVersion: '1.4.2',
+  headlampVersion: '0.27.0',
+  electronVersion: '30.0.0',
+  os: 'darwin' as const,
+  osMajor: '14',
+  arch: 'arm64' as const,
+  locale: 'en',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.appInsights = undefined;
+});
+
+afterEach(() => {
+  window.appInsights = undefined;
+});
+
+describe('enableTelemetry', () => {
+  it('no-ops when connection string is empty', () => {
+    const register = vi.fn();
+    enableTelemetry({
+      connectionString: '',
+      installId: VALID_INSTALL_ID,
+      sessionProps,
+      registerEventCallback: register,
+    });
+    expect(ai.ApplicationInsights).not.toHaveBeenCalled();
+    expect(window.appInsights).toBeUndefined();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when install ID is missing', () => {
+    const register = vi.fn();
+    enableTelemetry({
+      connectionString: 'InstrumentationKey=fake',
+      installId: undefined,
+      sessionProps,
+      registerEventCallback: register,
+    });
+    expect(ai.ApplicationInsights).not.toHaveBeenCalled();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('initializes SDK, attaches initializer, sets window.appInsights, fires session-start, registers callback', () => {
+    const register = vi.fn();
+    enableTelemetry({
+      connectionString: 'InstrumentationKey=fake',
+      installId: VALID_INSTALL_ID,
+      sessionProps,
+      registerEventCallback: register,
+    });
+    expect(ai.ApplicationInsights).toHaveBeenCalledTimes(1);
+    const mock = (ai as any).__mock;
+    expect(mock.addTelemetryInitializer).toHaveBeenCalledTimes(1);
+    expect(mock.loadAppInsights).toHaveBeenCalledTimes(1);
+    expect(window.appInsights).toBeDefined();
+    expect(mock.trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'headlamp.session-start' })
+    );
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it('the registered callback routes feature events through trackFeature with extracted kind', () => {
+    const register = vi.fn();
+    enableTelemetry({
+      connectionString: 'InstrumentationKey=fake',
+      installId: VALID_INSTALL_ID,
+      sessionProps,
+      registerEventCallback: register,
+    });
+    const callback = register.mock.calls[0][0];
+    const mock = (ai as any).__mock;
+    mock.trackEvent.mockClear();
+
+    callback({
+      type: 'headlamp.delete-resource',
+      data: { resource: { kind: 'Pod' }, status: 'confirmed' },
+    });
+
+    expect(mock.trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'headlamp.feature',
+        properties: expect.objectContaining({
+          feature: 'headlamp.delete-resource',
+          status: 'confirmed',
+          resourceKind: 'Pod',
+        }),
+      })
+    );
+  });
+
+  it('routes PLUGINS_LOADED to trackPluginsLoaded, not trackFeature', () => {
+    const register = vi.fn();
+    enableTelemetry({
+      connectionString: 'InstrumentationKey=fake',
+      installId: VALID_INSTALL_ID,
+      sessionProps,
+      registerEventCallback: register,
+    });
+    const callback = register.mock.calls[0][0];
+    const mock = (ai as any).__mock;
+    mock.trackEvent.mockClear();
+
+    callback({
+      type: 'headlamp.plugins-loaded',
+      data: {
+        plugins: [
+          { name: 'aks-desktop', version: '1.0', isEnabled: true },
+          { name: 'random-third-party', version: '0.1', isEnabled: true },
+          { name: 'disabled-plugin', version: '0.2', isEnabled: false },
+        ],
+      },
+    });
+
+    expect(mock.trackEvent).toHaveBeenCalledWith({
+      name: 'headlamp.plugins-loaded',
+      properties: {
+        totalCount: '3',
+        enabledCount: '2',
+        knownEnabledIds: 'aks-desktop',
+        thirdPartyCount: '1',
+      },
+    });
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/setup.ts
+++ b/plugins/aks-desktop/src/telemetry/setup.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { extractKindFromPayload } from './extractKind';
+import { makePrivacyInitializer } from './privacy';
+import { KNOWN_PLUGIN_IDS } from './schema';
+import {
+  type SessionStartProps,
+  trackFeature,
+  trackPluginsLoaded,
+  trackSessionStart,
+} from './track';
+
+export interface EnableTelemetryOptions {
+  /** App Insights connection string. Empty/missing → no-op. */
+  connectionString: string | undefined;
+  /** Per-install UUID. Undefined → no-op. We never ship without an ID. */
+  installId: string | undefined;
+  /** Properties for the initial `headlamp.session-start` event. */
+  sessionProps: SessionStartProps;
+  /**
+   * Injection point for tests: register the per-event callback. Defaults
+   * to the public plugin API `registerHeadlampEventCallback`. Tests can
+   * pass a spy.
+   */
+  registerEventCallback?: (cb: (event: { type: string; data?: unknown }) => void) => void;
+}
+
+/**
+ * Initialize App Insights and wire telemetry. Idempotent guards are not
+ * built in — callers should invoke once per session.
+ *
+ * No-ops when telemetry is disabled (missing connection string, missing
+ * install ID, or both). In that case, no SDK instance is created,
+ * `window.appInsights` is left untouched, and no envelopes can be sent.
+ */
+export function enableTelemetry(opts: EnableTelemetryOptions): void {
+  if (!opts.connectionString || !opts.installId) {
+    return;
+  }
+
+  const ai = new ApplicationInsights({
+    config: {
+      connectionString: opts.connectionString,
+      // Defense in depth: mirror PR #626's lockdown of auto-collection.
+      disableFetchTracking: true,
+      disableAjaxTracking: true,
+      disableExceptionTracking: true,
+      disableCookiesUsage: true,
+      isStorageUseDisabled: true,
+      enableAutoRouteTracking: false,
+    },
+  });
+
+  ai.addTelemetryInitializer(makePrivacyInitializer(opts.installId));
+  ai.loadAppInsights();
+  window.appInsights = ai;
+
+  // First event after init.
+  trackSessionStart(opts.sessionProps);
+
+  // Forward redux events as telemetry.
+  const register =
+    opts.registerEventCallback ??
+    (registerHeadlampEventCallback as unknown as (
+      cb: (event: { type: string; data?: unknown }) => void
+    ) => void);
+  register(event => {
+    try {
+      if (event.type === 'headlamp.plugins-loaded') {
+        const plugins =
+          (event.data as { plugins?: Array<{ name: string; isEnabled: boolean }> } | undefined)
+            ?.plugins ?? [];
+        const enabled = plugins.filter(p => p.isEnabled);
+        const knownEnabledIds = enabled.map(p => p.name).filter(n => KNOWN_PLUGIN_IDS.has(n));
+        const thirdPartyCount = enabled.filter(p => !KNOWN_PLUGIN_IDS.has(p.name)).length;
+        trackPluginsLoaded({
+          totalCount: plugins.length,
+          enabledCount: enabled.length,
+          knownEnabledIds,
+          thirdPartyCount,
+        });
+        return;
+      }
+      trackFeature({
+        feature: event.type,
+        status: (event.data as { status?: string } | undefined)?.status ?? 'unknown',
+        resourceKind: extractKindFromPayload(event),
+      });
+    } catch (e) {
+      // Never let telemetry break the app.
+      // eslint-disable-next-line no-console
+      console.error('Failed to forward event as telemetry', e);
+    }
+  });
+}

--- a/plugins/aks-desktop/src/telemetry/setup.ts
+++ b/plugins/aks-desktop/src/telemetry/setup.ts
@@ -2,6 +2,10 @@
 // Licensed under the Apache 2.0.
 
 import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
+import type {
+  HeadlampEvent,
+  HeadlampEventCallback,
+} from '@kinvolk/headlamp-plugin/lib/redux/headlampEventSlice';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import { extractKindFromPayload } from './extractKind';
 import { makePrivacyInitializer } from './privacy';
@@ -25,7 +29,7 @@ export interface EnableTelemetryOptions {
    * to the public plugin API `registerHeadlampEventCallback`. Tests can
    * pass a spy.
    */
-  registerEventCallback?: (cb: (event: { type: string; data?: unknown }) => void) => void;
+  registerEventCallback?: (cb: HeadlampEventCallback) => void;
 }
 
 /**
@@ -44,7 +48,8 @@ export function enableTelemetry(opts: EnableTelemetryOptions): void {
   const ai = new ApplicationInsights({
     config: {
       connectionString: opts.connectionString,
-      // Defense in depth: mirror PR #626's lockdown of auto-collection.
+      // Lock down auto-collection so nothing fires without going through
+      // the typed helpers.
       disableFetchTracking: true,
       disableAjaxTracking: true,
       disableExceptionTracking: true,
@@ -62,12 +67,8 @@ export function enableTelemetry(opts: EnableTelemetryOptions): void {
   trackSessionStart(opts.sessionProps);
 
   // Forward redux events as telemetry.
-  const register =
-    opts.registerEventCallback ??
-    (registerHeadlampEventCallback as unknown as (
-      cb: (event: { type: string; data?: unknown }) => void
-    ) => void);
-  register(event => {
+  const register = opts.registerEventCallback ?? registerHeadlampEventCallback;
+  register((event: HeadlampEvent) => {
     try {
       if (event.type === 'headlamp.plugins-loaded') {
         const plugins =
@@ -87,7 +88,7 @@ export function enableTelemetry(opts: EnableTelemetryOptions): void {
       trackFeature({
         feature: event.type,
         status: (event.data as { status?: string } | undefined)?.status ?? 'unknown',
-        resourceKind: extractKindFromPayload(event),
+        resourceKind: extractKindFromPayload({ type: event.type, data: event.data }),
       });
     } catch (e) {
       // Never let telemetry break the app.

--- a/plugins/aks-desktop/src/telemetry/track.test.ts
+++ b/plugins/aks-desktop/src/telemetry/track.test.ts
@@ -129,8 +129,9 @@ describe('trackPluginsLoaded', () => {
 
 describe('no-op behavior', () => {
   it('all helpers no-op when window.appInsights is undefined', () => {
-    // Use a fresh mock that we expect to NEVER be called.
-    const neverCalled = vi.fn();
+    // trackEventMock is installed by the file-level beforeEach. Unsetting
+    // window.appInsights here means emit() returns before calling it, so
+    // the mock should record zero calls.
     window.appInsights = undefined;
     trackSessionStart({
       installId: '11111111-1111-4111-8111-111111111111',
@@ -145,7 +146,7 @@ describe('no-op behavior', () => {
     trackFeature({ feature: 'headlamp.delete-resource', status: 'unknown' });
     trackException({ errorName: 'TypeError' });
     trackPluginsLoaded({ totalCount: 0, enabledCount: 0, knownEnabledIds: [], thirdPartyCount: 0 });
-    expect(neverCalled).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
   });
 
   it('trackFeature drops events whose feature is not in KNOWN_FEATURE_TYPES', () => {

--- a/plugins/aks-desktop/src/telemetry/track.test.ts
+++ b/plugins/aks-desktop/src/telemetry/track.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { trackException, trackFeature, trackPluginsLoaded, trackSessionStart } from './track';
+
+let trackEventMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  trackEventMock = vi.fn();
+  window.appInsights = { trackEvent: trackEventMock } as unknown as ApplicationInsights;
+});
+
+afterEach(() => {
+  window.appInsights = undefined;
+});
+
+describe('trackSessionStart', () => {
+  it('builds the session-start envelope with sanitized fields', () => {
+    trackSessionStart({
+      installId: '11111111-1111-4111-8111-111111111111',
+      appVersion: '1.4.2',
+      headlampVersion: '0.27.0',
+      electronVersion: '30.0.0',
+      os: 'darwin',
+      osMajor: '14.5.0',
+      arch: 'arm64',
+      locale: 'en-US',
+    });
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: 'headlamp.session-start',
+      properties: {
+        installId: '11111111-1111-4111-8111-111111111111',
+        appVersion: '1.4.2',
+        headlampVersion: '0.27.0',
+        electronVersion: '30.0.0',
+        os: 'darwin',
+        osMajor: '14',
+        arch: 'arm64',
+        locale: 'en',
+      },
+    });
+  });
+
+  it('drops extra properties passed via as-any cast', () => {
+    trackSessionStart({
+      installId: '11111111-1111-4111-8111-111111111111',
+      appVersion: '1.4.2',
+      headlampVersion: '0.27.0',
+      electronVersion: '30.0.0',
+      os: 'linux',
+      osMajor: '6',
+      arch: 'x64',
+      locale: 'ja',
+      attackerSneakedThis: 'secret value',
+    } as any);
+    const props = trackEventMock.mock.calls[0][0].properties;
+    expect(props).not.toHaveProperty('attackerSneakedThis');
+  });
+});
+
+describe('trackFeature', () => {
+  it('builds the feature envelope with sanitized kind', () => {
+    trackFeature({
+      feature: 'headlamp.delete-resource',
+      status: 'confirmed',
+      resourceKind: 'Pod',
+    });
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: 'headlamp.feature',
+      properties: {
+        feature: 'headlamp.delete-resource',
+        status: 'confirmed',
+        resourceKind: 'Pod',
+      },
+    });
+  });
+
+  it('omits resourceKind when undefined', () => {
+    trackFeature({ feature: 'headlamp.create-resource', status: 'confirmed' });
+    const props = trackEventMock.mock.calls[0][0].properties;
+    expect(props).not.toHaveProperty('resourceKind');
+  });
+
+  it('re-sanitizes resourceKind even if caller bypassed extractKind', () => {
+    trackFeature({
+      feature: 'headlamp.delete-resource',
+      status: 'confirmed',
+      resourceKind: 'MyCRD' as any,
+    });
+    expect(trackEventMock.mock.calls[0][0].properties.resourceKind).toBe('CustomResource');
+  });
+});
+
+describe('trackException', () => {
+  it('builds the exception envelope with sanitized errorName', () => {
+    trackException({ errorName: 'TypeError' });
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: 'headlamp.exception',
+      properties: { errorName: 'TypeError' },
+    });
+  });
+  it('collapses unknown errorName to Other', () => {
+    trackException({ errorName: 'WeirdCustomError' });
+    expect(trackEventMock.mock.calls[0][0].properties.errorName).toBe('Other');
+  });
+});
+
+describe('trackPluginsLoaded', () => {
+  it('builds the plugins-loaded envelope, keeping only first-party IDs', () => {
+    trackPluginsLoaded({
+      totalCount: 3,
+      enabledCount: 2,
+      knownEnabledIds: ['aks-desktop'],
+      thirdPartyCount: 1,
+    });
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: 'headlamp.plugins-loaded',
+      properties: {
+        totalCount: '3',
+        enabledCount: '2',
+        knownEnabledIds: 'aks-desktop',
+        thirdPartyCount: '1',
+      },
+    });
+  });
+});
+
+describe('no-op behavior', () => {
+  it('all helpers no-op when window.appInsights is undefined', () => {
+    window.appInsights = undefined;
+    trackSessionStart({
+      installId: '11111111-1111-4111-8111-111111111111',
+      appVersion: '1.4.2',
+      headlampVersion: '0.27.0',
+      electronVersion: '30.0.0',
+      os: 'darwin',
+      osMajor: '14',
+      arch: 'arm64',
+      locale: 'en',
+    });
+    trackFeature({ feature: 'x', status: 'unknown' });
+    trackException({ errorName: 'TypeError' });
+    trackPluginsLoaded({ totalCount: 0, enabledCount: 0, knownEnabledIds: [], thirdPartyCount: 0 });
+    // No throw, no crash. Mock not installed; no assertion needed beyond
+    // "we didn't crash."
+    expect(true).toBe(true);
+  });
+});

--- a/plugins/aks-desktop/src/telemetry/track.test.ts
+++ b/plugins/aks-desktop/src/telemetry/track.test.ts
@@ -129,6 +129,8 @@ describe('trackPluginsLoaded', () => {
 
 describe('no-op behavior', () => {
   it('all helpers no-op when window.appInsights is undefined', () => {
+    // Use a fresh mock that we expect to NEVER be called.
+    const neverCalled = vi.fn();
     window.appInsights = undefined;
     trackSessionStart({
       installId: '11111111-1111-4111-8111-111111111111',
@@ -140,11 +142,14 @@ describe('no-op behavior', () => {
       arch: 'arm64',
       locale: 'en',
     });
-    trackFeature({ feature: 'x', status: 'unknown' });
+    trackFeature({ feature: 'headlamp.delete-resource', status: 'unknown' });
     trackException({ errorName: 'TypeError' });
     trackPluginsLoaded({ totalCount: 0, enabledCount: 0, knownEnabledIds: [], thirdPartyCount: 0 });
-    // No throw, no crash. Mock not installed; no assertion needed beyond
-    // "we didn't crash."
-    expect(true).toBe(true);
+    expect(neverCalled).not.toHaveBeenCalled();
+  });
+
+  it('trackFeature drops events whose feature is not in KNOWN_FEATURE_TYPES', () => {
+    trackFeature({ feature: 'not.a.real.event', status: 'confirmed' });
+    expect(trackEventMock).not.toHaveBeenCalled();
   });
 });

--- a/plugins/aks-desktop/src/telemetry/track.ts
+++ b/plugins/aks-desktop/src/telemetry/track.ts
@@ -2,12 +2,16 @@
 // Licensed under the Apache 2.0.
 
 import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import type { AppInfo } from './appInfo';
 import {
   KNOWN_PLUGIN_IDS,
   KNOWN_PROPERTY_KEYS,
   localeLanguage,
+  type NamespaceCountBucket,
+  type NodeCountBucket,
   osMajor as sanitizeOsMajor,
   sanitizeErrorName,
+  sanitizeFeatureType,
   sanitizeKind,
 } from './schema';
 
@@ -40,14 +44,10 @@ function emit(name: string, properties: Record<string, string | undefined>): voi
   }
 }
 
-export interface SessionStartProps {
+export interface SessionStartProps extends AppInfo {
   installId: string;
   appVersion: string;
   headlampVersion: string;
-  electronVersion: string;
-  os: 'win32' | 'darwin' | 'linux';
-  osMajor: string;
-  arch: 'x64' | 'arm64' | 'ia32';
   locale: string;
 }
 
@@ -67,16 +67,13 @@ export function trackSessionStart(p: SessionStartProps): void {
 export interface ClusterShapeProps {
   provider: 'AKS';
   kubernetesMinor: string;
-  nodeCountBucket: '1-5' | '6-20' | '21-100' | '100+';
-  namespaceCountBucket: '1-10' | '11-50' | '51-200' | '200+';
+  nodeCountBucket: NodeCountBucket;
+  namespaceCountBucket: NamespaceCountBucket;
   region: string;
   aksTier: 'Free' | 'Standard' | 'Premium' | 'Unknown';
 }
 
 export function trackClusterShape(p: ClusterShapeProps): void {
-  // Region/kubernetesMinor were sanitized at the call site (the only place
-  // that has the raw values). We still pass them through KNOWN_PROPERTY_KEYS
-  // filter via emit().
   emit('headlamp.cluster-shape', {
     provider: p.provider,
     kubernetesMinor: p.kubernetesMinor,
@@ -94,8 +91,14 @@ export interface FeatureProps {
 }
 
 export function trackFeature(p: FeatureProps): void {
+  // Drop events whose `feature` string isn't in our allowlist. Prevents a
+  // future upstream change that encodes data in an event type (e.g.
+  // `cluster:my-prod`) from leaking that string through the `feature`
+  // property even if the envelope name is rewritten to `unknown`.
+  const safeFeature = sanitizeFeatureType(p.feature);
+  if (safeFeature === undefined) return;
   emit('headlamp.feature', {
-    feature: p.feature,
+    feature: safeFeature,
     status: p.status,
     resourceKind: p.resourceKind === undefined ? undefined : sanitizeKind(p.resourceKind),
   });
@@ -119,8 +122,6 @@ export interface PluginsLoadedProps {
 }
 
 export function trackPluginsLoaded(p: PluginsLoadedProps): void {
-  // Filter knownEnabledIds against the allowlist defensively, even though
-  // the caller is supposed to do it already.
   const knownOnly = p.knownEnabledIds.filter(id => KNOWN_PLUGIN_IDS.has(id));
   emit('headlamp.plugins-loaded', {
     totalCount: String(p.totalCount),

--- a/plugins/aks-desktop/src/telemetry/track.ts
+++ b/plugins/aks-desktop/src/telemetry/track.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import {
+  KNOWN_PLUGIN_IDS,
+  KNOWN_PROPERTY_KEYS,
+  localeLanguage,
+  osMajor as sanitizeOsMajor,
+  sanitizeErrorName,
+  sanitizeKind,
+} from './schema';
+
+declare global {
+  interface Window {
+    appInsights: ApplicationInsights | undefined;
+  }
+}
+
+/**
+ * Forward an event to App Insights, dropping any property whose key isn't
+ * in `KNOWN_PROPERTY_KEYS` (defense in depth — the call sites should
+ * already be schema-conformant; this is the last line before send).
+ */
+function emit(name: string, properties: Record<string, string | undefined>): void {
+  const ai = window.appInsights;
+  if (!ai) return;
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined) continue;
+    if (!KNOWN_PROPERTY_KEYS.has(key)) continue;
+    filtered[key] = value;
+  }
+  try {
+    ai.trackEvent({ name, properties: filtered });
+  } catch (e) {
+    // Never let telemetry failures break the app.
+    // eslint-disable-next-line no-console
+    console.error('Failed to track event', e);
+  }
+}
+
+export interface SessionStartProps {
+  installId: string;
+  appVersion: string;
+  headlampVersion: string;
+  electronVersion: string;
+  os: 'win32' | 'darwin' | 'linux';
+  osMajor: string;
+  arch: 'x64' | 'arm64' | 'ia32';
+  locale: string;
+}
+
+export function trackSessionStart(p: SessionStartProps): void {
+  emit('headlamp.session-start', {
+    installId: p.installId,
+    appVersion: p.appVersion,
+    headlampVersion: p.headlampVersion,
+    electronVersion: p.electronVersion,
+    os: p.os,
+    osMajor: sanitizeOsMajor(p.osMajor),
+    arch: p.arch,
+    locale: localeLanguage(p.locale),
+  });
+}
+
+export interface ClusterShapeProps {
+  provider: 'AKS';
+  kubernetesMinor: string;
+  nodeCountBucket: '1-5' | '6-20' | '21-100' | '100+';
+  namespaceCountBucket: '1-10' | '11-50' | '51-200' | '200+';
+  region: string;
+  aksTier: 'Free' | 'Standard' | 'Premium' | 'Unknown';
+}
+
+export function trackClusterShape(p: ClusterShapeProps): void {
+  // Region/kubernetesMinor were sanitized at the call site (the only place
+  // that has the raw values). We still pass them through KNOWN_PROPERTY_KEYS
+  // filter via emit().
+  emit('headlamp.cluster-shape', {
+    provider: p.provider,
+    kubernetesMinor: p.kubernetesMinor,
+    nodeCountBucket: p.nodeCountBucket,
+    namespaceCountBucket: p.namespaceCountBucket,
+    region: p.region,
+    aksTier: p.aksTier,
+  });
+}
+
+export interface FeatureProps {
+  feature: string;
+  status: string;
+  resourceKind?: string;
+}
+
+export function trackFeature(p: FeatureProps): void {
+  emit('headlamp.feature', {
+    feature: p.feature,
+    status: p.status,
+    resourceKind: p.resourceKind === undefined ? undefined : sanitizeKind(p.resourceKind),
+  });
+}
+
+export interface ExceptionProps {
+  errorName: string;
+}
+
+export function trackException(p: ExceptionProps): void {
+  emit('headlamp.exception', {
+    errorName: sanitizeErrorName(p.errorName),
+  });
+}
+
+export interface PluginsLoadedProps {
+  totalCount: number;
+  enabledCount: number;
+  knownEnabledIds: string[];
+  thirdPartyCount: number;
+}
+
+export function trackPluginsLoaded(p: PluginsLoadedProps): void {
+  // Filter knownEnabledIds against the allowlist defensively, even though
+  // the caller is supposed to do it already.
+  const knownOnly = p.knownEnabledIds.filter(id => KNOWN_PLUGIN_IDS.has(id));
+  emit('headlamp.plugins-loaded', {
+    totalCount: String(p.totalCount),
+    enabledCount: String(p.enabledCount),
+    knownEnabledIds: knownOnly.join(','),
+    thirdPartyCount: String(p.thirdPartyCount),
+  });
+}

--- a/plugins/aks-desktop/src/types/ClusterCapabilities.ts
+++ b/plugins/aks-desktop/src/types/ClusterCapabilities.ts
@@ -20,4 +20,10 @@ export interface ClusterCapabilities {
   kedaEnabled: boolean | null;
   /** Whether VPA addon is enabled */
   vpaEnabled: boolean | null;
+  /** Azure region (e.g. "eastus") */
+  location?: string | null;
+  /** AKS cluster tier (e.g. "Free", "Standard", "Premium") */
+  tier?: string | null;
+  /** Kubernetes version (e.g. "1.29.4") */
+  kubernetesVersion?: string | null;
 }

--- a/plugins/aks-desktop/src/utils/azure/az-clusters.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-clusters.ts
@@ -185,7 +185,7 @@ export async function getClusterCapabilities(options: {
     '--name',
     clusterName,
     '--query',
-    '{sku:sku.name,aadProfile:aadProfile,azureRbacEnabled:aadProfile.enableAzureRbac,networkPolicy:networkProfile.networkPolicy,networkPlugin:networkProfile.networkPlugin,prometheusEnabled:azureMonitorProfile.metrics.enabled,containerInsightsEnabled:addonProfiles.omsagent.enabled,kedaEnabled:workloadAutoScalerProfile.keda.enabled,vpaEnabled:workloadAutoScalerProfile.verticalPodAutoscaler.enabled}',
+    '{sku:sku.name,tier:sku.tier,location:location,kubernetesVersion:kubernetesVersion,aadProfile:aadProfile,azureRbacEnabled:aadProfile.enableAzureRbac,networkPolicy:networkProfile.networkPolicy,networkPlugin:networkProfile.networkPlugin,prometheusEnabled:azureMonitorProfile.metrics.enabled,containerInsightsEnabled:addonProfiles.omsagent.enabled,kedaEnabled:workloadAutoScalerProfile.keda.enabled,vpaEnabled:workloadAutoScalerProfile.verticalPodAutoscaler.enabled}',
     '--output',
     'json',
   ];
@@ -213,6 +213,9 @@ export async function getClusterCapabilities(options: {
       containerInsightsEnabled: result.containerInsightsEnabled ?? null,
       kedaEnabled: result.kedaEnabled ?? null,
       vpaEnabled: result.vpaEnabled ?? null,
+      location: (result.location as string) ?? null,
+      tier: (result.tier as string) ?? null,
+      kubernetesVersion: (result.kubernetesVersion as string) ?? null,
     };
   } catch (error) {
     console.error('Failed to parse cluster capabilities response:', error);

--- a/plugins/aks-desktop/src/utils/test/getClusterCapabilities.test.ts
+++ b/plugins/aks-desktop/src/utils/test/getClusterCapabilities.test.ts
@@ -99,6 +99,9 @@ describe('getClusterCapabilities', () => {
       containerInsightsEnabled: true,
       kedaEnabled: true,
       vpaEnabled: true,
+      location: null,
+      tier: null,
+      kubernetesVersion: null,
     });
   });
 


### PR DESCRIPTION
## Summary

Restores anonymous usage telemetry to AKS Desktop: feature usage, install/version counts, and React error-class counts. PR #626 hardened the App Insights pipeline down to event-name-only emissions; this PR reintroduces useful signal while keeping a strict no-PII contract — no cluster/namespace/resource names, no error messages or stack traces, no Azure subscription/tenant/account IDs, no IPs.

The plugin now owns the App Insights SDK end-to-end. App Insights init, the send-pipeline privacy initializer, and the redux event listener's hardcoded `trackEvent` call all move out of the headlamp fork and into `plugins/aks-desktop/src/telemetry/`. The fork delta is three `upstreamable:` commits that can be cherry-picked to upstream Headlamp.

### Five events

| Event | Properties |
|---|---|
| `headlamp.session-start` | installId, app/headlamp/electron versions, os, osMajor, arch, locale |
| `headlamp.cluster-shape` | k8s minor, bucketed node/namespace counts, Azure region, AKS tier — once per AKS cluster connect, only when full metadata is loaded |
| `headlamp.feature` | feature name (allowlisted enum), status, sanitized resource kind |
| `headlamp.exception` | sanitized error class name (e.g. `TypeError`, `KubeApiError`, or `Other`) |
| `headlamp.plugins-loaded` | plugin counts + first-party plugin IDs |

### Privacy contract — defense in depth

1. **Typed helpers** (`track.ts`) accept only strongly-typed prop objects; callers can't pass arbitrary data.
2. **Runtime sanitizers** (`schema.ts`) re-validate every value against fixed vocabularies — built-in k8s kinds, known error names, Azure regions, first-party plugin IDs.
3. **Send-pipeline initializer** (`privacy.ts`) strips identity tags (auth/account/session/IP), clears URL fields, rewrites the custom event name to `'unknown'` if not allowlisted, and drops any property key not on the schema.

### Per-install UUID

Generated on first launch by the Electron main process, persisted as a plain JSON file in `userData/installId.json` (mode `0600`), exposed to the renderer via a new `get-install-id` IPC on `window.desktopApi`. The privacy initializer keeps `ai.user.id` only when it matches the install-UUID regex. No MAC / hostname / account-id derivation.

### Opt-out

Toggle in plugin settings (default **on**), persisted via `ConfigStore` in localStorage, takes effect on next launch.

### Connection string

Defaults to the production App Insights instance (same string previously hardcoded in `headlamp/frontend/make-env.js`, which this PR removes). Set `REACT_APP_APPINSIGHTS_CONNECTION_STRING` before the plugin build to override (e.g. to a dev instance).

### Fork delta (cherry-pickable upstream)

Three `upstreamable:` commits remove fork-specific App Insights wiring so the plugin can own it cleanly:

- Remove hardcoded `trackEvent` from the listener middleware in `headlampEventSlice.ts`
- Remove `analyticsSetup.ts` / `analyticsPrivacy.ts` and their importer
- Drop the hardcoded connection string from `make-env.js`

Submodule branch: https://github.com/gambtho/aks-desktop/tree/aksd/telemetry-install-id

## Test plan

- [x] `npm run tsc` / `npm run lint` / `npm run format -- --check` clean (plugin + fork frontend)
- [x] 94 new telemetry tests pass (schema, extractKind, track, privacy, setup, clusterShape, appInfo, installId, plus Electron-side install-id IPC handler)
- [ ] **Manual smoke** with devtools Network → filter `track`:
  - Exactly one `headlamp.session-start` at startup, installId stamped into `ai.user.id`
  - Exactly one `headlamp.cluster-shape` per AKS cluster connect (zero for non-AKS)
  - `headlamp.feature` events on resource actions with **no** resource names or namespaces in any field
  - `headlamp.exception` on a triggered React error with `errorName` only
  - No `RemoteDependencyData`, no `PageView`
  - No `ai.user.authUserId` / `accountId` / `session.id` / `location.ip`
- [ ] Toggle telemetry off in plugin settings → restart → zero envelopes