### PR TITLE
fix: resolve Azure tenant display names for multi-tenant accounts

### DIFF
--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.stories.tsx
@@ -20,6 +20,38 @@ const SAMPLE_TENANTS = [
   { id: 'tenant-2', name: 'Tenant 2' },
 ];
 
+// Realistic multi-tenant data: real GUIDs plus the display names resolved from
+// `az account tenant list`, including a guest tenant that only has a domain.
+const MULTI_TENANTS = [
+  { id: '11111111-1111-1111-1111-111111111111', name: 'Contoso Corporation' },
+  { id: '22222222-2222-2222-2222-222222222222', name: 'Fabrikam Engineering' },
+  { id: '33333333-3333-3333-3333-333333333333', name: 'northwind.onmicrosoft.com' },
+];
+
+const MULTI_TENANT_SUBSCRIPTIONS = [
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    name: 'Contoso Production',
+    state: 'Enabled',
+    tenantId: MULTI_TENANTS[0].id,
+    tenantName: MULTI_TENANTS[0].name,
+  },
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000002',
+    name: 'Fabrikam Shared Services',
+    state: 'Enabled',
+    tenantId: MULTI_TENANTS[1].id,
+    tenantName: MULTI_TENANTS[1].name,
+  },
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000003',
+    name: 'Northwind Guest Access',
+    state: 'Enabled',
+    tenantId: MULTI_TENANTS[2].id,
+    tenantName: MULTI_TENANTS[2].name,
+  },
+];
+
 const SAMPLE_CLUSTERS = [
   {
     name: 'prod-aks-cluster',
@@ -260,4 +292,30 @@ TenantNotSelected.args = {
   tenantInputValue: '',
   selectedSubscription: null,
   subscriptionInputValue: '',
+};
+
+/**
+ * Multi-tenant account with real tenant display names resolved from
+ * `az account tenant list` — each option shows the name above its GUID.
+ * Regression cover for issue #853, where every option showed the GUID twice.
+ */
+export const MultipleTenantsWithNames = Template.bind({});
+MultipleTenantsWithNames.args = {
+  ...baseArgs,
+  tenants: MULTI_TENANTS,
+  selectedTenant: null,
+  tenantInputValue: '',
+  subscriptions: MULTI_TENANT_SUBSCRIPTIONS.filter(s => s.tenantId === MULTI_TENANTS[0].id),
+  selectedSubscription: null,
+  subscriptionInputValue: '',
+};
+
+/**
+ * Multi-tenant account where no display name could be resolved (tenant list
+ * unavailable, e.g. stale login). Options fall back to the GUID, shown once.
+ */
+export const MultipleTenantsUnresolvedNames = Template.bind({});
+MultipleTenantsUnresolvedNames.args = {
+  ...MultipleTenantsWithNames.args,
+  tenants: MULTI_TENANTS.map(tenant => ({ ...tenant, name: tenant.id })),
 };

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.test.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.test.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../CreateAKSProject/components/ClusterConfigurePanel', () => ({
+  ClusterConfigurePanel: () => <div data-testid="cluster-configure-panel" />,
+}));
+
+import RegisterAKSClusterDialogPure, {
+  RegisterAKSClusterDialogPureProps,
+} from './RegisterAKSClusterDialogPure';
+
+const TENANT_A = '11111111-1111-1111-1111-111111111111';
+const TENANT_B = '22222222-2222-2222-2222-222222222222';
+
+const noOp = () => {};
+
+const baseArgs: RegisterAKSClusterDialogPureProps = {
+  open: true,
+  isChecking: false,
+  isLoggedIn: true,
+  loading: false,
+  loadingSubscriptions: false,
+  loadingClusters: false,
+  capabilitiesLoading: false,
+  error: '',
+  success: '',
+  subscriptions: [],
+  selectedSubscription: null,
+  subscriptionInputValue: '',
+  tenants: [],
+  selectedTenant: null,
+  tenantInputValue: '',
+  clusters: [],
+  filteredClusters: [],
+  clusterInputValue: '',
+  selectedCluster: null,
+  capabilities: null,
+  onClose: noOp,
+  onSubscriptionChange: noOp as any,
+  onSubscriptionInputChange: noOp as any,
+  onTenantChange: noOp as any,
+  onTenantInputChange: noOp as any,
+  onClusterChange: noOp as any,
+  onClusterInputChange: noOp as any,
+  onRegister: noOp,
+  onDone: noOp,
+  onDismissError: noOp,
+  onDismissSuccess: noOp,
+  onConfigured: noOp,
+};
+
+/** Open the Tenant dropdown and return its listbox options. */
+async function openTenantDropdown() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox', { name: 'Tenant' }));
+  return within(screen.getByRole('listbox')).getAllByRole('option');
+}
+
+/** Assert the option renders `name` ahead of `id`, not just that both appear. */
+function expectNameBeforeId(option: HTMLElement, name: string, id: string) {
+  const text = option.textContent ?? '';
+  expect(text).toContain(name);
+  expect(text).toContain(id);
+  expect(text.indexOf(name)).toBeLessThan(text.indexOf(id));
+}
+
+describe('RegisterAKSClusterDialogPure tenant options', () => {
+  afterEach(cleanup);
+
+  test('shows the tenant display name above its ID when a name is resolved', async () => {
+    render(
+      <RegisterAKSClusterDialogPure
+        {...baseArgs}
+        tenants={[
+          { id: TENANT_A, name: 'Contoso' },
+          { id: TENANT_B, name: 'Fabrikam' },
+        ]}
+      />
+    );
+
+    const options = await openTenantDropdown();
+
+    expect(options).toHaveLength(2);
+    // The name must render *above* the ID, not merely somewhere in the option.
+    expectNameBeforeId(options[0], 'Contoso', TENANT_A);
+    expectNameBeforeId(options[1], 'Fabrikam', TENANT_B);
+  });
+
+  test('shows an unresolvable tenant GUID once, not twice', async () => {
+    render(
+      <RegisterAKSClusterDialogPure
+        {...baseArgs}
+        tenants={[
+          { id: TENANT_A, name: 'Contoso' },
+          // Name unresolvable upstream — callers fall back to the ID.
+          { id: TENANT_B, name: TENANT_B },
+        ]}
+      />
+    );
+
+    const options = await openTenantDropdown();
+    const guidOccurrences = (options[1].textContent ?? '').split(TENANT_B).length - 1;
+
+    expect(guidOccurrences).toBe(1);
+  });
+
+  test('keeps the tenant dropdown selectable when no name could be resolved', async () => {
+    const onTenantChange = vi.fn();
+    render(
+      <RegisterAKSClusterDialogPure
+        {...baseArgs}
+        tenants={[
+          { id: TENANT_A, name: TENANT_A },
+          { id: TENANT_B, name: TENANT_B },
+        ]}
+        onTenantChange={onTenantChange}
+      />
+    );
+
+    const options = await openTenantDropdown();
+    await userEvent.setup().click(options[1]);
+
+    expect(onTenantChange).toHaveBeenCalledTimes(1);
+    expect(onTenantChange.mock.calls[0][1]).toMatchObject({ id: TENANT_B });
+  });
+
+  test('disables the tenant dropdown when there is only one tenant', () => {
+    render(
+      <RegisterAKSClusterDialogPure
+        {...baseArgs}
+        tenants={[{ id: TENANT_A, name: 'Contoso' }]}
+        selectedTenant={{ id: TENANT_A, name: 'Contoso' }}
+        tenantInputValue="Contoso"
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Tenant' })).toBeDisabled();
+  });
+});

--- a/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
+++ b/plugins/aks-desktop/src/components/AKS/RegisterAKSClusterDialogPure.tsx
@@ -232,9 +232,13 @@ export default function RegisterAKSClusterDialogPure({
                   <li {...props} key={option.id}>
                     <Box>
                       <Typography variant="body1">{option.name}</Typography>
-                      <Typography variant="caption" color="textSecondary">
-                        {option.id}
-                      </Typography>
+                      {/* When the display name is unresolvable the name falls back to the
+                          tenant ID; showing it twice reads as a rendering bug. */}
+                      {option.name !== option.id && (
+                        <Typography variant="caption" color="textSecondary">
+                          {option.id}
+                        </Typography>
+                      )}
                     </Box>
                   </li>
                 )}

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useBasicsStep.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useBasicsStep.ts
@@ -220,11 +220,19 @@ export function useBasicsStep(props: UseBasicsStepInput): UseBasicsStepResult {
   // Derived values
   // ---------------------------------------------------------------------------
 
-  const subscriptionOptions: SearchableSelectOption[] = subscriptions.map(sub => ({
-    value: sub.id,
-    label: sub.name,
-    subtitle: `${t('Tenant')}: ${sub.tenantName} - (${sub.tenant}) • ${t('Status')}: ${sub.status}`,
-  }));
+  const subscriptionOptions: SearchableSelectOption[] = subscriptions.map(sub => {
+    // tenantName is absent for guest/cross-tenant subscriptions, and can equal
+    // the GUID once upstream fallbacks apply — don't render the GUID twice.
+    const tenantLabel =
+      sub.tenantName && sub.tenantName !== sub.tenant
+        ? `${sub.tenantName} - (${sub.tenant})`
+        : sub.tenant;
+    return {
+      value: sub.id,
+      label: sub.name,
+      subtitle: `${t('Tenant')}: ${tenantLabel} • ${t('Status')}: ${sub.status}`,
+    };
+  });
 
   const clusterOptions: SearchableSelectOption[] = clusters.map(cluster => ({
     value: cluster.name,

--- a/plugins/aks-desktop/src/utils/azure/az-subscriptions.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-subscriptions.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunCommandAsync = vi.fn();
+vi.mock('./az-cli-core', () => ({
+  runCommandAsync: (...args: unknown[]) => mockRunCommandAsync(...args),
+  runAzCommand: vi.fn(),
+  debugLog: vi.fn(),
+  isValidGuid: (s: string) => /^[0-9a-f-]{36}$/.test(s),
+  isAzError: () => false,
+  needsRelogin: () => false,
+}));
+
+vi.mock('./az-validation', () => ({
+  isValidAzResourceName: (s: string) => /^[a-zA-Z0-9-_]+$/.test(s),
+}));
+
+import { getSubscriptions } from './az-subscriptions';
+
+const TENANT_A = '11111111-1111-1111-1111-111111111111';
+const TENANT_B = '22222222-2222-2222-2222-222222222222';
+
+/**
+ * Route `az account list` / `az account tenant list` to the supplied payloads.
+ * `tenantResult` may be an Error to simulate the tenant call failing.
+ */
+function mockAz(accounts: any[], tenantResult: any[] | Error = []) {
+  mockRunCommandAsync.mockImplementation(async (cmd: string, args: string[]) => {
+    if (args[0] === 'account' && args[1] === 'tenant' && args[2] === 'list') {
+      if (tenantResult instanceof Error) throw tenantResult;
+      return { stdout: JSON.stringify(tenantResult), stderr: '' };
+    }
+    if (args[0] === 'account' && args[1] === 'list') {
+      return { stdout: JSON.stringify(accounts), stderr: '' };
+    }
+    // Fail loudly rather than silently serving the account payload for a
+    // command these tests never intended to exercise.
+    throw new Error(`Unexpected az command: ${cmd} ${args.join(' ')}`);
+  });
+}
+
+function tenantListCalls() {
+  return mockRunCommandAsync.mock.calls.filter(call => call[1][1] === 'tenant');
+}
+
+describe('getSubscriptions tenant name resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps tenantDisplayName and skips the tenant lookup when every name is present', async () => {
+    mockAz([
+      {
+        id: 'sub-1',
+        name: 'Prod',
+        tenantId: TENANT_A,
+        tenantDisplayName: 'Contoso',
+        state: 'Enabled',
+      },
+    ]);
+
+    const subs = await getSubscriptions();
+
+    expect(subs[0].tenantName).toBe('Contoso');
+    expect(tenantListCalls()).toHaveLength(0);
+  });
+
+  it('resolves a missing tenantDisplayName from az account tenant list', async () => {
+    mockAz(
+      [
+        {
+          id: 'sub-1',
+          name: 'Prod',
+          tenantId: TENANT_A,
+          tenantDisplayName: 'Contoso',
+          state: 'Enabled',
+        },
+        { id: 'sub-2', name: 'Guest', tenantId: TENANT_B, state: 'Enabled' },
+      ],
+      [
+        { tenantId: TENANT_A, displayName: 'Contoso' },
+        { tenantId: TENANT_B, displayName: 'Fabrikam', domains: ['fabrikam.com'] },
+      ]
+    );
+
+    const subs = await getSubscriptions();
+
+    expect(subs.map(s => s.tenantName)).toEqual(['Contoso', 'Fabrikam']);
+    expect(tenantListCalls()).toHaveLength(1);
+  });
+
+  it('falls back to the tenant domain when the tenant has no displayName', async () => {
+    mockAz(
+      [{ id: 'sub-1', name: 'Guest', tenantId: TENANT_B, state: 'Enabled' }],
+      [{ tenantId: TENANT_B, domains: ['fabrikam.onmicrosoft.com'] }]
+    );
+
+    const subs = await getSubscriptions();
+
+    expect(subs[0].tenantName).toBe('fabrikam.onmicrosoft.com');
+  });
+
+  it('leaves tenantName undefined when the tenant list omits the tenant', async () => {
+    mockAz(
+      [{ id: 'sub-1', name: 'Guest', tenantId: TENANT_B, state: 'Enabled' }],
+      [{ tenantId: TENANT_A, displayName: 'Contoso' }]
+    );
+
+    const subs = await getSubscriptions();
+
+    expect(subs[0].tenantName).toBeUndefined();
+    expect(subs[0].tenant).toBe(TENANT_B);
+  });
+
+  it('leaves tenantName undefined when the tenant has neither displayName nor domain', async () => {
+    mockAz(
+      [{ id: 'sub-1', name: 'Guest', tenantId: TENANT_B, state: 'Enabled' }],
+      [{ tenantId: TENANT_B }]
+    );
+
+    const subs = await getSubscriptions();
+
+    expect(subs[0].tenantName).toBeUndefined();
+  });
+
+  it('still returns subscriptions when az account tenant list fails', async () => {
+    mockAz(
+      [{ id: 'sub-1', name: 'Guest', tenantId: TENANT_B, state: 'Enabled' }],
+      new Error('Please run "az login"')
+    );
+
+    const subs = await getSubscriptions();
+
+    expect(subs).toHaveLength(1);
+    expect(subs[0]).toMatchObject({
+      id: 'sub-1',
+      name: 'Guest',
+      tenant: TENANT_B,
+      status: 'Enabled',
+    });
+    expect(subs[0].tenantName).toBeUndefined();
+  });
+
+  it('still throws when az account list itself returns nothing', async () => {
+    mockRunCommandAsync.mockResolvedValue({ stdout: '', stderr: 'az: command failed' });
+
+    await expect(getSubscriptions()).rejects.toThrow('az: command failed');
+  });
+});

--- a/plugins/aks-desktop/src/utils/azure/az-subscriptions.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-subscriptions.ts
@@ -27,13 +27,53 @@ export async function getSubscriptionIds(): Promise<string[]> {
 export async function getSubscriptions(): Promise<any[]> {
   const { stdout, stderr } = await runCommandAsync('az', ['account', 'list', '-o', 'json']);
   if (!stdout) throw new Error(stderr || 'Failed to get subscriptions');
-  return JSON.parse(stdout).map((sub: any) => ({
+  const subscriptions = JSON.parse(stdout).map((sub: any) => ({
     id: sub.id,
     name: sub.name,
     tenant: sub.tenantId,
     tenantName: sub.tenantDisplayName,
     status: sub.state,
   }));
+  return resolveMissingTenantNames(subscriptions);
+}
+
+/**
+ * Fill in `tenantName` for subscriptions where `az account list` omitted
+ * `tenantDisplayName` — which it does for guest and cross-tenant access, leaving
+ * the UI with nothing to show but the tenant GUID.
+ *
+ * Best-effort by design:
+ *  - the extra `az account tenant list` call only runs when a name is actually
+ *    missing, so the common single-tenant case pays no latency;
+ *  - any failure (no active login, tenant not returned, no display name and no
+ *    domain) leaves `tenantName` undefined so callers fall back to the GUID
+ *    exactly as before. Tenant naming must never break subscription loading.
+ */
+async function resolveMissingTenantNames(subscriptions: any[]): Promise<any[]> {
+  if (subscriptions.every(sub => sub.tenantName)) return subscriptions;
+
+  let tenants: any[];
+  try {
+    tenants = await getTenants();
+  } catch (error) {
+    debugLog('Could not resolve tenant display names, falling back to tenant IDs:', error);
+    return subscriptions;
+  }
+
+  const namesById = new Map<string, string>();
+  for (const tenant of tenants) {
+    // getTenants() already falls back to the GUID; treat that as "no name" so we
+    // don't overwrite an absent name with a value that renders identically.
+    const name = tenant.name && tenant.name !== tenant.id ? tenant.name : tenant.domain;
+    if (tenant.id && name) namesById.set(tenant.id, name);
+  }
+  if (namesById.size === 0) return subscriptions;
+
+  return subscriptions.map(sub =>
+    sub.tenantName || !namesById.has(sub.tenant)
+      ? sub
+      : { ...sub, tenantName: namesById.get(sub.tenant) }
+  );
 }
 
 export async function getTenants(): Promise<any[]> {

--- a/plugins/aks-desktop/src/utils/azure/az-subscriptions.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-subscriptions.ts
@@ -69,11 +69,11 @@ async function resolveMissingTenantNames(subscriptions: any[]): Promise<any[]> {
   }
   if (namesById.size === 0) return subscriptions;
 
-  return subscriptions.map(sub =>
-    sub.tenantName || !namesById.has(sub.tenant)
-      ? sub
-      : { ...sub, tenantName: namesById.get(sub.tenant) }
-  );
+  return subscriptions.map(sub => {
+    if (sub.tenantName) return sub;
+    const resolvedName = namesById.get(sub.tenant);
+    return resolvedName ? { ...sub, tenantName: resolvedName } : sub;
+  });
 }
 
 export async function getTenants(): Promise<any[]> {


### PR DESCRIPTION
Fixes #853.

## Problem

For accounts that belong to more than one tenant, the Tenant dropdown in the **Register AKS cluster** dialog showed a GUID as both the option label and the caption underneath it — the same GUID twice.

The UI was already correct. The data was not: `az account list` omits `tenantDisplayName` for many subscriptions (guest and cross-tenant access in particular). That undefined name then flowed through two layers of `|| tenantId` fallbacks, so `name === id` by the time the option rendered.

## Approach

The enrichment goes in `az-subscriptions.ts getSubscriptions()` rather than in the dialog, because the defect has more than one consumer. `useBasicsStep.ts` reads the *raw* field (it never passes through the `aks.ts` fallback), so it was rendering the literal string `undefined - (guid)` for guest subscriptions — the worse of the two symptoms. Fixing at the dialog would have left that in place.

New `resolveMissingTenantNames()` fills the gaps from the already-present-but-unused `getTenants()` (`az account tenant list`), preferring `displayName`, then the tenant's first domain, then leaving the name unset so callers keep their GUID fallback.

### Latency and failure tradeoff

`getSubscriptions()` is a hot path — `az-clusters.ts` calls it before fanning out `az aks list` per subscription — so this is deliberately conservative:

- **Lazy.** The extra `az account tenant list` call fires only when at least one subscription is actually missing a name. Fully-populated single-tenant accounts, which is the common case and the one `az-clusters` usually hits, pay zero added latency.
- **Cannot newly fail.** The call is wrapped in try/catch and returns the original subscriptions on any error. A stale login, a tenant the CLI won't list, or a tenant with neither display name nor domain all degrade to exactly today's GUID behaviour. `getSubscriptions()` gains no new throw path.

## Changes

- `utils/azure/az-subscriptions.ts` — lazy, best-effort tenant name resolution. Deliberately does not overwrite an absent name with `getTenants()`'s own GUID fallback, which would just reintroduce the bug a layer down.
- `components/AKS/RegisterAKSClusterDialogPure.tsx` — suppress the GUID caption when it is identical to the label, so an unresolvable tenant shows its GUID once.
- `components/CreateAKSProject/hooks/useBasicsStep.ts` — render `Name - (guid)` only when a distinct name exists, otherwise the bare GUID. No more `undefined - (guid)`.

No new `t()` strings — the existing `Tenant` / `Status` keys are reused, so no translation update is required.

## Tests

- `az-subscriptions.test.ts` (new, 7 tests): name preserved and tenant call skipped when nothing is missing; missing name resolved; domain fallback; tenant absent from the list; tenant with neither name nor domain; **tenant list throws → subscriptions still returned intact**; `az account list` failure still throws.
- `RegisterAKSClusterDialogPure.test.tsx` (new, 4 tests): name renders *above* the GUID; GUID appears exactly once when unresolvable; **dropdown still selectable in the all-GUID fallback state**; single-tenant disabled case.
- Two new stories: `MultipleTenantsWithNames` (three real GUIDs with resolved names, including a domain-only guest tenant) and `MultipleTenantsUnresolvedNames`.

## Verification

From `plugins/aks-desktop/`, on Node 20:

```
npm run tsc              → Done tsc-ing: "."
npm test -- --run        → 104 files, 1554 tests passed
npm run lint             → Done lint-ing: "."
npm run format -- --check → All matched files use Prettier code style!
```

CodeRabbit review: 0 findings across all 6 files (two minor test-quality findings from the first pass were applied).

## Where to focus review

The tradeoff call in `resolveMissingTenantNames()` — specifically whether gating the extra CLI call on "some name is missing" is the right trigger, and whether the domain-as-fallback-name behaviour is desirable or should be dropped in favour of going straight to the GUID.
