### PR TITLE
Use AKS desktop config dir for plugins and kubeconfigs

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -73,7 +73,7 @@ jobs:
           echo "coverage=$testcoverage" >> $GITHUB_ENV
           echo "testcoverage_full_base64=$testcoverage_full_base64" >> $GITHUB_ENV
           echo "cleaning up..."
-          rm ~/.config/Headlamp/kubeconfigs/config
+          rm -f "$HOME/.config/AKS desktop/kubeconfigs/config"
         shell: bash
 
       - name: Run fuzz tests

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -913,6 +913,16 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
     // Directory doesn't exist or is not readable — ignore and continue.
   }
 
+  // Point the backend at AKS Desktop's own plugin directories (rather than the
+  // backend's "Headlamp" defaults) so what it serves matches where the app
+  // installs plugins, keeping them separate from a co-installed Headlamp.
+  serverArgs = serverArgs.concat([
+    '--plugins-dir',
+    defaultPluginsDir(),
+    '--user-plugins-dir',
+    defaultUserPluginsDir(),
+  ]);
+
   serverArgs = serverArgs.concat(flags);
   console.log('arguments passed to backend server', serverArgs);
 

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1008,8 +1008,13 @@ function checkValidPluginFolder(folder: string): boolean {
   return false;
 }
 
+// The per-user config folder name AKS Desktop uses for its plugins and
+// user-plugins, so they do not collide with a co-installed Headlamp. Must stay
+// in sync with the backend (see backend/pkg/config/config.go appConfigDirName).
+const APP_CONFIG_DIR_NAME = 'AKS desktop';
+
 /**
- * Returns the default directory where Headlamp plugins are installed.
+ * Returns the default directory where AKS Desktop plugins are installed.
  * If the data path exists, it is used as the base directory.
  * Otherwise, the config path is used as the base directory.
  * The 'plugins' subdirectory of the base directory is returned.
@@ -1017,7 +1022,7 @@ function checkValidPluginFolder(folder: string): boolean {
  * @returns {string} The path to the default plugins directory.
  */
 export function defaultPluginsDir() {
-  const paths = envPaths('Headlamp', { suffix: '' });
+  const paths = envPaths(APP_CONFIG_DIR_NAME, { suffix: '' });
   const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
   return path.join(configDir, 'plugins');
 }
@@ -1031,7 +1036,7 @@ export function defaultPluginsDir() {
  * @returns {string} The path to the default user-plugins directory.
  */
 export function defaultUserPluginsDir() {
-  const paths = envPaths('Headlamp', { suffix: '' });
+  const paths = envPaths(APP_CONFIG_DIR_NAME, { suffix: '' });
   const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
   return path.join(configDir, 'user-plugins');
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2528,12 +2528,12 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	tempConfigHome := filepath.Join(tempDir, "config-home")
 	if runtime.GOOS == "darwin" {
 		require.NoError(t, os.MkdirAll(
-			filepath.Join(tempConfigHome, "Library", "Application Support", "Headlamp", "kubeconfigs"),
+			filepath.Join(tempConfigHome, "Library", "Application Support", "AKS desktop", "kubeconfigs"),
 			0o750,
 		))
 		t.Cleanup(setEnvForTest(t, "HOME", tempConfigHome))
 	} else {
-		require.NoError(t, os.MkdirAll(filepath.Join(tempConfigHome, "Headlamp", "kubeconfigs"), 0o750))
+		require.NoError(t, os.MkdirAll(filepath.Join(tempConfigHome, "AKS desktop", "kubeconfigs"), 0o750))
 		t.Cleanup(setEnvForTest(t, "XDG_CONFIG_HOME", tempConfigHome))
 	}
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -26,6 +26,10 @@ const (
 	defaultPort       = 4466
 	defaultSessionTTL = 86400 // 24 hours in seconds
 	osWindows         = "windows"
+	// appConfigDirName is the per-user folder for AKS Desktop's kubeconfigs, so
+	// they do not collide with a co-installed Headlamp. (Plugin directories are
+	// instead passed to the backend by the app via --plugins-dir.)
+	appConfigDirName = "AKS desktop"
 )
 
 const (
@@ -465,16 +469,17 @@ func Parse(args []string) (*Config, error) {
 	return &config, nil
 }
 
-// MakeHeadlampKubeConfigsDir returns the default directory to store kubeconfig
-// files of clusters that are loaded in Headlamp.
+// MakeHeadlampKubeConfigsDir returns the default directory (under the AKS
+// Desktop config folder) to store kubeconfig files of clusters that are loaded
+// in the app.
 func MakeHeadlampKubeConfigsDir() (string, error) {
 	userConfigDir, err := os.UserConfigDir()
 	if err == nil {
-		kubeConfigDir := filepath.Join(userConfigDir, "Headlamp", "kubeconfigs")
+		kubeConfigDir := filepath.Join(userConfigDir, appConfigDirName, "kubeconfigs")
 		if runtime.GOOS == osWindows {
 			// golang is wrong for config folder on windows.
 			// This matches env-paths and headlamp-plugin.
-			kubeConfigDir = filepath.Join(userConfigDir, "Headlamp", "Config", "kubeconfigs")
+			kubeConfigDir = filepath.Join(userConfigDir, appConfigDirName, "Config", "kubeconfigs")
 		}
 
 		// Create the directory if it doesn't exist.

--- a/e2e-tests/kubernetes-headlamp-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-ci.yaml
@@ -106,7 +106,7 @@ spec:
         - "-plugins-dir=/build/plugins"
         env:
         - name: KUBECONFIG
-          value: "/home/headlamp/.config/Headlamp/kubeconfigs/config"
+          value: "/home/headlamp/.config/AKS desktop/kubeconfigs/config"
         ports:
         - name: http
           containerPort: 4466
@@ -114,7 +114,7 @@ spec:
         volumeMounts:
         - mountPath: /build/plugins
           name: headlamp-plugins
-        - mountPath: "/home/headlamp/.config/Headlamp/kubeconfigs"
+        - mountPath: "/home/headlamp/.config/AKS desktop/kubeconfigs"
           name: kubeconfig
       nodeSelector:
         'kubernetes.io/os': linux


### PR DESCRIPTION
## Description

## What

Root the default plugins, user-plugins, and kubeconfigs directories at an
`AKS desktop` folder instead of the hardcoded `Headlamp` folder, in both the
Go backend and the Electron app.

## Why

These directories were rooted at `Headlamp`, so AKS Desktop shared them with a
co-installed Headlamp. Using `AKS desktop` (the app's userData folder name)
keeps them specific to AKS Desktop and alongside the app's other config.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

