### PR TITLE
aksd: Couple of telemetry fixes

### DIFF
--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -414,8 +414,16 @@ if (Headlamp.isRunningAsApp()) {
   });
 }
 
-registerPluginSettings('aks-desktop', PreviewFeaturesSettings, false);
-registerPluginSettings('aks-desktop-telemetry', TelemetrySettings, false);
+registerPluginSettings(
+  'aks-desktop',
+  () => (
+    <>
+      <PreviewFeaturesSettings />
+      <TelemetrySettings />
+    </>
+  ),
+  false
+);
 
 registerProjectOverviewSection({
   id: 'cluster-capabilities',

--- a/plugins/aks-desktop/src/telemetry/setup.ts
+++ b/plugins/aks-desktop/src/telemetry/setup.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
 import {
-  type HeadlampEvent,
-  HeadlampEventType,
-} from '@kinvolk/headlamp-plugin/lib/redux/headlampEventSlice';
+  DefaultHeadlampEvents as HeadlampEventType,
+  registerHeadlampEventCallback,
+} from '@kinvolk/headlamp-plugin/lib';
+// @ts-ignore
+import { type HeadlampEvent } from '@kinvolk/headlamp-plugin/lib/redux/headlampEventSlice';
 import { trackFeature, trackPluginsLoaded } from './index';
 import { KNOWN_PLUGIN_IDS, sanitizeKind } from './schema';
 


### PR DESCRIPTION
Fixes invalid import that was causing plugin crash
```
index.ts:228 Plugin execution error in aks-desktop: TypeError: Cannot read properties of undefined (reading 'HeadlampEventType')
    at eval (main.js:89:51196)
    at eval (main.js:3:937)
    at eval (main.js:3:1242)
    at runPlugin (runPlugin.ts:71:5)
    at runPluginInner (index.ts:221:3)
    at Array.forEach (<anonymous>)
    at fetchAndExecutePlugins (index.ts:410:25)
```

Fixes telemetry settings not showing up in the settings