### PR TITLE
insights-plugin: bump to v0.2.8

### DIFF
--- a/plugins/insights-plugin/package-lock.json
+++ b/plugins/insights-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insights-plugin",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insights-plugin",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.13.1"
       }

--- a/plugins/insights-plugin/package.json
+++ b/plugins/insights-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insights-plugin",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Insights plugin for eBPF-based Observability (based on Inspektor Gadget) (Preview)",
   "scripts": {
     "build": "bash scripts/download-artifacts.sh",


### PR DESCRIPTION
v0.2.8 deploys Inspektor Gadget with hostPid set in order to get symbolization.
