### PR TITLE
build: Flatten scoped shipped plugin paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,25 @@ env:
   NODE_VERSION: "20"
 
 jobs:
+  plugin-packaging:
+    name: Test plugin packaging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run plugin packaging tests
+        run: npm run test:build
+
   find_changed_plugins:
     name: Find changed plugins
     runs-on: ubuntu-latest

--- a/build/plugin-packaging.test.ts
+++ b/build/plugin-packaging.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, test } from 'node:test';
+
+import { copyShippedPlugin } from './plugin-packaging';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  tempDirs
+    .splice(0)
+    .forEach((dir) => fs.rmSync(dir, { recursive: true, force: true }));
+});
+
+function createPlugin(packageName: string) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aks-desktop-plugin-'));
+  const pluginDir = path.join(rootDir, 'source');
+  const pluginsDir = path.join(rootDir, '.plugins');
+  tempDirs.push(rootDir);
+
+  fs.mkdirSync(path.join(pluginDir, 'dist', 'locales'), { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, 'dist', 'main.js'), 'plugin bundle');
+  fs.writeFileSync(path.join(pluginDir, 'dist', 'locales', 'en.json'), '{}');
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({ name: packageName })
+  );
+
+  return { pluginDir, pluginsDir };
+}
+
+test('copies a scoped plugin to a direct shipped-plugin directory', () => {
+  const packageName = '@headlamp-k8s/ai-assistant';
+  const { pluginDir, pluginsDir } = createPlugin(packageName);
+  const legacyDir = path.join(pluginsDir, packageName);
+  fs.mkdirSync(legacyDir, { recursive: true });
+  fs.writeFileSync(path.join(legacyDir, 'stale.js'), 'stale bundle');
+  const existingTargetDir = path.join(pluginsDir, 'ai-assistant');
+  fs.mkdirSync(existingTargetDir, { recursive: true });
+  fs.writeFileSync(path.join(existingTargetDir, 'stale.js'), 'stale bundle');
+
+  const targetDir = copyShippedPlugin(pluginDir, pluginsDir, packageName);
+
+  assert.equal(targetDir, path.join(pluginsDir, 'ai-assistant'));
+  assert.equal(fs.existsSync(path.join(targetDir, 'main.js')), true);
+  assert.equal(fs.existsSync(path.join(targetDir, 'locales', 'en.json')), true);
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(targetDir, 'package.json'), 'utf8'))
+      .name,
+    packageName
+  );
+  assert.equal(fs.existsSync(path.join(targetDir, 'stale.js')), false);
+  assert.equal(fs.existsSync(path.join(pluginsDir, '@headlamp-k8s')), false);
+});
+
+test('preserves the directory name for an unscoped plugin', () => {
+  const packageName = 'aks-desktop';
+  const { pluginDir, pluginsDir } = createPlugin(packageName);
+
+  const targetDir = copyShippedPlugin(pluginDir, pluginsDir, packageName);
+
+  assert.equal(targetDir, path.join(pluginsDir, packageName));
+  assert.equal(fs.existsSync(path.join(targetDir, 'main.js')), true);
+});
+
+test('rejects plugin paths outside the shipped-plugin directory', () => {
+  const packageName = '../outside';
+  const { pluginDir, pluginsDir } = createPlugin(packageName);
+  const outsideDir = path.join(path.dirname(pluginsDir), 'outside');
+  fs.mkdirSync(outsideDir);
+  fs.writeFileSync(path.join(outsideDir, 'sentinel'), 'keep');
+
+  assert.throws(
+    () => copyShippedPlugin(pluginDir, pluginsDir, packageName),
+    /Plugin path must stay within/
+  );
+  assert.equal(fs.existsSync(path.join(outsideDir, 'sentinel')), true);
+});

