### PR TITLE
Add Headlamp events for project, settings and plugin views

### DIFF
--- a/plugins/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
+++ b/plugins/ai-assistant/src/components/appbar/HeadlampEventHandler.tsx
@@ -1,6 +1,7 @@
-import { registerHeadlampEventCallback } from '@kinvolk/headlamp-plugin/lib';
-// @todo: this HeadlampEventType import is weird. Maybe fix in headlamp to be better.
-import { DefaultHeadlampEvents as HeadlampEventType } from '@kinvolk/headlamp-plugin/lib/plugin/registry';
+import {
+  DefaultHeadlampEvents as HeadlampEventType,
+  registerHeadlampEventCallback,
+} from '@kinvolk/headlamp-plugin/lib';
 import type { HeadlampEventPayload } from '../../pluginState';
 import { useGlobalState } from '../../pluginState';
 


### PR DESCRIPTION
## What

Two changes:

1. **Bumps the `headlamp` submodule** to pick up the new `HeadlampEvent` types for the project list/details views, project create/delete, the general and cluster settings views, the plugin list/details views, and project details tab changes. See #849.
2. **Fixes the AI Assistant's `DefaultHeadlampEvents` import.**

## The AI Assistant bug

`HeadlampEventHandler.tsx` imported `DefaultHeadlampEvents` from the deep subpath `@kinvolk/headlamp-plugin/lib/plugin/registry`. That subpath is externalised to `globalThis.pluginLib.plugin.registry`, which does not exist at runtime — only the package root `@kinvolk/headlamp-plugin/lib` maps to a defined namespace. The bundled namespace object was therefore `undefined` and every tracker callback threw:

```
TypeError: Cannot read properties of undefined (reading 'DefaultHeadlampEvents')
```

The bug was latent because the affected pages dispatched no events; it surfaced as soon as the new project events started firing. The import now comes from the package root, matching the pattern already used in `plugins/aks-desktop/src/telemetry/setup.ts`.

## Note on the submodule branch

`headlamp` moves to `ashu/project-events`, which is based on the current `headlamp-downstream` tip. This PR should merge after #849.

The downstream-only telemetry allowlist commit that originally accompanied this work was dropped: `TELEMETRY_EVENT_ALLOWLIST` and the App Insights integration no longer exist on `headlamp-downstream`, so there is nothing to opt the new events into.

## Testing

- `npm run tsc` in `headlamp/frontend` — clean
- `npx vitest run src/redux/headlampEventSlice.test.tsx src/plugin/pluginLib.test.ts` — passing
- AI Assistant rebuilt and verified in the running app: the new events dispatch and no longer throw