### PR TITLE
aksd: telemetry: stamp app version on every event

### DIFF
--- a/plugins/aks-desktop/src/telemetry/envelope.test.ts
+++ b/plugins/aks-desktop/src/telemetry/envelope.test.ts
@@ -65,6 +65,7 @@ describe('real Application Insights envelope', () => {
     expect(featureEnvelope.data.baseData.properties).toEqual({
       feature: 'headlamp.logs',
       status: 'opened',
+      appVersion: '1.0.0-test',
     });
     const errorEnvelope = serializedBatch.find(
       (envelope: { data?: { baseData?: { name?: string } } }) =>

--- a/plugins/aks-desktop/src/telemetry/index.test.ts
+++ b/plugins/aks-desktop/src/telemetry/index.test.ts
@@ -190,6 +190,26 @@ describe('initTelemetry', () => {
     });
   });
 
+  it('stamps initialized appVersion on a non-exception event', () => {
+    initTelemetry({
+      connectionString: 'InstrumentationKey=test',
+      installId: VALID_INSTALL_ID,
+      sessionProps: SESSION_PROPS,
+    });
+    trackEvent.mockClear();
+
+    trackFeature({ feature: 'headlamp.logs', status: 'opened' });
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      name: 'headlamp.feature',
+      properties: {
+        appVersion: SESSION_PROPS.appVersion,
+        feature: 'headlamp.logs',
+        status: 'opened',
+      },
+    });
+  });
+
   it('is idempotent — second call does not re-construct AI', () => {
     initTelemetry({
       connectionString: 'InstrumentationKey=test',

--- a/plugins/aks-desktop/src/telemetry/index.ts
+++ b/plugins/aks-desktop/src/telemetry/index.ts
@@ -250,7 +250,7 @@ function send(event: PendingEvent): void {
   if (!ai) return;
   try {
     ai.trackEvent(
-      event.name === 'headlamp.exception' && initializedAppVersion
+      initializedAppVersion
         ? {
             ...event,
             properties: { ...event.properties, appVersion: initializedAppVersion },


### PR DESCRIPTION
## Problem

The recent telemetry privacy hardening only attached the `appVersion` property to `headlamp.session-start` and `headlamp.exception` events. Every other event — `headlamp.feature`, `headlamp.cluster-shape`, `headlamp.plugins-loaded` — carried no app version at all, so those events could not be correlated by release in the `appVersion` custom dimension our queries read.

Observed in production: `headlamp.feature` envelopes arrive with no version field.

## Change

Generalize the `appVersion` stamping in `send()` from `headlamp.exception` to all events, so every envelope carries the version as a `customDimensions.appVersion` property. `appVersion` is already in the `TELEMETRY_PROPERTY_KEYS` allowlist, so no schema change is needed.

## Testing

- `envelope.test.ts` now asserts the serialized `headlamp.feature` batch carries `properties.appVersion` (end-to-end serialization test).
- All 186 telemetry tests pass; `tsc`, `lint`, and `format --check` clean under Node 20.

