### PR TITLE
ai-assistant: Fix Azure model auto-detection

### DIFF
--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
@@ -535,6 +535,7 @@ describe('collectAzureOpenAIProviders', () => {
   it('stops after the first successful deployment batch for single-provider detection', async () => {
     const deploymentCalls: string[] = [];
     const abortedAccounts: string[] = [];
+    const fallbackSignals: AbortSignal[] = [];
     const accounts = Array.from({ length: 9 }, (_, index) => ({
       id: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/account-${index}`,
       name: `account-${index}`,
@@ -542,7 +543,7 @@ describe('collectAzureOpenAIProviders', () => {
       subscriptionId: 'sub',
       endpoint: `https://account-${index}.openai.azure.com`,
     }));
-    const runner: CommandRunner = async (_command, args) => {
+    const runner: CommandRunner = async (_command, args, signal) => {
       const call = args.join(' ');
       if (call.includes('account show')) {
         return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
@@ -552,6 +553,10 @@ describe('collectAzureOpenAIProviders', () => {
       }
       if (call.includes('get-access-token')) {
         return { stdout: 'token', exitCode: 0 };
+      }
+      if (call.includes('deployment list')) {
+        if (signal) fallbackSignals.push(signal);
+        return { stdout: '', exitCode: -1 };
       }
       return { stdout: '', exitCode: -1 };
     };
@@ -585,6 +590,8 @@ describe('collectAzureOpenAIProviders', () => {
       expect(result?.config.azAccountName).toBe('account-0');
       expect(deploymentCalls).toHaveLength(8);
       expect(abortedAccounts).toHaveLength(7);
+      expect(fallbackSignals).toHaveLength(7);
+      expect(fallbackSignals.every(signal => signal.aborted)).toBe(true);
     } finally {
       fetchSpy.mockRestore();
     }

--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
@@ -20,6 +20,7 @@ import {
   collectAzureOpenAIProviders,
   type CommandRunner,
   type CopilotModelEntry,
+  detectAzureOpenAIProvider,
   detectCopilotChatModels,
   detectCopilotProvider,
   type DetectedProvider,
@@ -299,6 +300,296 @@ describe('detectOllamaProvider', () => {
 // ---------------------------------------------------------------------------
 
 describe('collectAzureOpenAIProviders', () => {
+  it('uses Azure Management APIs without az graph, az rest, or key retrieval', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      const call = `${command} ${args.join(' ')}`;
+      calls.push(call);
+
+      if (call.includes('az account show')) {
+        return { stdout: JSON.stringify({ name: 'ActiveSub', id: 'active-sub' }), exitCode: 0 };
+      }
+      if (call.includes('az account list')) {
+        return { stdout: JSON.stringify([{ id: 'foundry-sub' }]), exitCode: 0 };
+      }
+      if (call.includes('az account get-access-token')) {
+        return { stdout: 'management-token\n', exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: '/subscriptions/foundry-sub/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/my-foundry',
+                name: 'my-foundry',
+                resourceGroup: 'foundry-rg',
+                subscriptionId: 'foundry-sub',
+                endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            value: [
+              {
+                name: 'gpt-4.1',
+                properties: {
+                  model: { name: 'gpt-4.1' },
+                  capabilities: { chatCompletion: 'true' },
+                },
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
+
+    try {
+      const result = await collectAzureOpenAIProviders(runner);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].config).toMatchObject({
+        azSubscriptionId: 'foundry-sub',
+        endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
+        deploymentName: 'gpt-4.1',
+      });
+      expect(calls.some(call => call.includes('az account get-access-token'))).toBe(true);
+      expect(calls.some(call => call.includes('az graph'))).toBe(false);
+      expect(calls.some(call => call.includes('az rest'))).toBe(false);
+      expect(calls.some(call => call.includes('account keys list'))).toBe(false);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('falls back to Azure CLI deployment discovery when the ARM API fails', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      const call = `${command} ${args.join(' ')}`;
+      calls.push(call);
+      if (call.includes('az account show')) {
+        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
+      }
+      if (call.includes('az account list')) {
+        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
+      }
+      if (call.includes('az account get-access-token')) {
+        return { stdout: 'token', exitCode: 0 };
+      }
+      if (call.includes('az cognitiveservices account deployment list')) {
+        return { stdout: CHAT_DEPLOYMENT_STDOUT, exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/account',
+                name: 'account',
+                resourceGroup: 'rg',
+                subscriptionId: 'sub',
+                endpoint: 'https://account.openai.azure.com',
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(new Response('', { status: 503 }));
+
+    try {
+      const result = await detectAzureOpenAIProvider(runner);
+
+      expect(result?.config.azAccountName).toBe('account');
+      expect(
+        calls.some(call => call.includes('az cognitiveservices account deployment list'))
+      ).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('follows Resource Graph API continuation tokens', async () => {
+    const runner: CommandRunner = async (_command, args) => {
+      const call = args.join(' ');
+      if (call.includes('account show')) {
+        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
+      }
+      if (call.includes('account list')) {
+        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
+      }
+      if (call.includes('get-access-token')) {
+        return { stdout: 'token', exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+    const graphBodies: Record<string, unknown>[] = [];
+    const accounts = ['first', 'second'];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, options) => {
+      if (String(url).includes('Microsoft.ResourceGraph/resources')) {
+        const body = JSON.parse(String(options?.body)) as Record<string, any>;
+        graphBodies.push(body);
+        const secondPage = body.options?.$skipToken === 'next-page';
+        const name = secondPage ? 'second' : 'first';
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/${name}`,
+                name,
+                resourceGroup: 'rg',
+                subscriptionId: 'sub',
+                endpoint: `https://${name}.openai.azure.com`,
+              },
+            ],
+            ...(secondPage ? {} : { $skipToken: 'next-page' }),
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response(JSON.stringify({ value: JSON.parse(CHAT_DEPLOYMENT_STDOUT) }), {
+        status: 200,
+      });
+    });
+
+    try {
+      const result = await collectAzureOpenAIProviders(runner);
+
+      expect(result.map(provider => provider.config.azAccountName)).toEqual(accounts);
+      expect(graphBodies).toHaveLength(2);
+      expect(graphBodies[1].options).toMatchObject({ $skipToken: 'next-page' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('limits deployment discovery to eight concurrent commands', async () => {
+    let activeCommands = 0;
+    let maxActiveCommands = 0;
+    const releaseCommands: Array<() => void> = [];
+    const accounts = Array.from({ length: 9 }, (_, index) => ({
+      id: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/account-${index}`,
+      name: `account-${index}`,
+      resourceGroup: 'rg',
+      subscriptionId: 'sub',
+      endpoint: `https://account-${index}.openai.azure.com`,
+    }));
+    const runner: CommandRunner = async (_command, args) => {
+      const call = args.join(' ');
+      if (call.includes('account show')) {
+        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
+      }
+      if (call.includes('account list')) {
+        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
+      }
+      if (call.includes('get-access-token')) {
+        return { stdout: 'token', exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async url => {
+      if (String(url).includes('Microsoft.ResourceGraph/resources')) {
+        return new Response(JSON.stringify({ data: accounts }), { status: 200 });
+      }
+      return new Promise<Response>(resolve => {
+        activeCommands += 1;
+        maxActiveCommands = Math.max(maxActiveCommands, activeCommands);
+        releaseCommands.push(() => {
+          activeCommands -= 1;
+          resolve(
+            new Response(JSON.stringify({ value: JSON.parse(CHAT_DEPLOYMENT_STDOUT) }), {
+              status: 200,
+            })
+          );
+        });
+      });
+    });
+
+    try {
+      const detection = collectAzureOpenAIProviders(runner);
+      await vi.waitFor(() => expect(releaseCommands).toHaveLength(8));
+      releaseCommands.splice(0).forEach(resolve => resolve());
+      await vi.waitFor(() => expect(releaseCommands).toHaveLength(1));
+      releaseCommands.splice(0).forEach(resolve => resolve());
+
+      expect(await detection).toHaveLength(9);
+      expect(maxActiveCommands).toBe(8);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('stops after the first successful deployment batch for single-provider detection', async () => {
+    const deploymentCalls: string[] = [];
+    const abortedAccounts: string[] = [];
+    const accounts = Array.from({ length: 9 }, (_, index) => ({
+      id: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/account-${index}`,
+      name: `account-${index}`,
+      resourceGroup: 'rg',
+      subscriptionId: 'sub',
+      endpoint: `https://account-${index}.openai.azure.com`,
+    }));
+    const runner: CommandRunner = async (_command, args) => {
+      const call = args.join(' ');
+      if (call.includes('account show')) {
+        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
+      }
+      if (call.includes('account list')) {
+        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
+      }
+      if (call.includes('get-access-token')) {
+        return { stdout: 'token', exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, options) => {
+      if (String(url).includes('Microsoft.ResourceGraph/resources')) {
+        return new Response(JSON.stringify({ data: accounts }), { status: 200 });
+      }
+      const match = String(url).match(/accounts\/(account-\d+)\/deployments/);
+      const accountName = match?.[1] ?? '';
+      deploymentCalls.push(accountName);
+      if (accountName === 'account-0') {
+        return new Response(JSON.stringify({ value: JSON.parse(CHAT_DEPLOYMENT_STDOUT) }), {
+          status: 200,
+        });
+      }
+      return new Promise(resolve => {
+        options?.signal?.addEventListener(
+          'abort',
+          () => {
+            abortedAccounts.push(accountName);
+            resolve(new Response('', { status: 499 }));
+          },
+          { once: true }
+        );
+      });
+    });
+
+    try {
+      const result = await detectAzureOpenAIProvider(runner);
+
+      expect(result?.config.azAccountName).toBe('account-0');
+      expect(deploymentCalls).toHaveLength(8);
+      expect(abortedAccounts).toHaveLength(7);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it('returns Azure providers with chat-capable deployments', async () => {
     const runner = mockCommandRunner({
       'az account show': {
@@ -336,6 +627,76 @@ describe('collectAzureOpenAIProviders', () => {
     expect(result[0].config.apiKey).toBe(AZ_CLI_AUTH_SENTINEL);
     expect(result[0].config.azAccountName).toBe('myopenai');
     expect(result[0].config.deploymentName).toBe('gpt4-deploy');
+  });
+
+  it('detects Foundry models in enabled non-active subscriptions', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      const call = `${command} ${args.join(' ')}`;
+      calls.push(call);
+
+      if (call.includes('az account show')) {
+        return { stdout: JSON.stringify({ name: 'ActiveSub', id: 'active-sub' }), exitCode: 0 };
+      }
+      if (call.includes('az account list')) {
+        return {
+          stdout: JSON.stringify([
+            { name: 'ActiveSub', id: 'active-sub' },
+            { name: 'FoundrySub', id: 'foundry-sub' },
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (call.includes('az cognitiveservices account list')) {
+        return call.includes('--subscription foundry-sub')
+          ? {
+              stdout: JSON.stringify([
+                {
+                  name: 'my-foundry',
+                  resourceGroup: 'foundry-rg',
+                  kind: 'AIServices',
+                  properties: {
+                    endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
+                  },
+                },
+              ]),
+              exitCode: 0,
+            }
+          : { stdout: '[]', exitCode: 0 };
+      }
+      if (call.includes('az cognitiveservices account deployment list')) {
+        return {
+          stdout: JSON.stringify([
+            {
+              name: 'gpt-4.1-deployment',
+              properties: {
+                model: { name: 'gpt-4.1' },
+                capabilities: { chatCompletion: 'true' },
+              },
+            },
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (call.includes('az cognitiveservices account keys list')) {
+        return { stdout: JSON.stringify({ key1: 'foundry-key' }), exitCode: 0 };
+      }
+      return { stdout: '', exitCode: -1 };
+    };
+
+    const result = await collectAzureOpenAIProviders(runner);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].config).toMatchObject({
+      azSubscriptionId: 'foundry-sub',
+      azAccountName: 'my-foundry',
+      deploymentName: 'gpt-4.1-deployment',
+      model: 'gpt-4.1',
+    });
+    expect(calls).toContain(
+      'az cognitiveservices account deployment list -g foundry-rg -n my-foundry --subscription foundry-sub -o json'
+    );
+    expect(calls.some(call => call.includes('account keys list'))).toBe(false);
   });
 
   it('returns empty when not logged in', async () => {
@@ -425,6 +786,20 @@ describe('dismissalKey', () => {
       displayName: 'Azure (myaccount)',
     };
     expect(dismissalKey(provider)).toBe('azure:myaccount');
+  });
+
+  it('returns a subscription-scoped key for detected Azure accounts', () => {
+    const provider: DetectedProvider = {
+      providerId: 'azure',
+      source: 'Azure CLI',
+      config: {
+        azAccountName: 'MyAccount',
+        azResourceGroup: 'MyGroup',
+        azSubscriptionId: 'MySubscription',
+      },
+      displayName: 'Azure',
+    };
+    expect(dismissalKey(provider)).toBe('azure-account:mysubscription/mygroup/myaccount');
   });
 
   it('returns bare azure for Azure without account name', () => {
@@ -592,6 +967,23 @@ describe('runDetectCommand — error paths (via detectGitHubToken)', () => {
     };
     const result = await detectGitHubToken(throwingRunner);
     expect(result).toBeNull();
+  });
+
+  it('aborts a command runner when detection times out', async () => {
+    vi.useFakeTimers();
+    try {
+      let receivedSignal: AbortSignal | undefined;
+      const runner: CommandRunner = async (_command, _args, signal) => {
+        receivedSignal = signal;
+        return new Promise(() => {});
+      };
+      const detection = detectGitHubToken(runner);
+      await vi.advanceTimersByTimeAsync(15_001);
+      expect(await detection).toBeNull();
+      expect(receivedSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns null after command timeout (timeout path)', async () => {
@@ -889,11 +1281,17 @@ describe('collectAzureOpenAIProviders — error and skip branches', () => {
     expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
   });
 
-  it('skips account when keys JSON is invalid (getAzureOpenAIKey catch)', async () => {
-    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, {
+  it('defers key validation until the detected provider is used', async () => {
+    const calls: string[] = [];
+    const baseRunner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, {
       'az cognitiveservices account keys list': { stdout: 'NOT_JSON{', exitCode: 0 },
     });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
+    const runner: CommandRunner = async (command, args) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      return baseRunner(command, args);
+    };
+    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(1);
+    expect(calls.some(call => call.includes('account keys list'))).toBe(false);
   });
 });
 
@@ -902,6 +1300,18 @@ describe('collectAzureOpenAIProviders — error and skip branches', () => {
 // ---------------------------------------------------------------------------
 
 describe('refreshAzureOpenAIKey — extra paths', () => {
+  it('scopes key refresh to the saved subscription', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      return { stdout: JSON.stringify({ key1: 'key' }), exitCode: 0 };
+    };
+    expect(await refreshAzureOpenAIKey('rg', 'account', runner, 'subscription')).toBe('key');
+    expect(calls).toEqual([
+      'az cognitiveservices account keys list -g rg -n account --subscription subscription -o json',
+    ]);
+  });
+
   it('returns key2 when key1 is absent', async () => {
     const runner = mockCommandRunner({
       'az cognitiveservices account keys list': {

--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.test.ts
@@ -306,12 +306,6 @@ describe('collectAzureOpenAIProviders', () => {
       const call = `${command} ${args.join(' ')}`;
       calls.push(call);
 
-      if (call.includes('az account show')) {
-        return { stdout: JSON.stringify({ name: 'ActiveSub', id: 'active-sub' }), exitCode: 0 };
-      }
-      if (call.includes('az account list')) {
-        return { stdout: JSON.stringify([{ id: 'foundry-sub' }]), exitCode: 0 };
-      }
       if (call.includes('az account get-access-token')) {
         return { stdout: 'management-token\n', exitCode: 0 };
       }
@@ -319,6 +313,14 @@ describe('collectAzureOpenAIProviders', () => {
     };
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            value: [{ id: '/subscriptions/foundry-sub', subscriptionId: 'foundry-sub' }],
+          }),
+          { status: 200 }
+        )
+      )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
@@ -361,37 +363,36 @@ describe('collectAzureOpenAIProviders', () => {
         endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
         deploymentName: 'gpt-4.1',
       });
-      expect(calls.some(call => call.includes('az account get-access-token'))).toBe(true);
+      expect(calls).toEqual([
+        'az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv',
+      ]);
       expect(calls.some(call => call.includes('az graph'))).toBe(false);
       expect(calls.some(call => call.includes('az rest'))).toBe(false);
       expect(calls.some(call => call.includes('account keys list'))).toBe(false);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
     } finally {
       fetchSpy.mockRestore();
     }
   });
 
-  it('falls back to Azure CLI deployment discovery when the ARM API fails', async () => {
+  it('returns no provider when the deployment API fails without invoking another command', async () => {
     const calls: string[] = [];
     const runner: CommandRunner = async (command, args) => {
       const call = `${command} ${args.join(' ')}`;
       calls.push(call);
-      if (call.includes('az account show')) {
-        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
-      }
-      if (call.includes('az account list')) {
-        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
-      }
       if (call.includes('az account get-access-token')) {
         return { stdout: 'token', exitCode: 0 };
-      }
-      if (call.includes('az cognitiveservices account deployment list')) {
-        return { stdout: CHAT_DEPLOYMENT_STDOUT, exitCode: 0 };
       }
       return { stdout: '', exitCode: -1 };
     };
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ value: [{ id: '/subscriptions/sub', subscriptionId: 'sub' }] }),
+          { status: 200 }
+        )
+      )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
@@ -413,10 +414,10 @@ describe('collectAzureOpenAIProviders', () => {
     try {
       const result = await detectAzureOpenAIProvider(runner);
 
-      expect(result?.config.azAccountName).toBe('account');
-      expect(
-        calls.some(call => call.includes('az cognitiveservices account deployment list'))
-      ).toBe(true);
+      expect(result).toBeNull();
+      expect(calls).toEqual([
+        'az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv',
+      ]);
     } finally {
       fetchSpy.mockRestore();
     }
@@ -425,12 +426,6 @@ describe('collectAzureOpenAIProviders', () => {
   it('follows Resource Graph API continuation tokens', async () => {
     const runner: CommandRunner = async (_command, args) => {
       const call = args.join(' ');
-      if (call.includes('account show')) {
-        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
-      }
-      if (call.includes('account list')) {
-        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
-      }
       if (call.includes('get-access-token')) {
         return { stdout: 'token', exitCode: 0 };
       }
@@ -439,6 +434,12 @@ describe('collectAzureOpenAIProviders', () => {
     const graphBodies: Record<string, unknown>[] = [];
     const accounts = ['first', 'second'];
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, options) => {
+      if (String(url).includes('/subscriptions?')) {
+        return new Response(
+          JSON.stringify({ value: [{ id: '/subscriptions/sub', subscriptionId: 'sub' }] }),
+          { status: 200 }
+        );
+      }
       if (String(url).includes('Microsoft.ResourceGraph/resources')) {
         const body = JSON.parse(String(options?.body)) as Record<string, any>;
         graphBodies.push(body);
@@ -489,18 +490,18 @@ describe('collectAzureOpenAIProviders', () => {
     }));
     const runner: CommandRunner = async (_command, args) => {
       const call = args.join(' ');
-      if (call.includes('account show')) {
-        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
-      }
-      if (call.includes('account list')) {
-        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
-      }
       if (call.includes('get-access-token')) {
         return { stdout: 'token', exitCode: 0 };
       }
       return { stdout: '', exitCode: -1 };
     };
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async url => {
+      if (String(url).includes('/subscriptions?')) {
+        return new Response(
+          JSON.stringify({ value: [{ id: '/subscriptions/sub', subscriptionId: 'sub' }] }),
+          { status: 200 }
+        );
+      }
       if (String(url).includes('Microsoft.ResourceGraph/resources')) {
         return new Response(JSON.stringify({ data: accounts }), { status: 200 });
       }
@@ -535,7 +536,6 @@ describe('collectAzureOpenAIProviders', () => {
   it('stops after the first successful deployment batch for single-provider detection', async () => {
     const deploymentCalls: string[] = [];
     const abortedAccounts: string[] = [];
-    const fallbackSignals: AbortSignal[] = [];
     const accounts = Array.from({ length: 9 }, (_, index) => ({
       id: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/account-${index}`,
       name: `account-${index}`,
@@ -543,24 +543,20 @@ describe('collectAzureOpenAIProviders', () => {
       subscriptionId: 'sub',
       endpoint: `https://account-${index}.openai.azure.com`,
     }));
-    const runner: CommandRunner = async (_command, args, signal) => {
+    const runner: CommandRunner = async (_command, args) => {
       const call = args.join(' ');
-      if (call.includes('account show')) {
-        return { stdout: JSON.stringify({ id: 'sub' }), exitCode: 0 };
-      }
-      if (call.includes('account list')) {
-        return { stdout: JSON.stringify([{ id: 'sub' }]), exitCode: 0 };
-      }
       if (call.includes('get-access-token')) {
         return { stdout: 'token', exitCode: 0 };
-      }
-      if (call.includes('deployment list')) {
-        if (signal) fallbackSignals.push(signal);
-        return { stdout: '', exitCode: -1 };
       }
       return { stdout: '', exitCode: -1 };
     };
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, options) => {
+      if (String(url).includes('/subscriptions?')) {
+        return new Response(
+          JSON.stringify({ value: [{ id: '/subscriptions/sub', subscriptionId: 'sub' }] }),
+          { status: 200 }
+        );
+      }
       if (String(url).includes('Microsoft.ResourceGraph/resources')) {
         return new Response(JSON.stringify({ data: accounts }), { status: 200 });
       }
@@ -590,49 +586,19 @@ describe('collectAzureOpenAIProviders', () => {
       expect(result?.config.azAccountName).toBe('account-0');
       expect(deploymentCalls).toHaveLength(8);
       expect(abortedAccounts).toHaveLength(7);
-      expect(fallbackSignals).toHaveLength(7);
-      expect(fallbackSignals.every(signal => signal.aborted)).toBe(true);
     } finally {
       fetchSpy.mockRestore();
     }
   });
 
   it('returns Azure providers with chat-capable deployments', async () => {
-    const runner = mockCommandRunner({
-      'az account show': {
-        stdout: JSON.stringify({ name: 'TestSub' }),
-        exitCode: 0,
-      },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([
-          {
-            name: 'myopenai',
-            resourceGroup: 'rg1',
-            properties: { endpoint: 'https://myopenai.openai.azure.com' },
-          },
-        ]),
-        exitCode: 0,
-      },
-      'az cognitiveservices account deployment list': {
-        stdout: JSON.stringify([
-          {
-            name: 'gpt4-deploy',
-            properties: { model: { name: 'gpt-4' }, capabilities: { chatCompletion: 'true' } },
-          },
-        ]),
-        exitCode: 0,
-      },
-      'az cognitiveservices account keys list': {
-        stdout: JSON.stringify({ key1: 'test-key-1' }),
-        exitCode: 0,
-      },
-    });
+    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT);
 
     const result = await collectAzureOpenAIProviders(runner);
     expect(result).toHaveLength(1);
     expect(result[0].providerId).toBe('azure');
     expect(result[0].config.apiKey).toBe(AZ_CLI_AUTH_SENTINEL);
-    expect(result[0].config.azAccountName).toBe('myopenai');
+    expect(result[0].config.azAccountName).toBe('myoai');
     expect(result[0].config.deploymentName).toBe('gpt4-deploy');
   });
 
@@ -642,54 +608,56 @@ describe('collectAzureOpenAIProviders', () => {
       const call = `${command} ${args.join(' ')}`;
       calls.push(call);
 
-      if (call.includes('az account show')) {
-        return { stdout: JSON.stringify({ name: 'ActiveSub', id: 'active-sub' }), exitCode: 0 };
-      }
-      if (call.includes('az account list')) {
-        return {
-          stdout: JSON.stringify([
-            { name: 'ActiveSub', id: 'active-sub' },
-            { name: 'FoundrySub', id: 'foundry-sub' },
-          ]),
-          exitCode: 0,
-        };
-      }
-      if (call.includes('az cognitiveservices account list')) {
-        return call.includes('--subscription foundry-sub')
-          ? {
-              stdout: JSON.stringify([
-                {
-                  name: 'my-foundry',
-                  resourceGroup: 'foundry-rg',
-                  kind: 'AIServices',
-                  properties: {
-                    endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
-                  },
-                },
-              ]),
-              exitCode: 0,
-            }
-          : { stdout: '[]', exitCode: 0 };
-      }
-      if (call.includes('az cognitiveservices account deployment list')) {
-        return {
-          stdout: JSON.stringify([
-            {
-              name: 'gpt-4.1-deployment',
-              properties: {
-                model: { name: 'gpt-4.1' },
-                capabilities: { chatCompletion: 'true' },
-              },
-            },
-          ]),
-          exitCode: 0,
-        };
-      }
-      if (call.includes('az cognitiveservices account keys list')) {
-        return { stdout: JSON.stringify({ key1: 'foundry-key' }), exitCode: 0 };
+      if (call.includes('az account get-access-token')) {
+        return { stdout: 'token', exitCode: 0 };
       }
       return { stdout: '', exitCode: -1 };
     };
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            value: [
+              { id: '/subscriptions/active-sub', subscriptionId: 'active-sub' },
+              { id: '/subscriptions/foundry-sub', subscriptionId: 'foundry-sub' },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: '/subscriptions/foundry-sub/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/my-foundry',
+                name: 'my-foundry',
+                resourceGroup: 'foundry-rg',
+                subscriptionId: 'foundry-sub',
+                endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            value: [
+              {
+                name: 'gpt-4.1-deployment',
+                properties: {
+                  model: { name: 'gpt-4.1' },
+                  capabilities: { chatCompletion: 'true' },
+                },
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
 
     const result = await collectAzureOpenAIProviders(runner);
 
@@ -700,37 +668,24 @@ describe('collectAzureOpenAIProviders', () => {
       deploymentName: 'gpt-4.1-deployment',
       model: 'gpt-4.1',
     });
-    expect(calls).toContain(
-      'az cognitiveservices account deployment list -g foundry-rg -n my-foundry --subscription foundry-sub -o json'
-    );
-    expect(calls.some(call => call.includes('account keys list'))).toBe(false);
+    expect(calls).toEqual([
+      'az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv',
+    ]);
+    fetchSpy.mockRestore();
   });
 
   it('returns empty when not logged in', async () => {
     const runner = mockCommandRunner({
-      'az account show': { stdout: '', exitCode: 1 },
+      'az account get-access-token': { stdout: '', exitCode: 1 },
     });
     const result = await collectAzureOpenAIProviders(runner);
     expect(result).toHaveLength(0);
   });
 
   it('skips accounts in the skip set', async () => {
-    const runner = mockCommandRunner({
-      'az account show': {
-        stdout: JSON.stringify({ name: 'TestSub' }),
-        exitCode: 0,
-      },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([
-          {
-            name: 'skippedAccount',
-            resourceGroup: 'rg1',
-            properties: { endpoint: 'https://skipped.openai.azure.com' },
-          },
-        ]),
-        exitCode: 0,
-      },
-    });
+    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, [
+      { ...AZURE_TEST_ACCOUNT, name: 'skippedAccount' },
+    ]);
 
     const result = await collectAzureOpenAIProviders(runner, new Set(['skippedAccount']));
     expect(result).toHaveLength(0);
@@ -752,18 +707,18 @@ describe('refreshGitHubToken', () => {
 });
 
 describe('refreshAzureOpenAIKey', () => {
-  it('returns fresh key from az CLI', async () => {
+  it('returns a fresh key using token auth and ARM', async () => {
     const runner = mockCommandRunner({
-      'az cognitiveservices account keys list': {
-        stdout: JSON.stringify({ key1: 'fresh-key' }),
-        exitCode: 0,
-      },
+      'az account get-access-token': { stdout: 'token', exitCode: 0 },
     });
-    const result = await refreshAzureOpenAIKey('rg1', 'account1', runner);
-    expect(result).toBe('fresh-key');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ key1: 'fresh-key' }), { status: 200 }));
+    expect(await refreshAzureOpenAIKey('rg1', 'account1', runner, 'sub')).toBe('fresh-key');
+    fetchSpy.mockRestore();
   });
 
-  it('returns null when az CLI fails', async () => {
+  it('returns null when token acquisition fails', async () => {
     const runner = mockCommandRunner({});
     const result = await refreshAzureOpenAIKey('rg1', 'account1', runner);
     expect(result).toBeNull();
@@ -1050,37 +1005,48 @@ describe('detectOllamaProvider — non-ok HTTP and abort', () => {
 // Helpers for Azure tests
 // ---------------------------------------------------------------------------
 
+/** Default account returned by the Azure Resource Graph API test harness. */
+const AZURE_TEST_ACCOUNT = {
+  id: '/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/myoai',
+  name: 'myoai',
+  resourceGroup: 'rg1',
+  subscriptionId: 'sub',
+  endpoint: 'https://myoai.openai.azure.com',
+};
+
 /**
- * Build a command runner that satisfies the full Azure detection flow,
- * with overridable responses per command.
+ * Builds an auth-only command runner and mocks the Azure APIs used for detection.
+ *
+ * @param deploymentStdout - JSON deployment array returned by the deployment API.
+ * @param accounts - Resource Graph account rows.
+ * @returns Command runner that supports only Azure token acquisition.
  */
 function makeAzureBaseRunner(
   deploymentStdout: string,
-  extraOverrides: Record<string, { stdout: string; exitCode: number }> = {}
+  accounts: Record<string, unknown>[] = [AZURE_TEST_ACCOUNT]
 ): CommandRunner {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async url => {
+    const requestUrl = String(url);
+    if (requestUrl.includes('/subscriptions?')) {
+      return new Response(
+        JSON.stringify({ value: [{ id: '/subscriptions/sub', subscriptionId: 'sub' }] }),
+        { status: 200 }
+      );
+    }
+    if (requestUrl.includes('Microsoft.ResourceGraph/resources')) {
+      return new Response(JSON.stringify({ data: accounts }), { status: 200 });
+    }
+    if (requestUrl.includes('/deployments?')) {
+      return new Response(JSON.stringify({ value: JSON.parse(deploymentStdout) }), { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  });
   return mockCommandRunner({
-    'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-    'az cognitiveservices account list': {
-      stdout: JSON.stringify([
-        {
-          name: 'myoai',
-          resourceGroup: 'rg1',
-          properties: { endpoint: 'https://myoai.openai.azure.com' },
-        },
-      ]),
-      exitCode: 0,
-    },
-    'az cognitiveservices account deployment list': {
-      stdout: deploymentStdout,
-      exitCode: 0,
-    },
-    'az cognitiveservices account keys list': {
-      stdout: JSON.stringify({ key1: 'test-key' }),
-      exitCode: 0,
-    },
-    ...extraOverrides,
+    'az account get-access-token': { stdout: 'management-token', exitCode: 0 },
   });
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 const CHAT_DEPLOYMENT_STDOUT = JSON.stringify([
   {
@@ -1161,75 +1127,25 @@ describe('isChatDeployment — deployment filtering via collectAzureOpenAIProvid
 // ---------------------------------------------------------------------------
 
 describe('collectAzureOpenAIProviders — error and skip branches', () => {
-  it('returns empty when az account show returns invalid JSON (checkAzureLogin catch)', async () => {
+  it('returns empty when token acquisition fails', async () => {
     const runner = mockCommandRunner({
-      'az account show': { stdout: 'NOT_JSON{{{', exitCode: 0 },
+      'az account get-access-token': { stdout: '', exitCode: 1 },
     });
     expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
   });
 
-  it('uses "Azure" as fallback subscriptionName when account JSON has neither name nor user.name', async () => {
+  it('returns empty when subscription discovery fails', async () => {
     const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ id: 'xyz' }), exitCode: 0 },
-      'az cognitiveservices account list': { stdout: JSON.stringify([]), exitCode: 0 },
+      'az account get-access-token': { stdout: 'token', exitCode: 0 },
     });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('uses user.name as subscriptionName when account.name is absent', async () => {
-    const runner = mockCommandRunner({
-      'az account show': {
-        stdout: JSON.stringify({ user: { name: 'user@example.com' } }),
-        exitCode: 0,
-      },
-      'az cognitiveservices account list': { stdout: JSON.stringify([]), exitCode: 0 },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('returns empty when account list exits non-zero (listAzureOpenAIAccounts early return)', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': { stdout: '', exitCode: 1 },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('returns empty when account list JSON is invalid (listAzureOpenAIAccounts catch)', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': { stdout: 'INVALID_JSON{{{', exitCode: 0 },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('returns empty when account list returns non-array JSON', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify({ not: 'an array' }),
-        exitCode: 0,
-      },
-    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 403 }));
     expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
   });
 
   it('skips account whose endpoint matches skipEndpoints (normalises trailing slashes)', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([
-          {
-            name: 'myoai',
-            resourceGroup: 'rg1',
-            // endpoint has trailing slash
-            properties: { endpoint: 'https://myoai.openai.azure.com/' },
-          },
-        ]),
-        exitCode: 0,
-      },
-    });
-    // skipEndpoints uses already-normalised value (no trailing slash)
+    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, [
+      { ...AZURE_TEST_ACCOUNT, endpoint: 'https://myoai.openai.azure.com/' },
+    ]);
     const result = await collectAzureOpenAIProviders(
       runner,
       new Set(),
@@ -1238,45 +1154,16 @@ describe('collectAzureOpenAIProviders — error and skip branches', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('skips account with no endpoint', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([{ name: 'myoai', resourceGroup: 'rg1', properties: {} }]),
-        exitCode: 0,
-      },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
+  it.each([
+    ['resource ID', { ...AZURE_TEST_ACCOUNT, id: undefined }],
+    ['endpoint', { ...AZURE_TEST_ACCOUNT, endpoint: undefined }],
+    ['resource group', { ...AZURE_TEST_ACCOUNT, resourceGroup: undefined }],
+  ])('skips accounts missing %s', async (_label, account) => {
+    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, [account]);
+    expect(await collectAzureOpenAIProviders(runner)).toEqual([]);
   });
 
-  it('skips account with no resourceGroup', async () => {
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'TestSub' }), exitCode: 0 },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([
-          { name: 'myoai', properties: { endpoint: 'https://myoai.openai.azure.com' } },
-        ]),
-        exitCode: 0,
-      },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('skips account when deployment list exits non-zero (listAzureOpenAIDeployments early return)', async () => {
-    const runner = makeAzureBaseRunner('', {
-      'az cognitiveservices account deployment list': { stdout: '', exitCode: 1 },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('skips account when deployment list JSON is invalid (listAzureOpenAIDeployments catch)', async () => {
-    const runner = makeAzureBaseRunner('', {
-      'az cognitiveservices account deployment list': { stdout: 'BAD_JSON{', exitCode: 0 },
-    });
-    expect(await collectAzureOpenAIProviders(runner)).toHaveLength(0);
-  });
-
-  it('skips account when all deployments are non-chat (chatDeployments.length === 0)', async () => {
+  it('skips account when all deployments are non-chat', async () => {
     const runner = makeAzureBaseRunner(
       JSON.stringify([
         {
@@ -1290,15 +1177,15 @@ describe('collectAzureOpenAIProviders — error and skip branches', () => {
 
   it('defers key validation until the detected provider is used', async () => {
     const calls: string[] = [];
-    const baseRunner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, {
-      'az cognitiveservices account keys list': { stdout: 'NOT_JSON{', exitCode: 0 },
-    });
+    const baseRunner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT);
     const runner: CommandRunner = async (command, args) => {
       calls.push(`${command} ${args.join(' ')}`);
       return baseRunner(command, args);
     };
     expect(await collectAzureOpenAIProviders(runner)).toHaveLength(1);
-    expect(calls.some(call => call.includes('account keys list'))).toBe(false);
+    expect(calls).toEqual([
+      'az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv',
+    ]);
   });
 });
 
@@ -1311,29 +1198,39 @@ describe('refreshAzureOpenAIKey — extra paths', () => {
     const calls: string[] = [];
     const runner: CommandRunner = async (command, args) => {
       calls.push(`${command} ${args.join(' ')}`);
-      return { stdout: JSON.stringify({ key1: 'key' }), exitCode: 0 };
+      return { stdout: 'token', exitCode: 0 };
     };
-    expect(await refreshAzureOpenAIKey('rg', 'account', runner, 'subscription')).toBe('key');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ key1: 'key' }), { status: 200 }));
+    expect(await refreshAzureOpenAIKey('rg name', 'account/name', runner, 'subscription')).toBe(
+      'key'
+    );
     expect(calls).toEqual([
-      'az cognitiveservices account keys list -g rg -n account --subscription subscription -o json',
+      'az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv',
     ]);
+    expect(fetchSpy.mock.calls[0][0]).toContain(
+      '/subscriptions/subscription/resourceGroups/rg%20name/providers/Microsoft.CognitiveServices/accounts/account%2Fname/listKeys'
+    );
   });
 
   it('returns key2 when key1 is absent', async () => {
     const runner = mockCommandRunner({
-      'az cognitiveservices account keys list': {
-        stdout: JSON.stringify({ key2: 'secondary-key' }),
-        exitCode: 0,
-      },
+      'az account get-access-token': { stdout: 'token', exitCode: 0 },
     });
-    expect(await refreshAzureOpenAIKey('rg1', 'account1', runner)).toBe('secondary-key');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ key2: 'secondary-key' }), { status: 200 })
+    );
+    expect(await refreshAzureOpenAIKey('rg1', 'account1', runner, 'sub')).toBe('secondary-key');
   });
 
-  it('returns null when keys response JSON is invalid', async () => {
+  it('returns null when the subscription or key API is unavailable', async () => {
     const runner = mockCommandRunner({
-      'az cognitiveservices account keys list': { stdout: 'NOT_VALID_JSON{{{', exitCode: 0 },
+      'az account get-access-token': { stdout: 'token', exitCode: 0 },
     });
     expect(await refreshAzureOpenAIKey('rg1', 'account1', runner)).toBeNull();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 403 }));
+    expect(await refreshAzureOpenAIKey('rg1', 'account1', runner, 'sub')).toBeNull();
   });
 });
 
@@ -1385,9 +1282,7 @@ describe('detectProviders — Azure and Copilot result building', () => {
 
   it('skips all Azure detection when "azure" is in dismissedKeys', async () => {
     fetchSpy.mockRejectedValueOnce(new Error('no ollama'));
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'MySub' }), exitCode: 0 },
-    });
+    const runner = mockCommandRunner({});
     const result = await detectProviders([], ['azure'], runner);
     expect(result.filter(p => p.providerId === 'azure')).toHaveLength(0);
   });
@@ -1424,29 +1319,9 @@ describe('detectProviders — Azure and Copilot result building', () => {
 
   it('skips Azure provider with empty accountName when azure is already configured', async () => {
     fetchSpy.mockRejectedValueOnce(new Error('no ollama'));
-    // Account list returns an account whose name is empty string
-    const runner = mockCommandRunner({
-      'az account show': { stdout: JSON.stringify({ name: 'MySub' }), exitCode: 0 },
-      'az cognitiveservices account list': {
-        stdout: JSON.stringify([
-          {
-            name: '',
-            resourceGroup: 'rg1',
-            properties: { endpoint: 'https://blank.openai.azure.com' },
-          },
-        ]),
-        exitCode: 0,
-      },
-      'az cognitiveservices account deployment list': {
-        stdout: CHAT_DEPLOYMENT_STDOUT,
-        exitCode: 0,
-      },
-      'az cognitiveservices account keys list': {
-        stdout: JSON.stringify({ key1: 'k' }),
-        exitCode: 0,
-      },
-    });
-    // Existing azure provider present → the empty-accountName result should be skipped
+    const runner = makeAzureBaseRunner(CHAT_DEPLOYMENT_STDOUT, [
+      { ...AZURE_TEST_ACCOUNT, name: '' },
+    ]);
     const existing = [{ providerId: 'azure', config: {} }];
     const result = await detectProviders(existing, [], runner);
     expect(result.filter(p => p.providerId === 'azure')).toHaveLength(0);

--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
@@ -123,7 +123,11 @@ async function runDetectCommand(
 
   const controller = new AbortController();
   const abort = () => controller.abort();
-  signal?.addEventListener('abort', abort, { once: true });
+  if (signal?.aborted) {
+    abort();
+  } else {
+    signal?.addEventListener('abort', abort, { once: true });
+  }
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([

--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
@@ -43,9 +43,14 @@ export interface CommandRunResult {
  *
  * @param command - Executable name.
  * @param args - Command arguments.
+ * @param signal - Optional cancellation signal for terminating supported command runners.
  * @returns Captured standard output and process exit code.
  */
-export type CommandRunner = (command: string, args: string[]) => Promise<CommandRunResult>;
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  signal?: AbortSignal
+) => Promise<CommandRunResult>;
 
 /** A provider discovered by the auto-detection system. */
 export interface DetectedProvider {
@@ -102,29 +107,42 @@ const COMMAND_TIMEOUT_MS = 15_000;
  * @param command - Executable name, which must be `gh` or `az`.
  * @param args - Command arguments passed to the runner.
  * @param commandRunner - Host-provided command executor.
+ * @param signal - Optional parent signal propagated to the command runner.
  * @returns Runner result, or an empty result with exit code `-1` when rejected or failed.
  */
 async function runDetectCommand(
   command: string,
   args: string[],
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  signal?: AbortSignal
 ): Promise<CommandRunResult> {
   if (!ALLOWED_COMMANDS.has(command)) {
     console.warn(`[ai-assistant auto-detect] command "${command}" not in allowlist — skipping`);
     return { stdout: '', exitCode: -1 };
   }
 
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signal?.addEventListener('abort', abort, { once: true });
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
-      commandRunner(command, args),
-      new Promise<CommandRunResult>((_resolve, reject) =>
-        setTimeout(() => reject(new Error(`Command "${command}" timed out`)), COMMAND_TIMEOUT_MS)
+      commandRunner(command, args, controller.signal),
+      new Promise<CommandRunResult>(
+        (_resolve, reject) =>
+          (timeoutId = setTimeout(() => {
+            controller.abort();
+            reject(new Error(`Command "${command}" timed out`));
+          }, COMMAND_TIMEOUT_MS))
       ),
     ]);
     return result;
   } catch (e) {
     console.debug(`[ai-assistant auto-detect] command "${command}" failed:`, e);
     return { stdout: '', exitCode: -1 };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', abort);
   }
 }
 
@@ -380,8 +398,10 @@ export async function detectOllamaProvider(): Promise<DetectedProvider | null> {
 // Azure OpenAI detection via `az` CLI
 // ---------------------------------------------------------------------------
 
-/** Azure OpenAI account returned by the Azure CLI. */
+/** Azure OpenAI account returned by Azure Management APIs or the Azure CLI fallback. */
 interface AzureOpenAIAccount {
+  /** Azure resource ID. */
+  id?: string;
   /** Azure resource name. */
   name: string;
   /** Optional account properties. */
@@ -391,9 +411,56 @@ interface AzureOpenAIAccount {
   };
   /** Resource group containing the account. */
   resourceGroup?: string;
+  /** Subscription containing the account. */
+  subscriptionId?: string;
 }
 
-/** Azure OpenAI deployment returned by the Azure CLI. */
+/** Azure account with the fields required for deployment discovery. */
+type DiscoverableAzureOpenAIAccount = AzureOpenAIAccount & {
+  properties: { endpoint: string };
+  resourceGroup: string;
+};
+
+/** Azure subscription returned by the Azure CLI session. */
+interface AzureSubscription {
+  /** Subscription ID used to scope resource commands. */
+  id?: string;
+}
+
+/** Maximum number of concurrent Azure deployment-list commands. */
+const AZURE_DEPLOYMENT_CONCURRENCY = 8;
+
+/** Account row projected by the Azure Resource Graph query. */
+interface AzureResourceGraphAccount {
+  /** Azure resource ID. */
+  id?: string;
+  /** Azure resource name. */
+  name: string;
+  /** Resource group containing the account. */
+  resourceGroup?: string;
+  /** Subscription containing the account. */
+  subscriptionId?: string;
+  /** Azure AI service endpoint. */
+  endpoint?: string;
+}
+
+/** Azure Resource Graph REST response envelope. */
+interface AzureResourceGraphResponse {
+  /** Accounts in the current page. */
+  data?: AzureResourceGraphAccount[];
+  /** Opaque token used to request the next page. */
+  $skipToken?: string;
+}
+
+/** Azure Resource Manager list response envelope. */
+interface AzureManagementListResponse<T> {
+  /** Resources in the current page. */
+  value?: T[];
+  /** Absolute URL for the next page. */
+  nextLink?: string;
+}
+
+/** Azure OpenAI deployment returned by Azure Management APIs or the Azure CLI fallback. */
 interface AzureOpenAIDeployment {
   /** Deployment name used by Azure OpenAI requests. */
   name: string;
@@ -404,7 +471,7 @@ interface AzureOpenAIDeployment {
       /** Underlying model name. */
       name?: string;
     };
-    /** Capability flags represented as Azure CLI strings. */
+    /** Capability flags represented as Azure response strings. */
     capabilities?: Record<string, string>;
   };
 }
@@ -435,12 +502,12 @@ function isChatDeployment(deployment: AzureOpenAIDeployment): boolean {
 }
 
 /**
- * Checks Azure CLI login state and extracts an account label.
+ * Checks Azure CLI login state and extracts the active subscription ID.
  *
  * @param commandRunner - Host-provided command executor.
- * @returns Account name, user name, `Azure`, or `null` when unavailable or invalid.
+ * @returns Active subscription metadata, or `null` when unavailable or invalid.
  */
-async function checkAzureLogin(commandRunner: CommandRunner): Promise<string | null> {
+async function checkAzureLogin(commandRunner: CommandRunner): Promise<AzureSubscription | null> {
   const { stdout, exitCode } = await runDetectCommand(
     'az',
     ['account', 'show', '-o', 'json'],
@@ -449,21 +516,194 @@ async function checkAzureLogin(commandRunner: CommandRunner): Promise<string | n
   if (exitCode !== 0 || !stdout) return null;
   try {
     const account = JSON.parse(stdout);
-    return account.name || account.user?.name || 'Azure';
+    return { id: account.id };
   } catch {
     return null;
   }
 }
 
 /**
+ * Lists enabled subscriptions, falling back to the active subscription.
+ *
+ * @param activeSubscription - Subscription returned by `az account show`.
+ * @param commandRunner - Host-provided command executor.
+ * @returns Enabled subscriptions, or the active subscription when listing fails.
+ */
+async function listAzureSubscriptions(
+  activeSubscription: AzureSubscription,
+  commandRunner: CommandRunner
+): Promise<AzureSubscription[]> {
+  const { stdout, exitCode } = await runDetectCommand(
+    'az',
+    ['account', 'list', '--query', "[?state=='Enabled'].{id:id,name:name}", '-o', 'json'],
+    commandRunner
+  );
+  if (exitCode === 0 && stdout) {
+    try {
+      const subscriptions: AzureSubscription[] = JSON.parse(stdout);
+      if (Array.isArray(subscriptions) && subscriptions.length > 0) return subscriptions;
+    } catch {
+      // Fall through to the active subscription.
+    }
+  }
+  return [activeSubscription];
+}
+
+/**
+ * Obtains an Azure Resource Manager token from the authenticated Azure CLI session.
+ *
+ * @param commandRunner - Host-provided command executor.
+ * @returns ARM bearer token, or `null` when authentication is unavailable.
+ */
+async function getAzureManagementToken(commandRunner: CommandRunner): Promise<string | null> {
+  const { stdout, exitCode } = await runDetectCommand(
+    'az',
+    [
+      'account',
+      'get-access-token',
+      '--resource',
+      'https://management.azure.com/',
+      '--query',
+      'accessToken',
+      '-o',
+      'tsv',
+    ],
+    commandRunner
+  );
+  if (exitCode !== 0) return null;
+  const token = stdout.trim();
+  return token || null;
+}
+
+/**
+ * Discovers Azure OpenAI and Foundry accounts through the Resource Graph REST API.
+ *
+ * @param token - ARM bearer token.
+ * @param subscriptions - Subscription IDs included in the query.
+ * @returns Accounts from Resource Graph, or `null` when the API is unavailable.
+ */
+async function listAzureOpenAIAccountsWithResourceGraphApi(
+  token: string,
+  subscriptions: string[]
+): Promise<AzureOpenAIAccount[] | null> {
+  const query = [
+    'Resources',
+    "| where type =~ 'microsoft.cognitiveservices/accounts'",
+    "| where kind in~ ('OpenAI', 'AIServices')",
+    '| project id, name, resourceGroup, subscriptionId, endpoint=tostring(properties.endpoint)',
+    '| order by name asc',
+  ].join(' ');
+  const accounts: AzureOpenAIAccount[] = [];
+  let skipToken: string | undefined;
+  do {
+    try {
+      const response = await fetch(
+        'https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            subscriptions,
+            query,
+            options: {
+              resultFormat: 'objectArray',
+              $top: 1000,
+              ...(skipToken ? { $skipToken: skipToken } : {}),
+            },
+          }),
+        }
+      );
+      if (!response.ok) return null;
+      const page: AzureResourceGraphResponse = await response.json();
+      if (!Array.isArray(page.data)) return null;
+      accounts.push(
+        ...page.data.map(account => ({
+          id: account.id,
+          name: account.name,
+          resourceGroup: account.resourceGroup,
+          subscriptionId: account.subscriptionId,
+          properties: { endpoint: account.endpoint },
+        }))
+      );
+      skipToken = page.$skipToken;
+    } catch {
+      return null;
+    }
+  } while (skipToken);
+  return accounts;
+}
+
+/**
+ * Lists deployments for one Azure account through the ARM REST API.
+ *
+ * @param account - Azure account with a resource ID.
+ * @param token - ARM bearer token.
+ * @param signal - Optional cancellation signal.
+ * @returns Parsed deployments, or `null` when the API is unavailable.
+ */
+async function listAzureOpenAIDeploymentsWithApi(
+  account: DiscoverableAzureOpenAIAccount,
+  token: string,
+  signal?: AbortSignal
+): Promise<AzureOpenAIDeployment[] | null> {
+  if (!account.id) return null;
+  const deployments: AzureOpenAIDeployment[] = [];
+  let url:
+    | string
+    | undefined = `https://management.azure.com${account.id}/deployments?api-version=2023-05-01`;
+  try {
+    while (url) {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal,
+      });
+      if (!response.ok) return null;
+      const page: AzureManagementListResponse<AzureOpenAIDeployment> = await response.json();
+      if (!Array.isArray(page.value)) return null;
+      deployments.push(...page.value);
+      url = page.nextLink;
+    }
+    return deployments;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Maps items in bounded concurrent batches while preserving input order.
+ *
+ * @param items - Items to process.
+ * @param concurrency - Maximum operations started at once.
+ * @param mapper - Async item mapper.
+ * @returns Mapped values in input order.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let offset = 0; offset < items.length; offset += concurrency) {
+    results.push(...(await Promise.all(items.slice(offset, offset + concurrency).map(mapper))));
+  }
+  return results;
+}
+
+/**
  * Lists Azure cognitive-service accounts of kind `OpenAI` or `AIServices`.
  *
  * @param commandRunner - Host-provided command executor.
+ * @param subscriptionId - Optional subscription used to scope the command.
  * @returns Parsed account array, or an empty array on command or JSON failure.
  */
 async function listAzureOpenAIAccounts(
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  subscriptionId?: string
 ): Promise<AzureOpenAIAccount[]> {
+  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
   const { stdout, exitCode } = await runDetectCommand(
     'az',
     [
@@ -472,6 +712,7 @@ async function listAzureOpenAIAccounts(
       'list',
       '--query',
       "[?kind=='OpenAI' || kind=='AIServices']",
+      ...subscriptionArgs,
       '-o',
       'json',
     ],
@@ -480,7 +721,7 @@ async function listAzureOpenAIAccounts(
   if (exitCode !== 0 || !stdout) return [];
   try {
     const accounts: AzureOpenAIAccount[] = JSON.parse(stdout);
-    return Array.isArray(accounts) ? accounts : [];
+    return Array.isArray(accounts) ? accounts.map(account => ({ ...account, subscriptionId })) : [];
   } catch {
     return [];
   }
@@ -492,13 +733,18 @@ async function listAzureOpenAIAccounts(
  * @param resourceGroup - Resource group containing the account.
  * @param accountName - Azure account resource name.
  * @param commandRunner - Host-provided command executor.
+ * @param subscriptionId - Optional subscription used to scope the command.
+ * @param signal - Optional cancellation signal for the deployment query.
  * @returns Parsed deployment array, or an empty array on command or JSON failure.
  */
 async function listAzureOpenAIDeployments(
   resourceGroup: string,
   accountName: string,
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  subscriptionId?: string,
+  signal?: AbortSignal
 ): Promise<AzureOpenAIDeployment[]> {
+  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
   const { stdout, exitCode } = await runDetectCommand(
     'az',
     [
@@ -510,10 +756,12 @@ async function listAzureOpenAIDeployments(
       resourceGroup,
       '-n',
       accountName,
+      ...subscriptionArgs,
       '-o',
       'json',
     ],
-    commandRunner
+    commandRunner,
+    signal
   );
   if (exitCode !== 0 || !stdout) return [];
   try {
@@ -530,13 +778,16 @@ async function listAzureOpenAIDeployments(
  * @param resourceGroup - Resource group containing the account.
  * @param accountName - Azure account resource name.
  * @param commandRunner - Host-provided command executor.
+ * @param subscriptionId - Optional subscription used to scope the command.
  * @returns Primary key, secondary key, or `null` when unavailable or invalid.
  */
 async function getAzureOpenAIKey(
   resourceGroup: string,
   accountName: string,
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  subscriptionId?: string
 ): Promise<string | null> {
+  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
   const { stdout, exitCode } = await runDetectCommand(
     'az',
     [
@@ -548,6 +799,7 @@ async function getAzureOpenAIKey(
       resourceGroup,
       '-n',
       accountName,
+      ...subscriptionArgs,
       '-o',
       'json',
     ],
@@ -576,6 +828,87 @@ function normaliseEndpoint(url: string): string {
   return s;
 }
 
+/** Returns the stable scoped identity of an Azure account when metadata is complete. */
+function azureAccountIdentity(account: {
+  name?: string;
+  resourceGroup?: string;
+  subscriptionId?: string;
+}): string | null {
+  if (!account.name || !account.resourceGroup || !account.subscriptionId) return null;
+  return [account.subscriptionId, account.resourceGroup, account.name]
+    .map(value => value.toLowerCase())
+    .join('/');
+}
+
+/**
+ * Checks whether an Azure account has usable identity and endpoint metadata.
+ *
+ * @param account - Account to validate.
+ * @param skipAccountNames - Exact account names to omit.
+ * @param skipEndpoints - Normalized endpoint URLs to omit.
+ * @param skipAccountIdentities - Subscription-scoped account identities to omit.
+ * @returns Whether the account can be checked for chat deployments.
+ */
+function isDiscoverableAzureAccount(
+  account: AzureOpenAIAccount,
+  skipAccountNames: ReadonlySet<string>,
+  skipEndpoints: ReadonlySet<string>,
+  skipAccountIdentities: ReadonlySet<string>
+): account is DiscoverableAzureOpenAIAccount {
+  if (skipAccountNames.has(account.name)) return false;
+  const identity = azureAccountIdentity(account);
+  if (identity && skipAccountIdentities.has(identity)) return false;
+  const endpoint = account.properties?.endpoint;
+  if (!endpoint || !account.resourceGroup) return false;
+  return !skipEndpoints.has(normaliseEndpoint(endpoint));
+}
+
+/**
+ * Detects the first chat deployment for one Azure account.
+ *
+ * @param account - Account with endpoint and resource-group metadata.
+ * @param commandRunner - Host-provided command executor.
+ * @param managementToken - Optional ARM token used for direct deployment API calls.
+ * @param signal - Optional cancellation signal for deployment discovery.
+ * @returns A detected provider, or `null` when the account has no chat deployment.
+ */
+async function detectAzureAccountProvider(
+  account: DiscoverableAzureOpenAIAccount,
+  commandRunner: CommandRunner,
+  managementToken?: string,
+  signal?: AbortSignal
+): Promise<DetectedProvider | null> {
+  const apiDeployments = managementToken
+    ? await listAzureOpenAIDeploymentsWithApi(account, managementToken, signal)
+    : null;
+  const deployments =
+    apiDeployments ??
+    (await listAzureOpenAIDeployments(
+      account.resourceGroup,
+      account.name,
+      commandRunner,
+      account.subscriptionId,
+      signal
+    ));
+  const deployment = deployments.find(isChatDeployment);
+  if (!deployment) return null;
+
+  return {
+    providerId: 'azure',
+    source: 'Azure CLI',
+    config: {
+      apiKey: AZ_CLI_AUTH_SENTINEL,
+      azResourceGroup: account.resourceGroup,
+      azAccountName: account.name,
+      ...(account.subscriptionId ? { azSubscriptionId: account.subscriptionId } : {}),
+      endpoint: account.properties.endpoint,
+      deploymentName: deployment.name,
+      model: deployment.properties?.model?.name || 'gpt-4',
+    },
+    displayName: `Azure OpenAI (${account.name})`,
+  };
+}
+
 /**
  * Collects all valid Azure OpenAI accounts with chat-capable deployments.
  *
@@ -585,61 +918,136 @@ function normaliseEndpoint(url: string): string {
  * @param commandRunner - Host-provided command executor.
  * @param skipAccountNames - Exact Azure account names to omit.
  * @param skipEndpoints - Normalized endpoint URLs to omit.
+ * @param skipAccountIdentities - Subscription-scoped account identities to omit.
+ * @param maxResults - Maximum providers to return before ending deployment discovery.
  * @returns Detected Azure providers with endpoints, deployments, and account metadata.
  */
-export async function collectAzureOpenAIProviders(
+async function collectAzureOpenAIProvidersWithLimit(
   commandRunner: CommandRunner,
-  skipAccountNames: ReadonlySet<string> = new Set(),
-  skipEndpoints: ReadonlySet<string> = new Set()
+  skipAccountNames: ReadonlySet<string>,
+  skipEndpoints: ReadonlySet<string>,
+  skipAccountIdentities: ReadonlySet<string>,
+  maxResults = Number.POSITIVE_INFINITY
 ): Promise<DetectedProvider[]> {
-  const subscriptionName = await checkAzureLogin(commandRunner);
-  if (!subscriptionName) return [];
+  const activeSubscription = await checkAzureLogin(commandRunner);
+  if (!activeSubscription) return [];
 
-  const accounts = await listAzureOpenAIAccounts(commandRunner);
+  const subscriptions = await listAzureSubscriptions(activeSubscription, commandRunner);
+  const subscriptionIds = subscriptions.flatMap(subscription =>
+    subscription.id ? [subscription.id] : []
+  );
+  const managementToken = await getAzureManagementToken(commandRunner);
+  let accounts =
+    managementToken && subscriptionIds.length > 0
+      ? await listAzureOpenAIAccountsWithResourceGraphApi(managementToken, subscriptionIds)
+      : null;
+  if (accounts === null) {
+    accounts = (
+      await mapWithConcurrency(subscriptions, AZURE_DEPLOYMENT_CONCURRENCY, subscription =>
+        listAzureOpenAIAccounts(commandRunner, subscription.id)
+      )
+    ).flat();
+  }
   if (accounts.length === 0) return [];
 
   const results: DetectedProvider[] = [];
 
-  for (const account of accounts) {
-    if (skipAccountNames.has(account.name)) continue;
+  const eligibleAccounts = accounts.filter(account =>
+    isDiscoverableAzureAccount(account, skipAccountNames, skipEndpoints, skipAccountIdentities)
+  );
 
-    const endpoint = account.properties?.endpoint;
-    const resourceGroup = account.resourceGroup;
-
-    if (endpoint && skipEndpoints.has(normaliseEndpoint(endpoint))) continue;
-    if (!endpoint || !resourceGroup) continue;
-
-    const deployments = await listAzureOpenAIDeployments(
-      resourceGroup,
-      account.name,
-      commandRunner
+  for (let offset = 0; offset < eligibleAccounts.length; offset += AZURE_DEPLOYMENT_CONCURRENCY) {
+    const batch = eligibleAccounts.slice(offset, offset + AZURE_DEPLOYMENT_CONCURRENCY);
+    if (maxResults === 1) {
+      const controllers = batch.map(() => new AbortController());
+      const provider = await new Promise<DetectedProvider | null>(resolve => {
+        let remaining = batch.length;
+        let settled = false;
+        batch.forEach((account, index) => {
+          void detectAzureAccountProvider(
+            account,
+            commandRunner,
+            managementToken ?? undefined,
+            controllers[index].signal
+          )
+            .then(result => {
+              if (result && !settled) {
+                settled = true;
+                controllers.forEach(controller => controller.abort());
+                resolve(result);
+              }
+            })
+            .catch(() => undefined)
+            .finally(() => {
+              remaining -= 1;
+              if (remaining === 0 && !settled) resolve(null);
+            });
+        });
+      });
+      if (provider) return [provider];
+      continue;
+    }
+    const detectedBatch = await Promise.all(
+      batch.map(account =>
+        detectAzureAccountProvider(account, commandRunner, managementToken ?? undefined)
+      )
     );
-    const chatDeployments = deployments.filter(isChatDeployment);
-    if (chatDeployments.length === 0) continue;
-
-    const deployment = chatDeployments[0];
-    const deploymentName = deployment.name;
-    const modelName = deployment.properties?.model?.name || 'gpt-4';
-
-    const apiKey = await getAzureOpenAIKey(resourceGroup, account.name, commandRunner);
-    if (!apiKey) continue;
-
-    results.push({
-      providerId: 'azure',
-      source: 'Azure CLI',
-      config: {
-        apiKey: AZ_CLI_AUTH_SENTINEL,
-        azResourceGroup: resourceGroup,
-        azAccountName: account.name,
-        endpoint,
-        deploymentName,
-        model: modelName,
-      },
-      displayName: `Azure OpenAI (${account.name})`,
-    });
+    results.push(...detectedBatch.filter(result => result !== null));
+    if (results.length >= maxResults) return results.slice(0, maxResults);
   }
 
   return results;
+}
+
+/**
+ * Collects Azure OpenAI and Foundry providers across accessible subscriptions.
+ *
+ * @param commandRunner - Host-provided command executor.
+ * @param skipAccountNames - Exact Azure account names to omit.
+ * @param skipEndpoints - Normalized endpoint URLs to omit.
+ * @param skipAccountIdentities - Subscription-scoped account identities to omit.
+ * @returns Detected providers with their first chat-capable deployment.
+ */
+export async function collectAzureOpenAIProviders(
+  commandRunner: CommandRunner,
+  skipAccountNames: ReadonlySet<string> = new Set(),
+  skipEndpoints: ReadonlySet<string> = new Set(),
+  skipAccountIdentities: ReadonlySet<string> = new Set()
+): Promise<DetectedProvider[]> {
+  return collectAzureOpenAIProvidersWithLimit(
+    commandRunner,
+    skipAccountNames,
+    skipEndpoints,
+    skipAccountIdentities
+  );
+}
+
+/**
+ * Detects the first usable Azure OpenAI or Foundry provider.
+ *
+ * @param commandRunner - Host-provided command executor.
+ * @param skipAccountNames - Exact Azure account names to omit.
+ * @param skipEndpoints - Normalized endpoint URLs to omit.
+ * @param skipAccountIdentities - Subscription-scoped account identities to omit.
+ * @returns First detected provider, or `null` when none is usable.
+ */
+export async function detectAzureOpenAIProvider(
+  commandRunner: CommandRunner,
+  skipAccountNames: ReadonlySet<string> = new Set(),
+  skipEndpoints: ReadonlySet<string> = new Set(),
+  skipAccountIdentities: ReadonlySet<string> = new Set()
+): Promise<DetectedProvider | null> {
+  return (
+    (
+      await collectAzureOpenAIProvidersWithLimit(
+        commandRunner,
+        skipAccountNames,
+        skipEndpoints,
+        skipAccountIdentities,
+        1
+      )
+    )[0] ?? null
+  );
 }
 
 /**
@@ -649,14 +1057,16 @@ export async function collectAzureOpenAIProviders(
  * @param resourceGroup - Resource group containing the account.
  * @param accountName - Azure account resource name.
  * @param commandRunner - Host-provided command executor.
+ * @param subscriptionId - Optional subscription used to scope the key lookup.
  * @returns Primary or secondary account key, or `null` when unavailable.
  */
 export async function refreshAzureOpenAIKey(
   resourceGroup: string,
   accountName: string,
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  subscriptionId?: string
 ): Promise<string | null> {
-  return getAzureOpenAIKey(resourceGroup, accountName, commandRunner);
+  return getAzureOpenAIKey(resourceGroup, accountName, commandRunner, subscriptionId);
 }
 
 /**
@@ -667,6 +1077,14 @@ export async function refreshAzureOpenAIKey(
  * @returns Account-specific Azure key when available, otherwise the provider ID.
  */
 export function dismissalKey(provider: DetectedProvider): string {
+  const identity = azureAccountIdentity({
+    name: provider.config.azAccountName as string | undefined,
+    resourceGroup: provider.config.azResourceGroup as string | undefined,
+    subscriptionId: provider.config.azSubscriptionId as string | undefined,
+  });
+  if (provider.providerId === 'azure' && identity) {
+    return `azure-account:${identity}`;
+  }
   if (provider.providerId === 'azure' && provider.config.azAccountName) {
     return `azure:${provider.config.azAccountName}`;
   }
@@ -713,10 +1131,28 @@ export async function detectProviders(
   const dismissedAzureNames = new Set(
     dismissedKeys.filter(k => k.startsWith('azure:')).map(k => k.slice('azure:'.length))
   );
+  const dismissedAzureIdentities = new Set(
+    dismissedKeys
+      .filter(k => k.startsWith('azure-account:'))
+      .map(k => k.slice('azure-account:'.length).toLowerCase())
+  );
   const savedAzureAccountNames = new Set(
     existingProviders
-      .filter(p => p.providerId === 'azure' && p.config?.azAccountName)
+      .filter(
+        p => p.providerId === 'azure' && p.config?.azAccountName && !p.config?.azSubscriptionId
+      )
       .map(p => p.config.azAccountName as string)
+  );
+  const savedAzureIdentities = new Set(
+    existingProviders.flatMap(provider => {
+      if (provider.providerId !== 'azure') return [];
+      const identity = azureAccountIdentity({
+        name: provider.config.azAccountName as string | undefined,
+        resourceGroup: provider.config.azResourceGroup as string | undefined,
+        subscriptionId: provider.config.azSubscriptionId as string | undefined,
+      });
+      return identity ? [identity] : [];
+    })
   );
   const savedAzureEndpoints = new Set(
     existingProviders
@@ -731,19 +1167,23 @@ export async function detectProviders(
       .map(k => normaliseEndpoint(k.slice('azure-endpoint:'.length))),
   ]);
 
-  const [copilot, azureAll, ollama] = await Promise.all([
+  const [copilot, azure, ollama] = await Promise.all([
     skipCopilot || !commandRunner ? Promise.resolve(null) : detectCopilotProvider(commandRunner),
     skipAllAzure || !commandRunner
-      ? Promise.resolve([])
-      : collectAzureOpenAIProviders(commandRunner, skipAzureAccountNames, skipAzureEndpoints),
+      ? Promise.resolve(null)
+      : detectAzureOpenAIProvider(
+          commandRunner,
+          skipAzureAccountNames,
+          skipAzureEndpoints,
+          new Set([...savedAzureIdentities, ...dismissedAzureIdentities])
+        ),
     skipLocal ? Promise.resolve(null) : detectOllamaProvider(),
   ]);
 
   if (copilot) detected.push(copilot);
-  for (const a of azureAll) {
-    const accountName = a.config?.azAccountName as string | undefined;
-    if (!accountName && hasProvider('azure')) continue;
-    detected.push(a);
+  if (azure) {
+    const accountName = azure.config?.azAccountName as string | undefined;
+    if (accountName || !hasProvider('azure')) detected.push(azure);
   }
   if (ollama) detected.push(ollama);
 

--- a/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/detectProvider.ts
@@ -399,10 +399,10 @@ export async function detectOllamaProvider(): Promise<DetectedProvider | null> {
 }
 
 // ---------------------------------------------------------------------------
-// Azure OpenAI detection via `az` CLI
+// Azure OpenAI detection via Azure Management APIs
 // ---------------------------------------------------------------------------
 
-/** Azure OpenAI account returned by Azure Management APIs or the Azure CLI fallback. */
+/** Azure OpenAI account returned by Azure Management APIs. */
 interface AzureOpenAIAccount {
   /** Azure resource ID. */
   id?: string;
@@ -421,14 +421,17 @@ interface AzureOpenAIAccount {
 
 /** Azure account with the fields required for deployment discovery. */
 type DiscoverableAzureOpenAIAccount = AzureOpenAIAccount & {
+  id: string;
   properties: { endpoint: string };
   resourceGroup: string;
 };
 
-/** Azure subscription returned by the Azure CLI session. */
+/** Azure subscription returned by Azure Resource Manager. */
 interface AzureSubscription {
-  /** Subscription ID used to scope resource commands. */
+  /** Subscription resource path. */
   id?: string;
+  /** Subscription GUID used by Azure Resource Graph. */
+  subscriptionId?: string;
 }
 
 /** Maximum number of concurrent Azure deployment-list commands. */
@@ -464,7 +467,7 @@ interface AzureManagementListResponse<T> {
   nextLink?: string;
 }
 
-/** Azure OpenAI deployment returned by Azure Management APIs or the Azure CLI fallback. */
+/** Azure OpenAI deployment returned by Azure Management APIs. */
 interface AzureOpenAIDeployment {
   /** Deployment name used by Azure OpenAI requests. */
   name: string;
@@ -506,54 +509,6 @@ function isChatDeployment(deployment: AzureOpenAIDeployment): boolean {
 }
 
 /**
- * Checks Azure CLI login state and extracts the active subscription ID.
- *
- * @param commandRunner - Host-provided command executor.
- * @returns Active subscription metadata, or `null` when unavailable or invalid.
- */
-async function checkAzureLogin(commandRunner: CommandRunner): Promise<AzureSubscription | null> {
-  const { stdout, exitCode } = await runDetectCommand(
-    'az',
-    ['account', 'show', '-o', 'json'],
-    commandRunner
-  );
-  if (exitCode !== 0 || !stdout) return null;
-  try {
-    const account = JSON.parse(stdout);
-    return { id: account.id };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Lists enabled subscriptions, falling back to the active subscription.
- *
- * @param activeSubscription - Subscription returned by `az account show`.
- * @param commandRunner - Host-provided command executor.
- * @returns Enabled subscriptions, or the active subscription when listing fails.
- */
-async function listAzureSubscriptions(
-  activeSubscription: AzureSubscription,
-  commandRunner: CommandRunner
-): Promise<AzureSubscription[]> {
-  const { stdout, exitCode } = await runDetectCommand(
-    'az',
-    ['account', 'list', '--query', "[?state=='Enabled'].{id:id,name:name}", '-o', 'json'],
-    commandRunner
-  );
-  if (exitCode === 0 && stdout) {
-    try {
-      const subscriptions: AzureSubscription[] = JSON.parse(stdout);
-      if (Array.isArray(subscriptions) && subscriptions.length > 0) return subscriptions;
-    } catch {
-      // Fall through to the active subscription.
-    }
-  }
-  return [activeSubscription];
-}
-
-/**
  * Obtains an Azure Resource Manager token from the authenticated Azure CLI session.
  *
  * @param commandRunner - Host-provided command executor.
@@ -577,6 +532,32 @@ async function getAzureManagementToken(commandRunner: CommandRunner): Promise<st
   if (exitCode !== 0) return null;
   const token = stdout.trim();
   return token || null;
+}
+
+/**
+ * Lists subscriptions available to the authenticated Azure identity.
+ *
+ * @param token - ARM bearer token.
+ * @returns Accessible subscriptions, or `null` when the API is unavailable.
+ */
+async function listAzureSubscriptionsWithApi(token: string): Promise<AzureSubscription[] | null> {
+  const subscriptions: AzureSubscription[] = [];
+  let url: string | undefined = 'https://management.azure.com/subscriptions?api-version=2022-12-01';
+  try {
+    while (url) {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) return null;
+      const page: AzureManagementListResponse<AzureSubscription> = await response.json();
+      if (!Array.isArray(page.value)) return null;
+      subscriptions.push(...page.value);
+      url = page.nextLink;
+    }
+    return subscriptions;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -677,148 +658,6 @@ async function listAzureOpenAIDeploymentsWithApi(
 }
 
 /**
- * Maps items in bounded concurrent batches while preserving input order.
- *
- * @param items - Items to process.
- * @param concurrency - Maximum operations started at once.
- * @param mapper - Async item mapper.
- * @returns Mapped values in input order.
- */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  concurrency: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = [];
-  for (let offset = 0; offset < items.length; offset += concurrency) {
-    results.push(...(await Promise.all(items.slice(offset, offset + concurrency).map(mapper))));
-  }
-  return results;
-}
-
-/**
- * Lists Azure cognitive-service accounts of kind `OpenAI` or `AIServices`.
- *
- * @param commandRunner - Host-provided command executor.
- * @param subscriptionId - Optional subscription used to scope the command.
- * @returns Parsed account array, or an empty array on command or JSON failure.
- */
-async function listAzureOpenAIAccounts(
-  commandRunner: CommandRunner,
-  subscriptionId?: string
-): Promise<AzureOpenAIAccount[]> {
-  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
-  const { stdout, exitCode } = await runDetectCommand(
-    'az',
-    [
-      'cognitiveservices',
-      'account',
-      'list',
-      '--query',
-      "[?kind=='OpenAI' || kind=='AIServices']",
-      ...subscriptionArgs,
-      '-o',
-      'json',
-    ],
-    commandRunner
-  );
-  if (exitCode !== 0 || !stdout) return [];
-  try {
-    const accounts: AzureOpenAIAccount[] = JSON.parse(stdout);
-    return Array.isArray(accounts) ? accounts.map(account => ({ ...account, subscriptionId })) : [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Lists deployments for one Azure cognitive-services account.
- *
- * @param resourceGroup - Resource group containing the account.
- * @param accountName - Azure account resource name.
- * @param commandRunner - Host-provided command executor.
- * @param subscriptionId - Optional subscription used to scope the command.
- * @param signal - Optional cancellation signal for the deployment query.
- * @returns Parsed deployment array, or an empty array on command or JSON failure.
- */
-async function listAzureOpenAIDeployments(
-  resourceGroup: string,
-  accountName: string,
-  commandRunner: CommandRunner,
-  subscriptionId?: string,
-  signal?: AbortSignal
-): Promise<AzureOpenAIDeployment[]> {
-  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
-  const { stdout, exitCode } = await runDetectCommand(
-    'az',
-    [
-      'cognitiveservices',
-      'account',
-      'deployment',
-      'list',
-      '-g',
-      resourceGroup,
-      '-n',
-      accountName,
-      ...subscriptionArgs,
-      '-o',
-      'json',
-    ],
-    commandRunner,
-    signal
-  );
-  if (exitCode !== 0 || !stdout) return [];
-  try {
-    const deployments: AzureOpenAIDeployment[] = JSON.parse(stdout);
-    return Array.isArray(deployments) ? deployments : [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Retrieves an Azure OpenAI account key.
- *
- * @param resourceGroup - Resource group containing the account.
- * @param accountName - Azure account resource name.
- * @param commandRunner - Host-provided command executor.
- * @param subscriptionId - Optional subscription used to scope the command.
- * @returns Primary key, secondary key, or `null` when unavailable or invalid.
- */
-async function getAzureOpenAIKey(
-  resourceGroup: string,
-  accountName: string,
-  commandRunner: CommandRunner,
-  subscriptionId?: string
-): Promise<string | null> {
-  const subscriptionArgs = subscriptionId ? ['--subscription', subscriptionId] : [];
-  const { stdout, exitCode } = await runDetectCommand(
-    'az',
-    [
-      'cognitiveservices',
-      'account',
-      'keys',
-      'list',
-      '-g',
-      resourceGroup,
-      '-n',
-      accountName,
-      ...subscriptionArgs,
-      '-o',
-      'json',
-    ],
-    commandRunner
-  );
-  if (exitCode !== 0 || !stdout) return null;
-  try {
-    const keys = JSON.parse(stdout);
-    return keys.key1 || keys.key2 || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Normalise an Azure OpenAI endpoint URL for comparison.
  *
  * @param url - Endpoint URL to normalize.
@@ -863,7 +702,7 @@ function isDiscoverableAzureAccount(
   const identity = azureAccountIdentity(account);
   if (identity && skipAccountIdentities.has(identity)) return false;
   const endpoint = account.properties?.endpoint;
-  if (!endpoint || !account.resourceGroup) return false;
+  if (!account.id || !endpoint || !account.resourceGroup) return false;
   return !skipEndpoints.has(normaliseEndpoint(endpoint));
 }
 
@@ -878,22 +717,11 @@ function isDiscoverableAzureAccount(
  */
 async function detectAzureAccountProvider(
   account: DiscoverableAzureOpenAIAccount,
-  commandRunner: CommandRunner,
-  managementToken?: string,
+  managementToken: string,
   signal?: AbortSignal
 ): Promise<DetectedProvider | null> {
-  const apiDeployments = managementToken
-    ? await listAzureOpenAIDeploymentsWithApi(account, managementToken, signal)
-    : null;
-  const deployments =
-    apiDeployments ??
-    (await listAzureOpenAIDeployments(
-      account.resourceGroup,
-      account.name,
-      commandRunner,
-      account.subscriptionId,
-      signal
-    ));
+  const deployments = await listAzureOpenAIDeploymentsWithApi(account, managementToken, signal);
+  if (!deployments) return null;
   const deployment = deployments.find(isChatDeployment);
   if (!deployment) return null;
 
@@ -933,25 +761,19 @@ async function collectAzureOpenAIProvidersWithLimit(
   skipAccountIdentities: ReadonlySet<string>,
   maxResults = Number.POSITIVE_INFINITY
 ): Promise<DetectedProvider[]> {
-  const activeSubscription = await checkAzureLogin(commandRunner);
-  if (!activeSubscription) return [];
-
-  const subscriptions = await listAzureSubscriptions(activeSubscription, commandRunner);
-  const subscriptionIds = subscriptions.flatMap(subscription =>
-    subscription.id ? [subscription.id] : []
-  );
   const managementToken = await getAzureManagementToken(commandRunner);
-  let accounts =
-    managementToken && subscriptionIds.length > 0
-      ? await listAzureOpenAIAccountsWithResourceGraphApi(managementToken, subscriptionIds)
-      : null;
-  if (accounts === null) {
-    accounts = (
-      await mapWithConcurrency(subscriptions, AZURE_DEPLOYMENT_CONCURRENCY, subscription =>
-        listAzureOpenAIAccounts(commandRunner, subscription.id)
-      )
-    ).flat();
-  }
+  if (!managementToken) return [];
+  const subscriptions = await listAzureSubscriptionsWithApi(managementToken);
+  if (!subscriptions) return [];
+  const subscriptionIds = subscriptions.flatMap(subscription =>
+    subscription.subscriptionId ? [subscription.subscriptionId] : []
+  );
+  if (subscriptionIds.length === 0) return [];
+  const accounts = await listAzureOpenAIAccountsWithResourceGraphApi(
+    managementToken,
+    subscriptionIds
+  );
+  if (!accounts) return [];
   if (accounts.length === 0) return [];
 
   const results: DetectedProvider[] = [];
@@ -968,12 +790,7 @@ async function collectAzureOpenAIProvidersWithLimit(
         let remaining = batch.length;
         let settled = false;
         batch.forEach((account, index) => {
-          void detectAzureAccountProvider(
-            account,
-            commandRunner,
-            managementToken ?? undefined,
-            controllers[index].signal
-          )
+          void detectAzureAccountProvider(account, managementToken, controllers[index].signal)
             .then(result => {
               if (result && !settled) {
                 settled = true;
@@ -992,9 +809,7 @@ async function collectAzureOpenAIProvidersWithLimit(
       continue;
     }
     const detectedBatch = await Promise.all(
-      batch.map(account =>
-        detectAzureAccountProvider(account, commandRunner, managementToken ?? undefined)
-      )
+      batch.map(account => detectAzureAccountProvider(account, managementToken))
     );
     results.push(...detectedBatch.filter(result => result !== null));
     if (results.length >= maxResults) return results.slice(0, maxResults);
@@ -1070,7 +885,28 @@ export async function refreshAzureOpenAIKey(
   commandRunner: CommandRunner,
   subscriptionId?: string
 ): Promise<string | null> {
-  return getAzureOpenAIKey(resourceGroup, accountName, commandRunner, subscriptionId);
+  if (!subscriptionId) return null;
+  const managementToken = await getAzureManagementToken(commandRunner);
+  if (!managementToken) return null;
+  const accountId = `/subscriptions/${encodeURIComponent(
+    subscriptionId
+  )}/resourceGroups/${encodeURIComponent(
+    resourceGroup
+  )}/providers/Microsoft.CognitiveServices/accounts/${encodeURIComponent(accountName)}`;
+  try {
+    const response = await fetch(
+      `https://management.azure.com${accountId}/listKeys?api-version=2023-05-01`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${managementToken}` },
+      }
+    );
+    if (!response.ok) return null;
+    const keys = await response.json();
+    return keys.key1 || keys.key2 || null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/plugins/ai-assistant/packages/ai-common/src/providers/savedConfigs.test.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/savedConfigs.test.ts
@@ -511,6 +511,26 @@ describe('ProviderConfigManager', () => {
       expect(isSameStoredConfig(a, b)).toBe(false);
     });
 
+    it('does not match same-named Azure accounts in different subscriptions', () => {
+      const a = {
+        providerId: 'azure',
+        config: {
+          azAccountName: 'shared',
+          azResourceGroup: 'rg',
+          azSubscriptionId: 'subscription-a',
+        },
+      };
+      const b = {
+        providerId: 'azure',
+        config: {
+          azAccountName: 'shared',
+          azResourceGroup: 'rg',
+          azSubscriptionId: 'subscription-b',
+        },
+      };
+      expect(isSameStoredConfig(a, b)).toBe(false);
+    });
+
     it('does not match an Azure account to a legacy config missing account metadata', () => {
       const account = {
         providerId: 'azure',
@@ -588,6 +608,28 @@ describe('ProviderConfigManager', () => {
         apiKey: '__AZ_CLI_AUTH__',
         azAccountName: 'account2',
         model: 'gpt-4o',
+      });
+      expect(result.providers).toHaveLength(2);
+    });
+
+    it('keeps same-named Azure accounts in different subscriptions distinct', () => {
+      const existing = {
+        providers: [
+          {
+            id: 'azure-1',
+            providerId: 'azure',
+            config: {
+              azAccountName: 'shared',
+              azResourceGroup: 'rg',
+              azSubscriptionId: 'subscription-a',
+            },
+          },
+        ],
+      };
+      const result = saveProviderConfig(existing, 'azure', {
+        azAccountName: 'shared',
+        azResourceGroup: 'rg',
+        azSubscriptionId: 'subscription-b',
       });
       expect(result.providers).toHaveLength(2);
     });

--- a/plugins/ai-assistant/packages/ai-common/src/providers/savedConfigs.ts
+++ b/plugins/ai-assistant/packages/ai-common/src/providers/savedConfigs.ts
@@ -37,6 +37,10 @@ export interface ProviderSettings {
   endpoint?: string;
   /** Azure account label used to match CLI-authenticated configs. */
   azAccountName?: string;
+  /** Azure resource group containing a CLI-detected account. */
+  azResourceGroup?: string;
+  /** Azure subscription containing a CLI-detected account. */
+  azSubscriptionId?: string;
   /** Additional provider-specific persisted setting. */
   [key: string]: unknown;
 }
@@ -82,6 +86,8 @@ function normalizeProviderSettings(value: Record<string, unknown>): ProviderSett
     'deploymentName',
     'endpoint',
     'azAccountName',
+    'azResourceGroup',
+    'azSubscriptionId',
   ] as const;
   stringFields.forEach(fieldName => {
     if (settings[fieldName] !== undefined && typeof settings[fieldName] !== 'string') {
@@ -138,10 +144,14 @@ export function isSameStoredConfig(a: StoredProviderConfig, b: StoredProviderCon
   if (a.id && b.id) return a.id === b.id;
   if (a.providerId !== b.providerId) return false;
   if (a.providerId === 'azure' && (a.config.azAccountName || b.config.azAccountName)) {
+    const bothScoped = Boolean(a.config.azSubscriptionId && b.config.azSubscriptionId);
     return Boolean(
       a.config.azAccountName &&
         b.config.azAccountName &&
-        a.config.azAccountName === b.config.azAccountName
+        a.config.azAccountName === b.config.azAccountName &&
+        (!bothScoped ||
+          (a.config.azSubscriptionId === b.config.azSubscriptionId &&
+            a.config.azResourceGroup === b.config.azResourceGroup))
     );
   }
   if (a.config.apiKey && b.config.apiKey) return a.config.apiKey === b.config.apiKey;
@@ -272,10 +282,14 @@ export function saveProviderConfig(
       providerId === 'azure' &&
       (p.config.azAccountName || config.azAccountName)
     ) {
+      const bothScoped = Boolean(p.config.azSubscriptionId && config.azSubscriptionId);
       return Boolean(
         p.config.azAccountName &&
           config.azAccountName &&
-          p.config.azAccountName === config.azAccountName
+          p.config.azAccountName === config.azAccountName &&
+          (!bothScoped ||
+            (p.config.azSubscriptionId === config.azSubscriptionId &&
+              p.config.azResourceGroup === config.azResourceGroup))
       );
     }
     // If displayName is provided, use that as primary matching criteria

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/AutoDetectProvider/AutoDetectProvider.test.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/AutoDetectProvider/AutoDetectProvider.test.tsx
@@ -91,7 +91,7 @@ describe('useAutoDetect', () => {
     expect(result.current.showDetectedDialog).toBe(true);
   });
 
-  it('clears stale results when a later run finds nothing', async () => {
+  it('opens an empty result dialog when a later run finds nothing', async () => {
     detectionMocks.detectProviders
       .mockResolvedValueOnce(sampleDetectedProviders)
       .mockResolvedValueOnce([]);
@@ -102,7 +102,7 @@ describe('useAutoDetect', () => {
     await act(async () => result.current.handleAutoDetect());
 
     expect(result.current.detectedProviders).toEqual([]);
-    expect(result.current.showDetectedDialog).toBe(false);
+    expect(result.current.showDetectedDialog).toBe(true);
   });
 
   it('ignores an older detection result that finishes last', async () => {

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/AutoDetectProvider/AutoDetectProvider.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/AutoDetectProvider/AutoDetectProvider.tsx
@@ -114,7 +114,7 @@ export function useAutoDetect({
     try {
       const existing = savedConfigs?.providers || [];
       const detected = await detectProviders(existing, dismissedProviders, commandRunner ?? null);
-      if (run === detectionRun.current && detected.length > 0) {
+      if (run === detectionRun.current) {
         setDetectedProviders(detected);
         setShowDetectedDialog(true);
       }

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/DetectedProvidersDialog/DetectedProvidersDialog.test.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/DetectedProvidersDialog/DetectedProvidersDialog.test.tsx
@@ -88,13 +88,15 @@ it('resets choices when the same provider list is reopened', async () => {
   );
 });
 
-it('renders an empty provider list with add disabled', () => {
+it('renders an actionable empty provider result', () => {
   const { rerender } = render(
     <DetectedProvidersDialog {...multipleProvidersArgs} detectedProviders={[]} open={false} />
   );
   expect(screen.queryByRole('dialog')).toBeNull();
   rerender(<DetectedProvidersDialog {...multipleProvidersArgs} detectedProviders={[]} open />);
-  expect(screen.getByRole('button', { name: 'Add Selected (0)' })).toHaveProperty('disabled', true);
+  expect(screen.getByText(/No AI providers were detected/)).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
+  expect(screen.queryByRole('button', { name: /Add Selected/ })).toBeNull();
 });
 
 it('disables add when nothing is selected and supports re-selection', () => {

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/DetectedProvidersDialog/DetectedProvidersDialog.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/DetectedProvidersDialog/DetectedProvidersDialog.tsx
@@ -108,9 +108,13 @@ export default function DetectedProvidersDialog({
       <DialogTitle>{t('Detected AI Providers')}</DialogTitle>
       <DialogContent>
         <DialogContentText sx={{ mb: 2 }}>
-          {t(
-            'The following AI providers were automatically detected on your system. Select which ones you would like to add.'
-          )}
+          {providerCount > 0
+            ? t(
+                'The following AI providers were automatically detected on your system. Select which ones you would like to add.'
+              )
+            : t(
+                'No AI providers were detected. Check that the provider CLI is installed and authenticated, then try again.'
+              )}
         </DialogContentText>
         {detectedProviders.map((provider, index) => {
           const providerInfo = getProviderById(provider.providerId);
@@ -138,12 +142,18 @@ export default function DetectedProvidersDialog({
         })}
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleDismiss} color="inherit">
-          {t('Not Now')}
-        </Button>
-        <Button onClick={handleAdd} variant="contained" disabled={selected.size === 0}>
-          {t('Add Selected ({{count}})', { count: selected.size })}
-        </Button>
+        {providerCount === 0 ? (
+          <Button onClick={onClose}>{t('Close')}</Button>
+        ) : (
+          <>
+            <Button onClick={handleDismiss} color="inherit">
+              {t('Not Now')}
+            </Button>
+            <Button onClick={handleAdd} variant="contained" disabled={selected.size === 0}>
+              {t('Add Selected ({{count}})', { count: selected.size })}
+            </Button>
+          </>
+        )}
       </DialogActions>
     </DialogSlot>
   );

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/ModelSelector/ModelSelector.test.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/ModelSelector/ModelSelector.test.tsx
@@ -33,6 +33,7 @@ import {
 } from './ModelSelector.stories';
 
 const detectionMocks = vi.hoisted(() => ({
+  detectAzureOpenAIProvider: vi.fn(),
   detectCopilotChatModels: vi.fn(),
   detectCopilotProvider: vi.fn(),
   detectGhCliAvailable: vi.fn(),
@@ -89,6 +90,7 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  detectionMocks.detectAzureOpenAIProvider.mockResolvedValue(null);
   detectionMocks.detectCopilotChatModels.mockResolvedValue([]);
   detectionMocks.detectCopilotProvider.mockResolvedValue(null);
   detectionMocks.detectGhCliAvailable.mockResolvedValue(true);
@@ -477,6 +479,56 @@ describe('ModelSelector configuration editing', () => {
     expect(screen.queryByRole('button', { name: 'Auto Detect' })).toBeNull();
   });
 
+  it('auto-detects Azure OpenAI settings in the provider form', async () => {
+    detectionMocks.detectAzureOpenAIProvider.mockResolvedValue({
+      providerId: 'azure',
+      source: 'Azure CLI',
+      displayName: 'Azure OpenAI (my-foundry)',
+      config: {
+        apiKey: '__AZ_CLI_AUTH__',
+        endpoint: 'https://my-foundry.cognitiveservices.azure.com/',
+        deploymentName: 'gpt-4.1-deployment',
+        model: 'gpt-4.1',
+        azSubscriptionId: 'foundry-subscription',
+        azResourceGroup: 'foundry-rg',
+        azAccountName: 'my-foundry',
+      },
+    });
+    const azureArgs: ModelSelectorProps = {
+      selectedConfigId: 'azure-primary',
+      selectedProvider: 'azure',
+      config: {},
+      savedConfigs: {
+        termsAccepted: true,
+        providers: [
+          {
+            id: 'azure-primary',
+            providerId: 'azure',
+            displayName: 'Azure OpenAI',
+            config: {},
+          },
+        ],
+      },
+      isConfigView: true,
+      onChange: vi.fn(),
+    };
+
+    renderSelector(azureArgs, { commandRunner });
+    await openEditDialog();
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Detect' }));
+
+    expect(await screen.findByText('Detected and applied provider settings.')).toBeTruthy();
+    expect(detectionMocks.detectAzureOpenAIProvider).toHaveBeenCalledWith(commandRunner);
+    expect(screen.getByDisplayValue('Azure OpenAI (my-foundry)')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue('https://my-foundry.cognitiveservices.azure.com/')
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue('gpt-4.1-deployment')).toBeTruthy();
+    expect(screen.getByDisplayValue('gpt-4.1')).toBeTruthy();
+    expect(detectionMocks.refreshGitHubToken).not.toHaveBeenCalled();
+    expect(detectionMocks.detectCopilotChatModels).not.toHaveBeenCalled();
+  });
+
   it('ignores stale manual detection after closing and opening another provider', async () => {
     let resolveDetection: (value: DetectedProvider | null) => void = () => {};
     detectionMocks.detectCopilotProvider.mockReturnValue(
@@ -514,6 +566,7 @@ describe('ModelSelector configuration editing', () => {
     renderSelector(withCopilotProviderArgs, { commandRunner, onChange });
     await openEditDialog();
     fireEvent.click(screen.getByRole('button', { name: 'Auto Detect' }));
+    expect(screen.getByRole('button', { name: 'Detecting…' })).toBeTruthy();
     fireEvent.change(screen.getByPlaceholderText('Give this configuration a name'), {
       target: { value: 'Keep my name' },
     });

--- a/plugins/ai-assistant/packages/ai-ui/src/components/settings/ModelSelector/ModelSelector.tsx
+++ b/plugins/ai-assistant/packages/ai-ui/src/components/settings/ModelSelector/ModelSelector.tsx
@@ -22,6 +22,7 @@ import {
 } from '@headlamp-k8s/ai-common/providers/catalog';
 import {
   type CommandRunner,
+  detectAzureOpenAIProvider,
   detectCopilotChatModels,
   detectCopilotProvider,
   DetectedProvider,
@@ -272,7 +273,7 @@ function ConfigurationDialog({
   latestConfig.current = config;
   latestConfigName.current = configName;
 
-  const isDetectSupported = providerId === 'copilot';
+  const isDetectSupported = providerId === 'copilot' || providerId === 'azure';
   const detectRequestId = useRef(0);
 
   // Reset detect state when dialog opens/provider changes
@@ -335,6 +336,8 @@ function ConfigurationDialog({
       let detected: DetectedProvider | null = null;
       if (providerId === 'copilot') {
         detected = await detectCopilotProvider(commandRunner);
+      } else if (providerId === 'azure') {
+        detected = await detectAzureOpenAIProvider(commandRunner);
       }
       if (detectRequestId.current !== requestId) return;
       if (detected) {
@@ -357,7 +360,7 @@ function ConfigurationDialog({
           onConfigNameChange(detected.displayName || provider?.name || providerId);
         }
         const detectedApiKey = detected.config.apiKey;
-        if (detected.config.model && detectedApiKey) {
+        if (providerId === 'copilot' && detected.config.model && detectedApiKey) {
           void (async () => {
             try {
               const modelToken =
@@ -749,7 +752,7 @@ function ConfigurationDialog({
             onClick={handleDetect}
             disabled={isDetecting}
           >
-            {isDetecting ? t('Auto Detecting...') : t('Auto Detect')}
+            {isDetecting ? t('Detecting…') : t('Auto Detect')}
           </Button>
         )}
         <Button onClick={onClose} disabled={isDetecting}>

--- a/plugins/ai-assistant/src/components/settings/Settings.tsx
+++ b/plugins/ai-assistant/src/components/settings/Settings.tsx
@@ -157,15 +157,21 @@ export default function Settings() {
   const [commandRunner, setCommandRunner] = React.useState<CommandRunner | null>(null);
   React.useEffect(() => {
     if (typeof pluginRunCommand !== 'undefined') {
-      setCommandRunner(() => async (command: string, args: string[]) => {
+      setCommandRunner(() => async (command: string, args: string[], signal?: AbortSignal) => {
         // pluginRunCommand returns an EventEmitter-like object; convert to
         // the { stdout, exitCode } shape that CommandRunner expects.
         return new Promise<{ stdout: string; exitCode: number }>(resolve => {
           // @ts-ignore — 'gh' and 'az' are narrower than the declared type
           const proc = pluginRunCommand(command as any, args, {});
           let out = '';
+          const abort = () => (proc as typeof proc & { kill?: () => void }).kill?.();
+          if (signal?.aborted) abort();
+          signal?.addEventListener('abort', abort, { once: true });
           proc.stdout.on('data', (d: any) => (out += String(d)));
-          proc.on('exit', (code: number | null) => resolve({ stdout: out, exitCode: code ?? -1 }));
+          proc.on('exit', (code: number | null) => {
+            signal?.removeEventListener('abort', abort);
+            resolve({ stdout: out, exitCode: code ?? -1 });
+          });
         });
       });
     }

--- a/plugins/ai-assistant/src/components/settings/Settings.tsx
+++ b/plugins/ai-assistant/src/components/settings/Settings.tsx
@@ -36,6 +36,7 @@ import {
   HOLMES_SERVICE_NAMESPACE,
   HOLMES_SERVICE_PORT,
 } from '../../holmesClient';
+import { createPluginCommandRunner } from '../../pluginCommandRunner';
 import {
   getAllAvailableTools,
   isToolEnabled,
@@ -157,23 +158,11 @@ export default function Settings() {
   const [commandRunner, setCommandRunner] = React.useState<CommandRunner | null>(null);
   React.useEffect(() => {
     if (typeof pluginRunCommand !== 'undefined') {
-      setCommandRunner(() => async (command: string, args: string[], signal?: AbortSignal) => {
-        // pluginRunCommand returns an EventEmitter-like object; convert to
-        // the { stdout, exitCode } shape that CommandRunner expects.
-        return new Promise<{ stdout: string; exitCode: number }>(resolve => {
-          // @ts-ignore — 'gh' and 'az' are narrower than the declared type
-          const proc = pluginRunCommand(command as any, args, {});
-          let out = '';
-          const abort = () => (proc as typeof proc & { kill?: () => void }).kill?.();
-          if (signal?.aborted) abort();
-          signal?.addEventListener('abort', abort, { once: true });
-          proc.stdout.on('data', (d: any) => (out += String(d)));
-          proc.on('exit', (code: number | null) => {
-            signal?.removeEventListener('abort', abort);
-            resolve({ stdout: out, exitCode: code ?? -1 });
-          });
-        });
-      });
+      setCommandRunner(() =>
+        createPluginCommandRunner((command, args, options) =>
+          pluginRunCommand(command as Parameters<typeof pluginRunCommand>[0], args, options)
+        )
+      );
     }
   }, []);
 

--- a/plugins/ai-assistant/src/modal.tsx
+++ b/plugins/ai-assistant/src/modal.tsx
@@ -100,6 +100,8 @@ interface CommandProcess {
   };
   /** Registers a listener for process exit. */
   on: (event: 'exit', listener: (code: number | null) => void) => void;
+  /** Terminates the command process when supported by the host. */
+  kill?: () => void;
 }
 
 interface HolmesTextEvent {
@@ -136,12 +138,18 @@ export default function AIPrompt(props: {
   const commandRunnerRef = React.useRef<CommandRunner | null>(null);
   React.useEffect(() => {
     if (typeof pluginRunCommand !== 'undefined') {
-      commandRunnerRef.current = (command: string, args: string[]) =>
+      commandRunnerRef.current = (command: string, args: string[], signal?: AbortSignal) =>
         new Promise<{ stdout: string; exitCode: number }>(resolve => {
           const proc = (pluginRunCommand as unknown as PluginCommandRunner)(command, args, {});
           let out = '';
+          const abort = () => proc.kill?.();
+          if (signal?.aborted) abort();
+          signal?.addEventListener('abort', abort, { once: true });
           proc.stdout.on('data', chunk => (out += String(chunk)));
-          proc.on('exit', (code: number | null) => resolve({ stdout: out, exitCode: code ?? -1 }));
+          proc.on('exit', (code: number | null) => {
+            signal?.removeEventListener('abort', abort);
+            resolve({ stdout: out, exitCode: code ?? -1 });
+          });
         });
     }
   }, []);

--- a/plugins/ai-assistant/src/modal.tsx
+++ b/plugins/ai-assistant/src/modal.tsx
@@ -91,18 +91,7 @@ import {
 } from '@headlamp-k8s/ai-common/providers/savedConfigs';
 import { getEnabledToolIds } from '@headlamp-k8s/ai-common/tools/settings/enabledTools';
 import { usePromptWidth } from '@headlamp-k8s/ai-ui/contexts/PromptWidthContext';
-
-interface CommandProcess {
-  /** Standard output stream emitted by the injected command. */
-  stdout: {
-    /** Registers a listener for command output chunks. */
-    on: (event: 'data', listener: (chunk: unknown) => void) => void;
-  };
-  /** Registers a listener for process exit. */
-  on: (event: 'exit', listener: (code: number | null) => void) => void;
-  /** Terminates the command process when supported by the host. */
-  kill?: () => void;
-}
+import { createPluginCommandRunner } from './pluginCommandRunner';
 
 interface HolmesTextEvent {
   /** Streamed message identifier. */
@@ -118,12 +107,6 @@ interface HolmesToolEvent {
   toolCallName?: string;
 }
 
-type PluginCommandRunner = (
-  command: string,
-  args: string[],
-  options: Record<string, unknown>
-) => CommandProcess;
-
 export default function AIPrompt(props: {
   openPopup: boolean;
   setOpenPopup: (open: boolean) => void;
@@ -138,19 +121,9 @@ export default function AIPrompt(props: {
   const commandRunnerRef = React.useRef<CommandRunner | null>(null);
   React.useEffect(() => {
     if (typeof pluginRunCommand !== 'undefined') {
-      commandRunnerRef.current = (command: string, args: string[], signal?: AbortSignal) =>
-        new Promise<{ stdout: string; exitCode: number }>(resolve => {
-          const proc = (pluginRunCommand as unknown as PluginCommandRunner)(command, args, {});
-          let out = '';
-          const abort = () => proc.kill?.();
-          if (signal?.aborted) abort();
-          signal?.addEventListener('abort', abort, { once: true });
-          proc.stdout.on('data', chunk => (out += String(chunk)));
-          proc.on('exit', (code: number | null) => {
-            signal?.removeEventListener('abort', abort);
-            resolve({ stdout: out, exitCode: code ?? -1 });
-          });
-        });
+      commandRunnerRef.current = createPluginCommandRunner((command, args, options) =>
+        pluginRunCommand(command as Parameters<typeof pluginRunCommand>[0], args, options)
+      );
     }
   }, []);
 

--- a/plugins/ai-assistant/src/pluginCommandRunner.test.ts
+++ b/plugins/ai-assistant/src/pluginCommandRunner.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPluginCommandRunner, type PluginCommandProcess } from './pluginCommandRunner';
+
+function createProcess() {
+  let exitListener: ((code: number | null) => void) | undefined;
+  let dataListener: ((chunk: unknown) => void) | undefined;
+  const process: PluginCommandProcess = {
+    stdout: {
+      on: (_event, listener) => {
+        dataListener = listener;
+      },
+    },
+    on: (_event, listener) => {
+      exitListener = listener;
+    },
+    kill: vi.fn(),
+  };
+  return {
+    process,
+    emitData: (chunk: unknown) => dataListener?.(chunk),
+    emitExit: (code: number | null) => exitListener?.(code),
+  };
+}
+
+describe('createPluginCommandRunner', () => {
+  it('collects stdout and resolves on process exit', async () => {
+    const child = createProcess();
+    const runner = createPluginCommandRunner(() => child.process);
+    const resultPromise = runner('az', ['account', 'show']);
+
+    child.emitData('first');
+    child.emitData(' second');
+    child.emitExit(0);
+
+    await expect(resultPromise).resolves.toEqual({ stdout: 'first second', exitCode: 0 });
+  });
+
+  it('kills and resolves immediately when aborted', async () => {
+    const child = createProcess();
+    const runner = createPluginCommandRunner(() => child.process);
+    const controller = new AbortController();
+    const resultPromise = runner('az', ['account', 'list'], controller.signal);
+
+    controller.abort();
+
+    await expect(resultPromise).resolves.toEqual({ stdout: '', exitCode: -1 });
+    expect(child.process.kill).toHaveBeenCalledOnce();
+    child.emitExit(0);
+    await expect(resultPromise).resolves.toEqual({ stdout: '', exitCode: -1 });
+  });
+
+  it('handles a signal that is already aborted', async () => {
+    const child = createProcess();
+    const runCommand = vi.fn(() => child.process);
+    const runner = createPluginCommandRunner(runCommand);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(runner('az', ['account', 'show'], controller.signal)).resolves.toEqual({
+      stdout: '',
+      exitCode: -1,
+    });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/ai-assistant/src/pluginCommandRunner.ts
+++ b/plugins/ai-assistant/src/pluginCommandRunner.ts
@@ -1,0 +1,61 @@
+/** Promise-based command runner with optional cancellation support. */
+export type CancellableCommandRunner = (
+  command: string,
+  args: string[],
+  signal?: AbortSignal
+) => Promise<{ stdout: string; exitCode: number }>;
+
+/** Event-emitting process returned by Headlamp's injected plugin command runner. */
+export interface PluginCommandProcess {
+  /** Captured standard-output stream. */
+  stdout: {
+    /** Registers a standard-output listener. */
+    on: (event: 'data', listener: (chunk: unknown) => void) => void;
+  };
+  /** Registers a process-exit listener. */
+  on: (event: 'exit', listener: (code: number | null) => void) => void;
+  /** Terminates the process when supported by the host. */
+  kill?: () => void;
+}
+
+/** Function that starts a command through Headlamp's injected plugin API. */
+export type PluginRunCommand = (
+  command: string,
+  args: string[],
+  options: Record<string, unknown>
+) => PluginCommandProcess;
+
+/**
+ * Adapts Headlamp's event-emitting command API to the promise-based detector API.
+ *
+ * @param runCommand - Injected Headlamp command launcher.
+ * @returns A command runner that collects stdout and always settles on exit or abort.
+ */
+export function createPluginCommandRunner(runCommand: PluginRunCommand): CancellableCommandRunner {
+  return (command, args, signal) => {
+    if (signal?.aborted) {
+      return Promise.resolve({ stdout: '', exitCode: -1 });
+    }
+
+    return new Promise(resolve => {
+      const process = runCommand(command, args, {});
+      let stdout = '';
+      let settled = false;
+
+      const settle = (exitCode: number): void => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener('abort', abort);
+        resolve({ stdout, exitCode });
+      };
+      const abort = (): void => {
+        process.kill?.();
+        settle(-1);
+      };
+
+      process.stdout.on('data', chunk => (stdout += String(chunk)));
+      process.on('exit', code => settle(code ?? -1));
+      signal?.addEventListener('abort', abort, { once: true });
+    });
+  };
+}

--- a/plugins/ai-assistant/src/resolveRuntimeProviderConfig.test.ts
+++ b/plugins/ai-assistant/src/resolveRuntimeProviderConfig.test.ts
@@ -32,16 +32,24 @@ describe('resolveRuntimeProviderConfig', () => {
       apiKey: AZ_CLI_AUTH_SENTINEL,
       azResourceGroup: 'resource-group',
       azAccountName: 'account',
+      azSubscriptionId: 'subscription-id',
       model: 'deployment',
     });
     const serializedBefore = JSON.stringify(persisted);
+    const refreshAzureOpenAIKey = vi.fn().mockResolvedValue('real-azure-key');
     const runtime = await resolveRuntimeProviderConfig(persisted, {
       commandRunner,
       refreshGitHubToken: vi.fn(),
-      refreshAzureOpenAIKey: vi.fn().mockResolvedValue('real-azure-key'),
+      refreshAzureOpenAIKey,
     });
 
     expect(runtime.apiKey).toBe('real-azure-key');
+    expect(refreshAzureOpenAIKey).toHaveBeenCalledWith(
+      'resource-group',
+      'account',
+      commandRunner,
+      'subscription-id'
+    );
     expect(persisted.apiKey).toBe(AZ_CLI_AUTH_SENTINEL);
     expect(JSON.stringify(persisted)).toBe(serializedBefore);
   });

--- a/plugins/ai-assistant/src/resolveRuntimeProviderConfig.ts
+++ b/plugins/ai-assistant/src/resolveRuntimeProviderConfig.ts
@@ -15,7 +15,8 @@ export interface RuntimeCredentialResolver {
   refreshAzureOpenAIKey: (
     resourceGroup: string,
     accountName: string,
-    runner: CommandRunner
+    runner: CommandRunner,
+    subscriptionId?: string
   ) => Promise<string | null>;
 }
 
@@ -51,13 +52,19 @@ export async function resolveRuntimeProviderConfig(
   if (runtimeConfig.apiKey === AZ_CLI_AUTH_SENTINEL) {
     const resourceGroup = runtimeConfig.azResourceGroup;
     const accountName = runtimeConfig.azAccountName;
+    const subscriptionId = runtimeConfig.azSubscriptionId;
     const freshKey =
       resolver.commandRunner &&
       typeof resourceGroup === 'string' &&
       typeof accountName === 'string' &&
       resourceGroup &&
       accountName
-        ? await resolver.refreshAzureOpenAIKey(resourceGroup, accountName, resolver.commandRunner)
+        ? await resolver.refreshAzureOpenAIKey(
+            resourceGroup,
+            accountName,
+            resolver.commandRunner,
+            typeof subscriptionId === 'string' ? subscriptionId : undefined
+          )
         : null;
     if (!freshKey) {
       throw new Error(


### PR DESCRIPTION
## Summary

- detect Azure OpenAI and Azure AI Foundry accounts across subscriptions
- use only `az account get-access-token` for Azure CLI authentication
- query subscriptions, Azure Resource Graph, deployments, and account keys through Azure HTTPS APIs
- keep API requests paginated and deployment discovery bounded
- defer Azure key retrieval until model use and keep same-named accounts distinct across subscriptions
- add working Azure Auto Detect in the provider form and standardize progress labels to `Detecting…`
- make the main Auto Detect return promptly and show an actionable empty state
- settle command runners immediately on cancellation, including already-aborted signals

## Testing

- `npm --prefix plugins/ai-assistant/packages/ai-common run check` (65 files, 1807 tests)
- `npm --prefix plugins/ai-assistant/packages/ai-ui run check` (54 files, 642 tests)
- `npm --prefix plugins/ai-assistant run check` (49 tests passed, 1 storyshot skipped, plus ai-common checks)
- `npm --prefix plugins/ai-assistant run build`
- `git diff --check`

## Manual verification

The exported detector was exercised against the current Azure CLI session and found an `AIServices` model. Detection and key refresh invoked only `az account get-access-token`; all subscriptions, resources, deployments, and key requests used Azure APIs directly.