### PR TITLE
app: Allow artifacthub.io external proxy requests

### DIFF
--- a/app/app-build-manifest.json
+++ b/app/app-build-manifest.json
@@ -1,4 +1,5 @@
 {
+  "proxy-urls": ["https://artifacthub.io/*"],
   "plugins": [
     {
       "name": "prometheus",


### PR DESCRIPTION
## What

Add `artifacthub.io` to the `proxy-urls` in `app-build-manifest.json`.

## Why

The backend's `/externalproxy` endpoint only forwards requests to hosts listed in `proxy-urls` (passed to the backend at startup). Without an entry for ArtifactHub, the plugin catalog cannot fetch plugin details, so requests are blocked.

Fixes #831