### PR TITLE
ci: bump Go to 1.26 for backend build

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -14,7 +14,7 @@ parameters:
     default: 20.x
   - name: goVersion
     type: string
-    default: 1.24.9
+    default: 1.26.3
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/.github/workflows/1es-pipeline-mac.yml
+++ b/.github/workflows/1es-pipeline-mac.yml
@@ -13,7 +13,7 @@ parameters:
     default: 20.x
   - name: goVersion
     type: string
-    default: 1.24.9
+    default: 1.26.3
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines

--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -14,7 +14,7 @@ parameters:
     default: 20.x
   - name: goVersion
     type: string
-    default: 1.24.9
+    default: 1.26.3
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/.github/workflows/build-app-linux.yml
+++ b/.github/workflows/build-app-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.24.*'
+          go-version: '1.26.*'
 
       - name: Setup nodejs
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build-app-mac.yml
+++ b/.github/workflows/build-app-mac.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.24.*'
+          go-version: '1.26.*'
 
       - name: Setup nodejs
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build-app-win.yml
+++ b/.github/workflows/build-app-win.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.24.*'
+          go-version: '1.26.*'
 
       - name: Setup nodejs
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

The scheduled Windows build (and Linux/mac) fails at `make backend`:

```
go: go.mod requires go >= 1.26.0 (running go 1.24.13; GOTOOLCHAIN=local)
make[1]: *** [Makefile:120: backend] Error 1
```

The pinned Headlamp submodule commit bumped its backend `go.mod` to `go 1.26.0` / `toolchain go1.26.3`, but the workflows install Go `1.24.*`. With `GOTOOLCHAIN=local`, Go refuses to auto-download the newer toolchain, so the backend compile hard-fails. All plugins and the frontend bundle build fine — only the Go backend step is affected.

Failing run: https://github.com/Azure/aks-desktop/actions/runs/29217828104/job/86717051575

## Change

- `build-app-{linux,mac,win}.yml`: `go-version: '1.24.*'` → `'1.26.*'`
- `1es-pipeline{,-linux,-mac}.yml`: `goVersion` default `1.24.9` → `1.26.3`

Go 1.26.x is stable and available via the Go release feed / `actions/setup-go`.
