### PR TITLE
app: Use AKS desktop icon in system tray

### DIFF
--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BrowserWindow, Menu, nativeImage, Tray } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import { MenuItemConstructorOptions } from 'electron/main';
 import path from 'path';
 
@@ -96,7 +96,7 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
     return false;
   }
 
-  tray.setToolTip('Headlamp');
+  tray.setToolTip(app.name);
   tray.setContextMenu(buildTrayMenu(options, [{ label: 'Loading...', enabled: false }]));
 
   trayUpdateTimeout = setTimeout(() => {
@@ -185,7 +185,7 @@ function buildTrayMenu(
 ): Menu {
   return Menu.buildFromTemplate([
     {
-      label: 'Open Headlamp',
+      label: `Open ${app.name}`,
       click: () => {
         void showWindow(options);
       },
@@ -203,7 +203,7 @@ function buildTrayMenu(
     },
     { type: 'separator' },
     {
-      label: 'About Headlamp',
+      label: `About ${app.name}`,
       click: () => openAboutDialog(options),
     },
     { type: 'separator' },

--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -72,10 +72,10 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
   }
 
   const iconPath = options.isDev
-    ? path.join(__dirname, '..', 'assets', 'tray-icon.png')
-    : path.join(process.resourcesPath, 'assets', 'tray-icon.png');
+    ? path.join(__dirname, '..', '..', 'frontend', 'public', 'favicon-32x32.png')
+    : path.join(process.resourcesPath, 'frontend', 'favicon-32x32.png');
 
-  const trayIcon = nativeImage.createFromPath(iconPath);
+  let trayIcon = nativeImage.createFromPath(iconPath);
   if (trayIcon.isEmpty()) {
     console.error(
       `Failed to load tray icon from path "${iconPath}". System tray will not be created.`
@@ -84,6 +84,7 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
   }
 
   if (process.platform === 'darwin') {
+    trayIcon = trayIcon.resize({ width: 22, height: 22 });
     trayIcon.setTemplateImage(true);
   }
 


### PR DESCRIPTION
This change replaces the Headlamp system tray icon with the AKS Desktop icon. It also preserves native light and dark menu bar rendering on macOS.

Fixes: https://github.com/Azure/aks-desktop/issues/812

### Screenshots

#### Before -> After

<img width="41" height="33" alt="image" src="https://github.com/user-attachments/assets/8908fbe7-fb20-46bf-a628-1c5b2f7e161e" />

<img width="38" height="33" alt="image" src="https://github.com/user-attachments/assets/e017bca5-fe78-42b7-8964-26c5cf155769" />
