### PR TITLE
app: Use AKS desktop name in system tray

### DIFF
--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BrowserWindow, Menu, nativeImage, Tray } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import { MenuItemConstructorOptions } from 'electron/main';
 import path from 'path';
 
@@ -95,7 +95,7 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
     return false;
   }
 
-  tray.setToolTip('Headlamp');
+  tray.setToolTip(app.name);
   tray.setContextMenu(buildTrayMenu(options, [{ label: 'Loading...', enabled: false }]));
 
   trayUpdateTimeout = setTimeout(() => {
@@ -184,7 +184,7 @@ function buildTrayMenu(
 ): Menu {
   return Menu.buildFromTemplate([
     {
-      label: 'Open Headlamp',
+      label: `Open ${app.name}`,
       click: () => {
         void showWindow(options);
       },
@@ -202,7 +202,7 @@ function buildTrayMenu(
     },
     { type: 'separator' },
     {
-      label: 'About Headlamp',
+      label: `About ${app.name}`,
       click: () => openAboutDialog(options),
     },
     { type: 'separator' },


### PR DESCRIPTION
This change replaces the hardcoded Headlamp system tray name with the configured application name. It updates the tooltip and menu labels to display AKS desktop.

Fixes: #825 

### Screenshots

#### Before -> After

<img width="173" height="70" alt="Image" src="https://github.com/user-attachments/assets/293bbadd-0f77-4fc8-a85e-2c8676830a51" />

<img width="190" height="71" alt="image" src="https://github.com/user-attachments/assets/7f498744-242c-4155-b002-ace681df5bd5" />