### PR TITLE
aksd: Use canonical AI Assistant package identity

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1518,7 +1518,7 @@ async function startElectron() {
   console.info('App starting...');
   // add run cmd consent for aks-desktop to avoid consent dialogs for the aks-desktop plugin
   addRunCmdConsent({ name: 'aks-desktop' });
-  addRunCmdConsent({ name: 'ai-assistant' });
+  addRunCmdConsent({ name: '@headlamp-k8s/ai-assistant' });
 
   // Increase max listeners to prevent false positive warnings
   // The app legitimately needs multiple IPC listeners (currently 11)

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -17,7 +17,14 @@
 import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { checkPermissionSecret, handleRunCommand, validateCommandData } from './runCmd';
+import {
+  addRunCmdConsent,
+  checkPermissionSecret,
+  handleRunCommand,
+  removeRunCmdConsent,
+  validateCommandData,
+} from './runCmd';
+import { loadSettings, saveSettings } from './settings';
 
 vi.mock('./plugin-management', () => ({
   defaultPluginsDir: vi.fn(() => '/plugins/default'),
@@ -35,6 +42,47 @@ vi.mock('./settings', () => ({
 vi.mock('./i18next.config', () => ({
   default: { t: (s: string) => s },
 }));
+
+describe('AI Assistant runCmd consent', () => {
+  const aiAssistantCommands = ['gh auth', 'az account', 'az cognitiveservices'];
+  const defaultSettings = {
+    confirmedCommands: { 'minikube start': true, gh: true, az: true },
+  };
+
+  beforeEach(() => {
+    vi.mocked(saveSettings).mockClear();
+  });
+
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue(defaultSettings);
+  });
+
+  it('adds consent for the canonical package name', () => {
+    const settings = { confirmedCommands: {} as Record<string, boolean> };
+    vi.mocked(loadSettings).mockReturnValue(settings);
+
+    addRunCmdConsent({ name: '@headlamp-k8s/ai-assistant' });
+
+    expect(settings.confirmedCommands).toEqual(
+      Object.fromEntries(aiAssistantCommands.map(command => [command, true]))
+    );
+    expect(saveSettings).toHaveBeenCalledOnce();
+  });
+
+  it('removes consent using the package name', () => {
+    const settings = {
+      confirmedCommands: Object.fromEntries(
+        aiAssistantCommands.map(command => [command, true])
+      ) as Record<string, boolean>,
+    };
+    vi.mocked(loadSettings).mockReturnValue(settings);
+
+    removeRunCmdConsent('@headlamp-k8s/ai-assistant');
+
+    expect(settings.confirmedCommands).toEqual({});
+    expect(saveSettings).toHaveBeenCalledOnce();
+  });
+});
 
 describe('checkPermissionSecret', () => {
   const baseCommandData = {

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -144,9 +144,12 @@ const COMMANDS_WITH_CONSENT = {
     'kubectl top',
     'kubectl config',
   ],
-  headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
-  ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
+  aiAssistant: ['gh auth', 'az account', 'az cognitiveservices'],
 };
+
+function isAIAssistantPlugin(pluginName: string): boolean {
+  return pluginName === '@headlamp-k8s/ai-assistant';
+}
 
 /**
  * Adds the runCmd consent for the plugin.
@@ -171,22 +174,13 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
     commands = COMMANDS_WITH_CONSENT.headlamp_minikube;
   }
 
-  const pluginIsHeadlampAiAssistant =
-    pluginInfo.name === 'headlamp_ai-assistant' ||
-    pluginInfo.name === 'headlamp_ai-assistantprerelease' ||
-    (process.env.NODE_ENV === 'development' && pluginInfo.name === 'ai-assistant');
-  if (pluginIsHeadlampAiAssistant) {
-    commands = COMMANDS_WITH_CONSENT.headlamp_ai_assistant;
+  if (isAIAssistantPlugin(pluginInfo.name)) {
+    commands = COMMANDS_WITH_CONSENT.aiAssistant;
   }
 
   const pluginIsAksDesktop = pluginInfo.name === 'aks-desktop';
   if (pluginIsAksDesktop) {
     commands = COMMANDS_WITH_CONSENT.aks_desktop;
-  }
-
-  const pluginIsAiAssistant = pluginInfo.name === 'ai-assistant';
-  if (pluginIsAiAssistant) {
-    commands = COMMANDS_WITH_CONSENT.ai_assistant;
   }
 
   for (const command of commands) {
@@ -215,14 +209,8 @@ export function removeRunCmdConsent(pluginName: string): void {
   ) {
     commands = COMMANDS_WITH_CONSENT.headlamp_minikube;
   }
-  if (pluginName === 'ai-assistant') {
-    commands = COMMANDS_WITH_CONSENT.ai_assistant;
-  }
-  if (
-    pluginName === '@headlamp-k8s/ai-assistant' ||
-    pluginName === '@headlamp-k8s/ai-assistantprerelease'
-  ) {
-    commands = COMMANDS_WITH_CONSENT.headlamp_ai_assistant;
+  if (isAIAssistantPlugin(pluginName)) {
+    commands = COMMANDS_WITH_CONSENT.aiAssistant;
   }
   for (const command of commands) {
     delete settings.confirmedCommands[command];

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -625,11 +625,6 @@ export async function fetchAndExecutePlugins(
             secretsToReturn['runCmd-kubectl'] = secrets['runCmd-kubectl'];
           }
 
-          if (isPackage['ai-assistant']) {
-            secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
-            secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
-          }
-
           if (isPackage['@headlamp-k8s/ai-assistant']) {
             secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
             secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
@@ -706,26 +701,6 @@ export async function fetchAndExecutePlugins(
             ];
           }
 
-          if (isPackage['ai-assistant']) {
-            function pluginRunCommand(
-              command: 'gh' | 'az',
-              args: string[],
-              options: {}
-            ): ReturnType<typeof internalRunCommand> {
-              return internalRunCommand(
-                command,
-                args,
-                options,
-                allowedPermissions,
-                pluginDesktopApiSend,
-                pluginDesktopApiReceive
-              );
-            }
-            return [
-              ['pluginRunCommand', 'pluginPath'],
-              [pluginRunCommand, pluginPath],
-            ];
-          }
           return [[], []];
         },
         PrivateFunction,

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -336,7 +336,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -350,7 +349,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -365,7 +363,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube': true,
       '@headlamp-k8s/ai-assistant': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
@@ -379,7 +376,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube': true,
       '@headlamp-k8s/ai-assistant': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
@@ -388,7 +384,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -398,7 +393,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -408,7 +402,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -418,7 +411,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -428,7 +420,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -438,7 +429,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -452,7 +442,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -467,7 +456,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube': true,
       '@headlamp-k8s/ai-assistant': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
@@ -476,7 +464,6 @@ describe('identifyPackages', () => {
     expect(result).toEqual({
       '@headlamp-k8s/minikube': true,
       'aks-desktop': false,
-      'ai-assistant': false,
       '@headlamp-k8s/ai-assistant': false,
     });
   });
@@ -487,178 +474,19 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/minikube': false,
       '@headlamp-k8s/ai-assistant': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
-  // Tests for ai-assistant package
-  test('should identify ai-assistant package by path and name in production mode', () => {
-    const result = identifyPackages(
-      'plugins/headlamp_ai-assistant',
-      '@headlamp-k8s/ai-assistant',
-      false
-    );
-    expect(result).toEqual({
+  describe('AI Assistant package', () => {
+    const expectedMatch = {
       '@headlamp-k8s/minikube': false,
       '@headlamp-k8s/ai-assistant': true,
       'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should identify ai-assistant package by prerelease path and name in production mode', () => {
-    const result = identifyPackages(
-      'plugins/headlamp_ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should identify ai-assistant package by static path and name in production mode', () => {
-    const result = identifyPackages(
-      'static-plugins/headlamp_ai-assistant',
-      '@headlamp-k8s/ai-assistant',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should identify ai-assistant package by static prerelease path and name in production mode', () => {
-    const result = identifyPackages(
-      'static-plugins/headlamp_ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should identify ai-assistant package by dev path in development mode', () => {
-    const result = identifyPackages('plugins/ai-assistant', '@headlamp-k8s/ai-assistant', true);
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should identify ai-assistant package by dev prerelease path in development mode', () => {
-    const result = identifyPackages(
-      'plugins/ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      true
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should not identify ai-assistant package by dev prerelease path if not in development mode', () => {
-    const result = identifyPackages(
-      'plugins/ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': false,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should not identify ai-assistant package if path does not match', () => {
-    const result = identifyPackages('plugins/other_plugin', '@headlamp-k8s/ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': false,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should not identify ai-assistant package if name does not match', () => {
-    const result = identifyPackages('plugins/headlamp_ai-assistant', '@other/package', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': false,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should handle windows paths for ai-assistant correctly', () => {
-    const result = identifyPackages(
-      'plugins\\headlamp_ai-assistant',
-      '@headlamp-k8s/ai-assistant',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should handle windows static paths for ai-assistant correctly', () => {
-    const result = identifyPackages(
-      'static-plugins\\headlamp_ai-assistant',
-      '@headlamp-k8s/ai-assistant',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should handle windows paths for ai-assistant prerelease correctly', () => {
-    const result = identifyPackages(
-      'plugins\\headlamp_ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should handle windows static paths for ai-assistant prerelease correctly', () => {
-    const result = identifyPackages(
-      'static-plugins\\headlamp_ai-assistantprerelease',
-      '@headlamp-k8s/ai-assistantprerelease',
-      false
-    );
-    expect(result).toEqual({
-      '@headlamp-k8s/minikube': false,
-      '@headlamp-k8s/ai-assistant': true,
-      'aks-desktop': false,
-      'ai-assistant': false,
+    };
+    test('identifies the canonical package name independently of its location', () => {
+      expect(
+        identifyPackages('plugins/arbitrary-location', '@headlamp-k8s/ai-assistant', false)
+      ).toEqual(expectedMatch);
     });
   });
 
@@ -669,7 +497,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': true,
-      'ai-assistant': false,
     });
   });
 
@@ -679,7 +506,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': true,
-      'ai-assistant': false,
     });
   });
 
@@ -689,7 +515,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': true,
-      'ai-assistant': false,
     });
   });
 
@@ -699,7 +524,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
@@ -709,7 +533,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': false,
-      'ai-assistant': false,
     });
   });
 
@@ -719,7 +542,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': true,
-      'ai-assistant': false,
     });
   });
 
@@ -729,78 +551,6 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant': false,
       '@headlamp-k8s/minikube': false,
       'aks-desktop': true,
-      'ai-assistant': false,
-    });
-  });
-
-  // Tests for ai-assistant package
-  test('should identify ai-assistant package by path and name in production mode', () => {
-    const result = identifyPackages('plugins/ai-assistant', 'ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': true,
-    });
-  });
-
-  test('should identify ai-assistant package by static path and name in production mode', () => {
-    const result = identifyPackages('static-plugins/ai-assistant', 'ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': true,
-    });
-  });
-
-  test('should identify ai-assistant package by dev path in development mode', () => {
-    const result = identifyPackages('plugins/ai-assistant', 'ai-assistant', true);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': true,
-    });
-  });
-
-  test('should not identify ai-assistant package if path does not match', () => {
-    const result = identifyPackages('plugins/other_plugin', 'ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should not identify ai-assistant package if name does not match', () => {
-    const result = identifyPackages('plugins/ai-assistant', '@other/package', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': false,
-    });
-  });
-
-  test('should handle windows paths for ai-assistant correctly', () => {
-    const result = identifyPackages('plugins\\ai-assistant', 'ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': true,
-    });
-  });
-
-  test('should handle windows static paths for ai-assistant correctly', () => {
-    const result = identifyPackages('static-plugins\\ai-assistant', 'ai-assistant', false);
-    expect(result).toEqual({
-      '@headlamp-k8s/ai-assistant': false,
-      '@headlamp-k8s/minikube': false,
-      'aks-desktop': false,
-      'ai-assistant': true,
     });
   });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -235,7 +235,7 @@ export function identifyPackages(
     .replace(/static-plugins[\\/]/, 'static-plugins/')
     .replace(/user-plugins[\\/]/, 'user-plugins/');
 
-  // For artifacthub installed packages, the package name is the folder name.
+  // Map package names to the plugin directories they are allowed to run from.
   const pluginPaths: Record<string, string[]> = {
     '@headlamp-k8s/minikube': [
       'plugins/headlamp_minikube',
@@ -245,36 +245,17 @@ export function identifyPackages(
       'user-plugins/headlamp_minikubeprerelease',
       'static-plugins/headlamp_minikubeprerelease',
     ],
-    '@headlamp-k8s/ai-assistant': [
-      'plugins/headlamp_ai-assistant',
-      'user-plugins/headlamp_ai-assistant',
-      'static-plugins/headlamp_ai-assistant',
-      'plugins/headlamp_ai-assistantprerelease',
-      'user-plugins/headlamp_ai-assistantprerelease',
-      'static-plugins/headlamp_ai-assistantprerelease',
-    ],
     'aks-desktop': ['plugins/aks-desktop', 'static-plugins/aks-desktop'],
-    'ai-assistant': ['plugins/ai-assistant', 'static-plugins/ai-assistant'],
   };
 
   if (isDevelopmentMode) {
     pluginPaths['@headlamp-k8s/minikube'][pluginPaths['@headlamp-k8s/minikube'].length] =
       'plugins/minikube';
-    pluginPaths['@headlamp-k8s/ai-assistant'].push(
-      'plugins/ai-assistant',
-      'plugins/ai-assistantprerelease'
-    );
     pluginPaths['aks-desktop'][pluginPaths['aks-desktop'].length] = 'plugins/aks-desktop';
-    pluginPaths['ai-assistant'][pluginPaths['ai-assistant'].length] = 'plugins/ai-assistant';
   }
   const pluginPackageNames: Record<string, string[]> = {
     '@headlamp-k8s/minikube': ['@headlamp-k8s/minikube', '@headlamp-k8s/minikubeprerelease'],
-    '@headlamp-k8s/ai-assistant': [
-      '@headlamp-k8s/ai-assistant',
-      '@headlamp-k8s/ai-assistantprerelease',
-    ],
     'aks-desktop': ['aks-desktop'],
-    'ai-assistant': ['ai-assistant'],
   };
   const isPackage: Record<string, boolean> = {};
   for (const key in pluginPaths) {
@@ -294,5 +275,6 @@ export function identifyPackages(
     }
     isPackage[key] = foundPath && foundName;
   }
+  isPackage['@headlamp-k8s/ai-assistant'] = pluginName === '@headlamp-k8s/ai-assistant';
   return isPackage;
 }


### PR DESCRIPTION
## Summary

- recognize only `@headlamp-k8s/ai-assistant` when granting Electron `runCmd` permissions and loading the plugin
- identify AI Assistant permissions from the package name rather than its deployment directory
- remove unscoped, prerelease, and underscore-folder package aliases from Electron consent and frontend permission injection
- update focused Electron and frontend package-identification coverage

## Validation

- `npm --prefix app test -- --run electron/runCmd.test.ts` (25 tests)
- `npm --prefix frontend test -- --run src/plugin/runPlugin.test.ts` (28 tests)
- `npm --prefix app run lint`

See related:
- https://github.com/Azure/aks-desktop/pull/770