### PR TITLE
aksd: Allow AI Assistant Azure Resource Graph queries

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -44,7 +44,7 @@ vi.mock('./i18next.config', () => ({
 }));
 
 describe('AI Assistant runCmd consent', () => {
-  const aiAssistantCommands = ['gh auth', 'az account', 'az cognitiveservices'];
+  const aiAssistantCommands = ['gh auth', 'az account', 'az cognitiveservices', 'az graph'];
   const defaultSettings = {
     confirmedCommands: { 'minikube start': true, gh: true, az: true },
   };

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -144,7 +144,7 @@ const COMMANDS_WITH_CONSENT = {
     'kubectl top',
     'kubectl config',
   ],
-  aiAssistant: ['gh auth', 'az account', 'az cognitiveservices'],
+  aiAssistant: ['gh auth', 'az account', 'az cognitiveservices', 'az graph'],
 };
 
 function isAIAssistantPlugin(pluginName: string): boolean {


### PR DESCRIPTION
## Summary

- pre-approve `az graph` for the shipped AI Assistant plugin
- keep add/remove consent behavior symmetric
- cover the canonical package consent list

## Why

Azure OpenAI and Azure AI Foundry auto-detection now uses Azure Resource Graph to discover accounts across subscriptions efficiently. Without this consent entry, AKS Desktop rejects the command and the main Auto Detect flow reports no providers.

## Testing

- `cd app && npm test -- --run electron/runCmd.test.ts`
- `npm run app:tsc`