### PR TITLE
Add tenant picker to AKS cluster registration

### DIFF
--- a/Localize/locales/en/plugin-translation.json
+++ b/Localize/locales/en/plugin-translation.json
@@ -661,6 +661,8 @@
   "_Select an Azure Container Registry for building and pushing container images, or create a new one..comment": "{Locked=\"Azure\"}",
   "Select an Azure subscription": "Select an Azure subscription",
   "_Select an Azure subscription.comment": "{Locked=\"Azure\"}",
+  "Select an Azure tenant": "Select an Azure tenant",
+  "_Select an Azure tenant.comment": "{Locked=\"Azure\"}",
   "Select an option": "Select an option",
   "Select Deployment": "Select Deployment",
   "Select managed identity": "Select managed identity",

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialog.tsx
@@ -8,7 +8,7 @@ import { useAzureAuth } from '../../hooks/useAzureAuth';
 import type { ClusterCapabilities } from '../../types/ClusterCapabilities';
 import { getAKSClusters, getSubscriptions, registerAKSCluster } from '../../utils/azure/aks';
 import { getClusterCapabilities } from '../../utils/azure/az-clusters';
-import type { AKSCluster, Subscription } from './RegisterAKSClusterDialogPure';
+import type { AKSCluster, Subscription, Tenant } from './RegisterAKSClusterDialogPure';
 import RegisterAKSClusterDialogPure from './RegisterAKSClusterDialogPure';
 
 interface RegisterAKSClusterDialogProps {
@@ -32,6 +32,8 @@ export default function RegisterAKSClusterDialog({
   const [success, setSuccess] = useState('');
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [selectedSubscription, setSelectedSubscription] = useState<Subscription | null>(null);
+  const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null);
+  const [tenantInputValue, setTenantInputValue] = useState('');
   const [clusters, setClusters] = useState<AKSCluster[]>([]);
   const [selectedCluster, setSelectedCluster] = useState<AKSCluster | null>(null);
   const [subscriptionInputValue, setSubscriptionInputValue] = useState('');
@@ -51,6 +53,18 @@ export default function RegisterAKSClusterDialog({
         const bi = b.name.toLowerCase().indexOf(query);
         return ai !== bi ? ai - bi : a.name.localeCompare(b.name);
       });
+  }
+
+  /** Extract unique, sorted list of tenants that own the available subscriptions. */
+  function extractTenants(subs: Subscription[]): Tenant[] {
+    const byId = new Map<string, Tenant>();
+    for (const sub of subs) {
+      if (sub.tenantId && !byId.has(sub.tenantId)) {
+        byId.set(sub.tenantId, { id: sub.tenantId, name: sub.tenantName || sub.tenantId });
+      }
+    }
+    const uniqueTenants = Array.from(byId.values());
+    return uniqueTenants.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   const resetClusterState = () => {
@@ -94,11 +108,19 @@ export default function RegisterAKSClusterDialog({
         return;
       }
 
-      setSubscriptions(result.subscriptions || []);
+      const subs = result.subscriptions || [];
+      setSubscriptions(subs);
+
+      // Auto-select tenant when all subscriptions belong to the same tenant.
+      const uniqueTenants = extractTenants(subs);
+      if (uniqueTenants.length === 1) {
+        setSelectedTenant(uniqueTenants[0]);
+        setTenantInputValue(uniqueTenants[0].name);
+      }
 
       // Auto-select if only one subscription
-      if (result.subscriptions && result.subscriptions.length === 1) {
-        const sub = result.subscriptions[0];
+      if (subs.length === 1) {
+        const sub = subs[0];
         setSelectedSubscription(sub);
         setSubscriptionInputValue(`${sub.name}${sub.state !== 'Enabled' ? ` (${sub.state})` : ''}`);
       }
@@ -134,15 +156,43 @@ export default function RegisterAKSClusterDialog({
     }
   };
 
+  const tenants = React.useMemo(() => extractTenants(subscriptions), [subscriptions]);
+
+  const tenantScopedSubscriptions = React.useMemo(() => {
+    return selectedTenant
+      ? subscriptions.filter(sub => sub.tenantId === selectedTenant.id)
+      : subscriptions;
+  }, [subscriptions, selectedTenant]);
+
   const filteredSubscriptions = React.useMemo(() => {
     return selectedSubscription
-      ? subscriptions
-      : rankNameMatches(subscriptions, subscriptionInputValue);
-  }, [subscriptions, subscriptionInputValue, selectedSubscription]);
+      ? tenantScopedSubscriptions
+      : rankNameMatches(tenantScopedSubscriptions, subscriptionInputValue);
+  }, [tenantScopedSubscriptions, subscriptionInputValue, selectedSubscription]);
 
   const filteredClusters = React.useMemo(() => {
     return rankNameMatches(clusters, clusterInputValue);
   }, [clusters, clusterInputValue]);
+
+  const handleTenantChange = (_event: React.SyntheticEvent, value: Tenant | null) => {
+    setSelectedTenant(value);
+    setTenantInputValue(value ? value.name : '');
+    setSelectedSubscription(null);
+    setSubscriptionInputValue('');
+    resetClusterState();
+  };
+
+  const handleTenantInputChange = (_event: React.SyntheticEvent, value: string, reason: string) => {
+    if (reason === 'input' || reason === 'clear') {
+      setTenantInputValue(value);
+      if (reason === 'clear') {
+        setSelectedTenant(null);
+        setSelectedSubscription(null);
+        setSubscriptionInputValue('');
+        resetClusterState();
+      }
+    }
+  };
 
   const handleSubscriptionChange = (event: React.SyntheticEvent, value: Subscription | null) => {
     setSelectedSubscription(value);
@@ -288,6 +338,9 @@ export default function RegisterAKSClusterDialog({
       subscriptions={filteredSubscriptions}
       selectedSubscription={selectedSubscription}
       subscriptionInputValue={subscriptionInputValue}
+      tenants={tenants}
+      selectedTenant={selectedTenant}
+      tenantInputValue={tenantInputValue}
       clusters={clusters}
       filteredClusters={filteredClusters}
       selectedCluster={selectedCluster}
@@ -296,6 +349,8 @@ export default function RegisterAKSClusterDialog({
       onClose={handleClose}
       onSubscriptionChange={handleSubscriptionChange}
       onSubscriptionInputChange={handleSubscriptionInputChange}
+      onTenantChange={handleTenantChange}
+      onTenantInputChange={handleTenantInputChange}
       onClusterChange={handleClusterChange}
       onClusterInputChange={handleClusterInputChange}
       onRegister={handleRegister}

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
@@ -15,6 +15,11 @@ const SAMPLE_SUBSCRIPTIONS = [
   { id: 'sub-3', name: 'Legacy Subscription', state: 'Disabled', tenantId: 'tenant-2' },
 ];
 
+const SAMPLE_TENANTS = [
+  { id: 'tenant-1', name: 'Tenant 1' },
+  { id: 'tenant-2', name: 'Tenant 2' },
+];
+
 const SAMPLE_CLUSTERS = [
   {
     name: 'prod-aks-cluster',
@@ -42,9 +47,12 @@ const baseArgs: RegisterAKSClusterDialogPureProps = {
   capabilitiesLoading: false,
   error: '',
   success: '',
-  subscriptions: SAMPLE_SUBSCRIPTIONS,
+  subscriptions: SAMPLE_SUBSCRIPTIONS.filter(s => s.tenantId === SAMPLE_TENANTS[0].id),
   selectedSubscription: null,
   subscriptionInputValue: '',
+  tenants: SAMPLE_TENANTS,
+  selectedTenant: SAMPLE_TENANTS[0],
+  tenantInputValue: SAMPLE_TENANTS[0].name,
   clusters: [],
   filteredClusters: [],
   clusterInputValue: '',
@@ -53,6 +61,8 @@ const baseArgs: RegisterAKSClusterDialogPureProps = {
   onClose: noOp,
   onSubscriptionChange: noOp as any,
   onSubscriptionInputChange: noOp as any,
+  onTenantChange: noOp as any,
+  onTenantInputChange: noOp as any,
   onClusterChange: noOp as any,
   onClusterInputChange: noOp as any,
   onRegister: noOp,
@@ -240,4 +250,14 @@ NoNetworkPolicy.args = {
     vpaEnabled: true,
     networkPolicy: 'none',
   },
+};
+
+/** Multiple tenants, none selected — Subscription field stays disabled. */
+export const TenantNotSelected = Template.bind({});
+TenantNotSelected.args = {
+  ...baseArgs,
+  selectedTenant: null,
+  tenantInputValue: '',
+  selectedSubscription: null,
+  subscriptionInputValue: '',
 };

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
@@ -25,6 +25,12 @@ export interface Subscription {
   name: string;
   state: string;
   tenantId: string;
+  tenantName?: string;
+}
+
+export interface Tenant {
+  id: string;
+  name: string;
 }
 
 export interface AKSCluster {
@@ -48,6 +54,9 @@ export interface RegisterAKSClusterDialogPureProps {
   subscriptions: Subscription[];
   selectedSubscription: Subscription | null;
   subscriptionInputValue: string;
+  tenants: Tenant[];
+  selectedTenant: Tenant | null;
+  tenantInputValue: string;
   clusters: AKSCluster[];
   filteredClusters: AKSCluster[];
   clusterInputValue: string;
@@ -56,6 +65,8 @@ export interface RegisterAKSClusterDialogPureProps {
   onClose: () => void;
   onSubscriptionChange: (event: React.SyntheticEvent, value: Subscription | null) => void;
   onSubscriptionInputChange: (event: React.SyntheticEvent, value: string, reason: string) => void;
+  onTenantChange: (event: React.SyntheticEvent, value: Tenant | null) => void;
+  onTenantInputChange: (event: React.SyntheticEvent, value: string, reason: string) => void;
   onClusterChange: (event: React.SyntheticEvent, value: AKSCluster | null) => void;
   onClusterInputChange: (event: React.SyntheticEvent, value: string, reason: string) => void;
   onRegister: () => void;
@@ -78,6 +89,9 @@ export default function RegisterAKSClusterDialogPure({
   subscriptions,
   selectedSubscription,
   subscriptionInputValue,
+  tenants,
+  selectedTenant,
+  tenantInputValue,
   clusters,
   filteredClusters,
   selectedCluster,
@@ -86,6 +100,8 @@ export default function RegisterAKSClusterDialogPure({
   onClose,
   onSubscriptionChange,
   onSubscriptionInputChange,
+  onTenantChange,
+  onTenantInputChange,
   onClusterChange,
   onClusterInputChange,
   onRegister,
@@ -196,6 +212,36 @@ export default function RegisterAKSClusterDialogPure({
             <>
               <Autocomplete
                 fullWidth
+                options={tenants}
+                value={selectedTenant}
+                onChange={onTenantChange}
+                inputValue={tenantInputValue}
+                onInputChange={onTenantInputChange}
+                getOptionKey={option => option.id}
+                getOptionLabel={option => option.name}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                disabled={loadingSubscriptions || tenants.length <= 1}
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    label={t('Tenant')}
+                    placeholder={t('Select an Azure tenant')}
+                  />
+                )}
+                renderOption={(props, option) => (
+                  <li {...props} key={option.id}>
+                    <Box>
+                      <Typography variant="body1">{option.name}</Typography>
+                      <Typography variant="caption" color="textSecondary">
+                        {option.id}
+                      </Typography>
+                    </Box>
+                  </li>
+                )}
+              />
+
+              <Autocomplete
+                fullWidth
                 options={subscriptions}
                 value={selectedSubscription}
                 onChange={onSubscriptionChange}
@@ -207,7 +253,7 @@ export default function RegisterAKSClusterDialogPure({
                   `${option.name}${option.state !== 'Enabled' ? ` (${option.state})` : ''}`
                 }
                 isOptionEqualToValue={(option, value) => option.id === value.id}
-                disabled={loadingSubscriptions}
+                disabled={loadingSubscriptions || (tenants.length > 1 && !selectedTenant)}
                 loading={loadingSubscriptions}
                 renderInput={params => (
                   <TextField

--- a/plugins/aks-desktop/src/utils/azure/aks.ts
+++ b/plugins/aks-desktop/src/utils/azure/aks.ts
@@ -6,6 +6,7 @@ export interface Subscription {
   name: string;
   state: string;
   tenantId: string;
+  tenantName: string;
   isDefault: boolean;
 }
 
@@ -38,6 +39,7 @@ export async function getSubscriptions(): Promise<{
         name: sub.name,
         state: sub.status || 'Unknown',
         tenantId: sub.tenant,
+        tenantName: sub.tenantName || sub.tenant,
         isDefault: false, // We don't have this info from the existing function
       })),
     };


### PR DESCRIPTION
## Description

Implements #21 . This PR adds a tenant first picker to the Register AKS Cluster dialog. Users can now select a tenant, and the Subscription picker is scoped to subscriptions owned by that tenant. 

(Tenant data was already returned from subscription fetch, so the new tenant scoping here doesn't incur any additional `az` calls)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Related Issues

Closes #21 
- https://github.com/Azure/aks-desktop/issues/21

## Changes Made

- `RegisterAKSClusterDialog.tsx`: Added `extractTenants` to produce sorted & deduplicated list, which is then used for subscription scoping and input changes.
- `RegisterAKSClusterDialogPure.tsx` : Added new tenant properties and `Autocomplete` component for tenant selection
- `RegisterAKSClusterDialogPure.stories.tsx` - Added sample tenants and a no-tenant-selected scenario. 
- `utils/azure/aks.ts`: Added tenant name properties.
- New Tenant selector behavior: Users who's subscriptions all reside in one tenant have the single tenant auto-selected, matching original flow. Tenant changes reset cluster & subscription state.

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

### Test Cases

Describe the test cases that were run:

1. Register a cluster with AKS.
2. Observe new Tenant selector dropdown
3. Observe if tenant is auto selected (in case of 1 tenant) or dropdown is interactable.
4. If interactable, select desired tenant. 
5. Complete flow with subscription and cluster selection
6. Observe if cluster registration completes fine.