### PR TITLE
aksd: document what telemetry collects and how to turn it off

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,185 @@
+# Telemetry in AKS Desktop
+
+AKS Desktop sends a small amount of pseudonymous usage data to Microsoft to
+help us find crashes, fix broken workflows, and decide what to build next.
+
+This page lists everything that is collected, everything that is not, and how
+to turn it off. It is written to be complete: if something is sent, it is
+described here.
+
+## Turning it off
+
+Telemetry is **on by default**. To turn it off, open **Settings**, find the
+**AKS Desktop** plugin settings, and switch off **Send pseudonymous usage
+data**.
+
+You can change this as often as you like. When you change it, we record that
+the setting changed — see [Telemetry setting changes](#telemetry-setting-changes)
+below — and nothing further.
+
+## What we collect
+
+Everything below is drawn from a fixed list defined in the source code. The
+application cannot send an event or a field that is not on that list — the
+check is enforced in code and covered by tests, not by convention. The list
+lives in
+[`plugins/aks-desktop/src/telemetry/schema.ts`](../plugins/aks-desktop/src/telemetry/schema.ts).
+
+### Session start
+
+Sent once when the application starts.
+
+| Field | Example | Why |
+|---|---|---|
+| `appVersion` | `1.4.0` | Tells us which release a problem belongs to |
+| `headlampVersion` | `0.30.0` | Same, for the underlying Headlamp version |
+| `os` | `darwin`, `win32`, `linux` | Which platforms need attention |
+| `arch` | `x64`, `arm64` | Catches architecture-specific failures |
+| `electronVersion` | `31.2.0` | Narrows down runtime-specific bugs |
+| `locale` | `en`, `de` | Language only, never region or country |
+
+### Cluster shape
+
+Sent once per AKS cluster you open, describing its size and configuration.
+It never contains the cluster's name, resource group, or subscription.
+
+| Field | Example | Why |
+|---|---|---|
+| `provider` | `AKS` | Which platform the cluster runs on |
+| `kubernetesMinor` | `1.29` | Major and minor version only, never the patch |
+| `nodeCountBucket` | `6-20` | A range, never the exact count |
+| `namespaceCountBucket` | `11-50` | A range, never the exact count |
+| `region` | `eastus` | Where capacity problems cluster |
+| `aksTier` | `Standard` | Whether behaviour differs by tier |
+
+Counts are reported as ranges rather than exact numbers specifically so a
+cluster cannot be recognised by its size.
+
+### Feature use
+
+Sent when you use a tracked feature. It records *which* feature and *whether it
+worked* — never what you typed, selected, or named.
+
+| Field | Example | Why |
+|---|---|---|
+| `feature` | `aksd.project-create` | Which feature was used |
+| `status` | `opened`, `started`, `succeeded`, `failed`, `cancelled` | Whether it completed |
+| `resourceKind` | `Pod`, `Deployment` | The *type* of object, never its name |
+
+Tracked features are AKS Desktop workflows — creating and importing projects,
+signing in and out, adding clusters, creating namespaces, deploying, deleting
+projects — and common Kubernetes actions such as viewing logs, opening a
+terminal, scaling, restarting, editing and deleting resources.
+
+`resourceKind` is restricted to a fixed list of standard Kubernetes types.
+Anything outside that list is reported as `CustomResource`, so the name of a
+custom resource definition is never sent.
+
+### Errors
+
+Sent when something fails. It records the *category* of failure, never the
+error message or stack trace.
+
+| Field | Example | Why |
+|---|---|---|
+| `area` | `deploy`, `auth-login` | Which part of the app failed |
+| `errorClass` | `NetworkError`, `TimeoutError`, `PermissionError` | What kind of failure |
+| `phase` | `started`, `failed` | Where in the workflow it happened |
+
+`errorClass` is one of six fixed values. Error text is never inspected to pick
+one, because doing so risks copying message content into the field.
+
+Repeated failures of the same kind are capped, so a persistent error produces a
+handful of events rather than a flood.
+
+### Installed plugins
+
+Sent once per session, describing how many plugins are installed.
+
+| Field | Example | Why |
+|---|---|---|
+| `totalCount` | `4` | How many plugins are installed |
+| `enabledCount` | `3` | How many are turned on |
+| `knownEnabledIds` | `aks-desktop` | Which *Microsoft* plugins are enabled |
+| `thirdPartyCount` | `2` | How many third-party plugins, as a count only |
+
+Third-party plugins are counted but never named.
+
+### Telemetry setting changes
+
+Sent when you turn telemetry on or off.
+
+| Field | Example | Why |
+|---|---|---|
+| `consent` | `granted`, `revoked` | Whether telemetry was switched on or off |
+
+**One event is sent immediately after you turn telemetry off.** We are calling
+that out rather than leaving it to be discovered: it is the only way to know
+how many people opt out, which is something we hold ourselves accountable to.
+It carries the single field above and nothing else, and no further events are
+sent afterwards.
+
+## What we never collect
+
+None of the following is sent, in any event or field:
+
+- **Your name, email address, or Azure account details.**
+- **Cluster, resource group, or subscription names**, or any Azure resource ID.
+- **Namespace, application, or Kubernetes resource names.**
+- **Kubeconfig contents or any credential, token, or secret.**
+- **Application content** — logs, terminal output, YAML, environment
+  variables, or anything from inside your workloads.
+- **Error messages or stack traces.**
+- **File paths or URLs.**
+- **Your IP address.** It is explicitly discarded rather than merely unused.
+- **Your location.** Country, state and city are removed. The cluster's Azure
+  region is collected, which describes where the cluster runs, not where you
+  are.
+- **What you type**, anywhere in the application.
+
+## How this is enforced
+
+Rather than relying on care alone, the application constrains itself:
+
+- **Fixed lists.** Every event name and field name is checked against a list
+  in code. An unlisted field is dropped before sending. Tests pin the exact
+  contents of those lists, so adding one is a deliberate, reviewable change.
+- **Fixed values.** Fields like error class, status and cluster tier accept
+  only known values; anything unrecognised becomes a safe default or is
+  dropped rather than passed through.
+- **Outbound filter.** Every event passes a final check that removes anything
+  resembling a file path, URL, Azure resource ID, or location before it is
+  sent — a backstop in case something slips past the earlier stages.
+- **Ranges instead of counts**, and version numbers truncated to major and
+  minor.
+- **No cookies, no browser storage** used for tracking, and no automatic
+  page-view tracking.
+
+## The installation identifier
+
+A random identifier is generated the first time the application runs and stored
+on your device. It is attached to events so we can tell "one installation used
+this feature ten times" from "ten installations used it once" — a distinction
+that matters for nearly every question we ask of this data.
+
+It is a random value. It is not derived from your name, account, email,
+machine name, or hardware, and it is not combined with anything that could
+identify you. We cannot use it to work out who you are.
+
+If you turn telemetry off, it stops being sent.
+
+## Where the data goes
+
+Data is sent over an encrypted HTTPS connection to Microsoft's Azure
+Application Insights service, batched in the background so it does not slow the
+application down. It is handled under Microsoft's privacy practices, including
+GDPR and CCPA obligations, and is kept only for a limited retention period.
+
+See the [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement).
+
+## Questions
+
+If something here is unclear, or you think the application is sending
+something this page does not describe, please
+[open an issue](https://github.com/Azure/aks-desktop/issues). We would treat
+that as a bug.


### PR DESCRIPTION
## Description

Adds `docs/telemetry.md` — a public, user-facing description of what AKS Desktop's telemetry collects, what it never collects, and how to turn it off.

Closes PRD non-functional requirement #4 (clear documentation of what is collected and why) and makes FAQ #6 true — it promises that a description of telemetry categories is available on GitHub, and until now none existed.

Documentation only. No source changes.

## Type of Change

- [x] Documentation update

## Changes Made

One new file, `docs/telemetry.md`, covering:

- **How to turn it off**, stated up front rather than buried at the end.
- **Every event and field**, in plain language, each with the reason it is collected — session start, cluster shape, feature use, errors, installed plugins, and telemetry setting changes.
- **An explicit list of what is never collected** — account details, cluster/resource-group/subscription names, namespace and resource names, kubeconfig contents, credentials, application content, error messages, stack traces, file paths, URLs, IP address, location, and anything typed into the app.
- **How the guarantees are enforced** — the fixed event and field lists, the outbound filter, closed value vocabularies, count bucketing and version truncation — described as mechanisms rather than promises, because they are checked in code and pinned by tests.
- **What the installation identifier is**, described as a random value not derived from account, machine or hardware. "Pseudonymous" on its own invites the assumption that it is derived from something about the user, which it is not.

## Testing

- [x] Unit tests pass (no code changed; nothing to affect)

`docs/` at the repository root is not covered by lint-staged or the plugin format check, so no formatter applies to this file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Documentation Updates

- [x] User guide updated

## Reviewer Notes

**Please merge this after #871.** The doc describes the telemetry setting-change event, which #871 introduces. Everything else in it is accurate against `main` today. If #871 does not land, delete the "Telemetry setting changes" section and the cross-reference to it in "Turning it off" — that is the only part that depends on it.

**Two things I could not verify headlessly and would like a second pair of eyes on:**

1. **The settings navigation path.** The plugin registers its settings under the plugin name via `registerPluginSettings('aks-desktop', …)`, so I described the route as "open Settings, find the AKS Desktop plugin settings" rather than asserting an exact menu path I could not confirm against a running app. If the real path is more specific — or if a screenshot would serve better than prose — that is worth correcting before this is pointed at from anywhere user-visible.

2. **Whether anything is missing.** I derived the event and field list from `telemetry/schema.ts` and the `track*` functions rather than from any existing document, so the risk is omission rather than error. The claim this document makes is that it is *complete* — if you know of anything sent that is not described here, that is the bug to report.

**Where this is aimed.** Privacy and legal review will ask for exactly this document, so it is written to be handed over without a covering explanation. That drove two choices worth flagging: the single consent event sent immediately *after* a user opts out is called out explicitly rather than omitted, since that is the disclosure a reader would most reasonably feel misled by if they found it in the code instead; and the enforcement section leads with the fact that the fixed lists are machine-checked, because "we promise not to" and "the code cannot" are very different assurances.