--- a/build/plugin-packaging.ts
+++ b/build/plugin-packaging.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function resolvePluginDir(pluginsDir: string, pluginPath: string) {
+  const pluginsRoot = path.resolve(pluginsDir);
+  const resolvedPath = path.resolve(pluginsRoot, pluginPath);
+  const relativePath = path.relative(pluginsRoot, resolvedPath);
+
+  if (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Plugin path must stay within ${pluginsRoot}: ${pluginPath}`);
+  }
+
+  return resolvedPath;
+}
+
+export function copyShippedPlugin(
+  pluginDir: string,
+  pluginsDir: string,
+  pluginName: string
+) {
+  const targetDir = resolvePluginDir(pluginsDir, path.basename(pluginName));
+  const legacyTargetDir = resolvePluginDir(pluginsDir, pluginName);
+
+  if (legacyTargetDir !== targetDir) {
+    fs.rmSync(legacyTargetDir, { recursive: true, force: true });
+    const legacyScopeDir = path.dirname(legacyTargetDir);
+    if (
+      fs.existsSync(legacyScopeDir) &&
+      fs.readdirSync(legacyScopeDir).length === 0
+    ) {
+      fs.rmdirSync(legacyScopeDir);
+    }
+  }
+
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const distDir = path.join(pluginDir, 'dist');
+  fs.readdirSync(distDir).forEach((file) => {
+    const src = path.join(distDir, file);
+    const dest = path.join(targetDir, file);
+    fs.cpSync(src, dest, { recursive: true });
+  });
+
+  fs.copyFileSync(
+    path.join(pluginDir, 'package.json'),
+    path.join(targetDir, 'package.json')
+  );
+
+  return targetDir;
+}

--- a/build/setup-plugins.ts
+++ b/build/setup-plugins.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { copyShippedPlugin } from './plugin-packaging';
 
 const SCRIPT_DIR = __dirname;
 const ROOT_DIR = path.dirname(SCRIPT_DIR);
@@ -68,19 +69,8 @@ for (const plugin of PLUGINS) {
   execSync('npm install && npm run build', { stdio: 'inherit' });
 
   console.log(`Copying built files for plugin: ${pluginName}`);
-  const targetDir = path.join(ROOT_DIR, 'headlamp', '.plugins', pluginName);
-  fs.mkdirSync(targetDir, { recursive: true });
-
-  // Copy dist folder contents
-  const distDir = path.join(pluginDir, 'dist');
-  fs.readdirSync(distDir).forEach((file) => {
-    const src = path.join(distDir, file);
-    const dest = path.join(targetDir, file);
-    fs.cpSync(src, dest, { recursive: true });
-  });
-
-  // Copy package.json
-  fs.copyFileSync('./package.json', path.join(targetDir, 'package.json'));
+  const pluginsDir = path.join(ROOT_DIR, 'headlamp', '.plugins');
+  const targetDir = copyShippedPlugin(pluginDir, pluginsDir, pluginName);
 
   console.log(`Plugin ${pluginName} has been built and copied to ${targetDir}`);
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:unpacked:linux": "npm run plugin:setup && cd headlamp && make app-build",
     "build:unpacked:mac": "npm run plugin:setup && cd headlamp && make app-build",
     "build:unpacked:win": "npm run plugin:setup && cd headlamp && make app-build",
+    "test:build": "tsx --test build/plugin-packaging.test.ts",
     "test:post-build": "npx --yes tsx ./build/verify-bundled-tools.ts",
     "plugin:setup": "npx --yes tsx ./build/setup-plugins.ts",
     "plugin:install": "cd plugins/aks-desktop && npm install",


### PR DESCRIPTION
Scoped plugin names created nested directories under `.plugins`, but Headlamp only discovers direct children. This flattens scoped plugin paths while preserving the canonical package identity.

Fixes: #787 

### Changes

- Package AI Assistant at `.plugins/ai-assistant`
- Preserve `@headlamp-k8s/ai-assistant` in `package.json`
- Add regression coverage and run it in CI

### Testing

- [x] `npm run test:build`
- [x] `npm run plugin:setup`
- [x] Built the macOS app and confirmed AI Assistant appears as **Shipped** under Settings -> Plugins

### Screenshot

<img width="1446" height="584" alt="image" src="https://github.com/user-attachments/assets/0dfa303b-5484-4c79-bff0-5675ae7886f9" />