### PR TITLE
deploy: ungate manual deploy and edit from pipelines preview

### DIFF
--- a/Localize/locales/en/plugin-translation.json
+++ b/Localize/locales/en/plugin-translation.json
@@ -267,8 +267,6 @@
   "Edit HPA Configuration": "Edit HPA Configuration",
   "Edit Manual Scaling Configuration": "Edit Manual Scaling Configuration",
   "Egress Policy": "Egress Policy",
-  "Enable GitHub Pipelines in Settings → Preview Features to use pipeline deployments.": "Enable GitHub Pipelines in Settings → Preview Features to use pipeline deployments.",
-  "_Enable GitHub Pipelines in Settings → Preview Features to use pipeline deployments..comment": "{Locked=\"GitHub\"}",
   "Enable GitHub-based deployment pipelines for AKS projects.": "Enable GitHub-based deployment pipelines for AKS projects.",
   "_Enable GitHub-based deployment pipelines for AKS projects..comment": "{Locked=\"GitHub\"}",
   "Enable Horizontal Pod Autoscaler": "Enable Horizontal Pod Autoscaler",

--- a/plugins/aks-desktop/src/components/DeployTab/DeployTab.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/DeployTab.test.tsx
@@ -72,6 +72,15 @@ describe('DeployTab pipeline gating', () => {
     expect(screen.getByTestId('github-auth-provider')).toBeInTheDocument();
   });
 
+  it('keeps pipeline actions off when both the preview feature and the setting are off', () => {
+    pipelineSettings.githubPipelineEnabled = false;
+
+    render(<DeployTab project={project} />);
+
+    expect(screen.getByTestId('cluster-deploy-card')).toHaveTextContent('pipeline-disabled');
+    expect(screen.queryByTestId('github-auth-provider')).not.toBeInTheDocument();
+  });
+
   it('keeps pipeline actions off when the preview feature is on but the setting is off', () => {
     previewFeatures.githubPipelines = true;
     pipelineSettings.githubPipelineEnabled = false;

--- a/plugins/aks-desktop/src/components/DeployTab/DeployTab.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/DeployTab.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const previewFeatures = vi.hoisted(() => ({ githubPipelines: false }));
+const pipelineSettings = vi.hoisted(() => ({ githubPipelineEnabled: true }));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('../../hooks/usePreviewFeatures', () => ({
+  usePreviewFeatures: () => previewFeatures,
+}));
+vi.mock('./hooks/usePipelineSettings', () => ({
+  usePipelineSettings: () => ({ settings: pipelineSettings, updateSettings: vi.fn() }),
+}));
+vi.mock('../GitHubPipeline/GitHubAuthContext', () => ({
+  GitHubAuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="github-auth-provider">{children}</div>
+  ),
+}));
+vi.mock('./components/ClusterDeployCard', () => ({
+  ClusterDeployCard: ({
+    cluster,
+    pipelineEnabled,
+  }: {
+    cluster: string;
+    pipelineEnabled: boolean;
+  }) => (
+    <div data-testid="cluster-deploy-card" data-cluster={cluster}>
+      {pipelineEnabled ? 'pipeline-enabled' : 'pipeline-disabled'}
+    </div>
+  ),
+}));
+
+import DeployTab from './DeployTab';
+
+const project = { id: 'p1', clusters: ['cluster-a'], namespaces: ['ns-a'] } as never;
+
+describe('DeployTab pipeline gating', () => {
+  beforeEach(() => {
+    previewFeatures.githubPipelines = false;
+    pipelineSettings.githubPipelineEnabled = true;
+  });
+
+  afterEach(cleanup);
+
+  it('renders workloads when the GitHub Pipelines preview feature is off', () => {
+    render(<DeployTab project={project} />);
+
+    expect(screen.getByText('Workloads')).toBeInTheDocument();
+    expect(screen.getByTestId('cluster-deploy-card')).toHaveAttribute('data-cluster', 'cluster-a');
+  });
+
+  it('disables pipeline actions and skips GitHub auth when the preview feature is off', () => {
+    render(<DeployTab project={project} />);
+
+    expect(screen.getByTestId('cluster-deploy-card')).toHaveTextContent('pipeline-disabled');
+    expect(screen.queryByTestId('github-auth-provider')).not.toBeInTheDocument();
+  });
+
+  it('enables pipeline actions and provides GitHub auth when both flags are on', () => {
+    previewFeatures.githubPipelines = true;
+
+    render(<DeployTab project={project} />);
+
+    expect(screen.getByTestId('cluster-deploy-card')).toHaveTextContent('pipeline-enabled');
+    expect(screen.getByTestId('github-auth-provider')).toBeInTheDocument();
+  });
+
+  it('keeps pipeline actions off when the preview feature is on but the setting is off', () => {
+    previewFeatures.githubPipelines = true;
+    pipelineSettings.githubPipelineEnabled = false;
+
+    render(<DeployTab project={project} />);
+
+    expect(screen.getByTestId('cluster-deploy-card')).toHaveTextContent('pipeline-disabled');
+    expect(screen.queryByTestId('github-auth-provider')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployTab/DeployTab.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/DeployTab.tsx
@@ -7,6 +7,7 @@ import { visuallyHidden } from '@mui/utils';
 import React, { useEffect, useState } from 'react';
 import { usePreviewFeatures } from '../../hooks/usePreviewFeatures';
 import type { ProjectDefinition } from '../../types/project';
+import { GitHubAuthProvider } from '../GitHubPipeline/GitHubAuthContext';
 import { ClusterDeployCard } from './components/ClusterDeployCard';
 import { usePipelineSettings } from './hooks/usePipelineSettings';
 
@@ -25,17 +26,11 @@ function DeployTab({ project }: DeployTabProps) {
     setLiveReady(true);
   }, []);
 
-  if (!githubPipelines) {
-    return (
-      <Box sx={{ p: 3, textAlign: 'center' }}>
-        <Typography color="text.secondary">
-          {t('Enable GitHub Pipelines in Settings → Preview Features to use pipeline deployments.')}
-        </Typography>
-      </Box>
-    );
-  }
+  // Pipeline deployment is a preview feature; manual deploy and editing an
+  // AKS Desktop-deployed app are always available (issue #264).
+  const pipelineEnabled = githubPipelines && settings.githubPipelineEnabled;
 
-  return (
+  const content = (
     <Box sx={{ my: 3 }}>
       <Box sx={{ mb: 3 }}>
         <Typography variant="h5">{t('Workloads')}</Typography>
@@ -60,12 +55,16 @@ function DeployTab({ project }: DeployTabProps) {
             key={clusterName}
             cluster={clusterName}
             namespace={ns}
-            pipelineEnabled={settings.githubPipelineEnabled}
+            pipelineEnabled={pipelineEnabled}
           />
         );
       })}
     </Box>
   );
+
+  // The GitHub auth context is only consumed by the pipeline deploy dialog, so
+  // skip the provider (and its token validation) when pipelines are disabled.
+  return pipelineEnabled ? <GitHubAuthProvider>{content}</GitHubAuthProvider> : content;
 }
 
 export default DeployTab;

--- a/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const deployments = vi.hoisted(() => ({
+  list: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: { icon: string }) => <span data-testid={`icon-${icon}`} />,
+}));
+vi.mock('../../../hooks/useAzureContext', () => ({
+  useAzureContext: () => ({
+    azureContext: { subscriptionId: 'sub-1', resourceGroup: 'rg-1' },
+  }),
+}));
+vi.mock('../../../hooks/useNamespaceCapabilities', () => ({
+  useNamespaceCapabilities: () => ({ isManagedNamespace: false, azureRbacEnabled: false }),
+}));
+vi.mock('../hooks/usePipelineStatus', () => ({
+  usePipelineStatus: () => ({
+    isConfigured: true,
+    repos: [{ owner: 'contoso', repo: 'store' }],
+  }),
+}));
+vi.mock('../hooks/useClusterDeployStatus', () => ({
+  useClusterDeployStatus: () => ({
+    deployments: deployments.list,
+    services: [],
+    loading: false,
+    error: null,
+  }),
+}));
+vi.mock('../../DeployWizard/DeployWizard', () => ({
+  default: () => <div>Deploy wizard</div>,
+}));
+vi.mock('./PipelineDeployDialog', () => ({
+  // Mirrors the real component's dependency on the GitHub auth context, which
+  // throws when no provider is mounted above it.
+  PipelineDeployDialog: () => {
+    throw new Error('useGitHubAuthContext must be used within GitHubAuthProvider');
+  },
+}));
+
+import { ClusterDeployCard } from './ClusterDeployCard';
+
+const pipelineDeployment = {
+  name: 'store-front',
+  replicas: 1,
+  readyReplicas: 1,
+  availableReplicas: 1,
+  provenance: 'pipeline',
+  pipelineRepo: 'contoso/store',
+  pipelineRunUrl: 'https://github.com/contoso/store/actions/runs/1',
+  pipelineWorkflow: 'deploy.yaml',
+  rawDeployment: {},
+};
+
+describe('ClusterDeployCard pipeline gating', () => {
+  afterEach(() => {
+    cleanup();
+    deployments.list = [];
+  });
+
+  it('hides pipeline actions when pipelines are disabled', () => {
+    deployments.list = [pipelineDeployment];
+
+    render(<ClusterDeployCard cluster="c1" namespace="ns1" pipelineEnabled={false} />);
+
+    // No GitHubAuthProvider is mounted in this state, so any affordance that
+    // opens PipelineDeployDialog would crash the tab (see issue #264 follow-up).
+    expect(screen.queryByTestId('icon-mdi:replay')).not.toBeInTheDocument();
+    expect(screen.queryByText('Deploy via Pipeline')).not.toBeInTheDocument();
+    expect(screen.getByText('Manual Deploy')).toBeInTheDocument();
+  });
+
+  it('shows pipeline actions when pipelines are enabled', () => {
+    deployments.list = [pipelineDeployment];
+
+    render(<ClusterDeployCard cluster="c1" namespace="ns1" pipelineEnabled />);
+
+    expect(screen.getByTestId('icon-mdi:replay')).toBeInTheDocument();
+    expect(screen.getByText('Deploy via Pipeline')).toBeInTheDocument();
+  });
+
+  it('keeps the edit action for manually deployed apps when pipelines are disabled', () => {
+    deployments.list = [
+      { ...pipelineDeployment, provenance: 'manual', pipelineRepo: null, pipelineRunUrl: null },
+    ];
+
+    render(<ClusterDeployCard cluster="c1" namespace="ns1" pipelineEnabled={false} />);
+
+    expect(screen.getByTestId('icon-mdi:pencil')).toBeInTheDocument();
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
@@ -84,7 +84,10 @@ export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: Clust
   const { t } = useTranslation();
   const { azureContext } = useAzureContext(cluster);
   const pipelineStatus = usePipelineStatus(cluster, namespace);
-  const pipelineRepos = pipelineStatus.isConfigured ? pipelineStatus.repos : [];
+  // Pipeline actions stay behind the preview flag; with them disabled there is
+  // no GitHubAuthProvider above this card, so nothing may open a dialog that
+  // consumes the GitHub auth context.
+  const pipelineRepos = pipelineEnabled && pipelineStatus.isConfigured ? pipelineStatus.repos : [];
   const { deployments, services, loading, error } = useClusterDeployStatus(
     cluster,
     namespace,
@@ -254,7 +257,8 @@ export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: Clust
                                 </IconButton>
                               </Tooltip>
                             )}
-                          {(d.provenance === 'pipeline' || d.provenance === 'vscode') &&
+                          {pipelineEnabled &&
+                            (d.provenance === 'pipeline' || d.provenance === 'vscode') &&
                             d.pipelineRepo && (
                               <Tooltip title={t('Re-deploy')}>
                                 <IconButton size="small" onClick={() => handleRedeployPipeline(d)}>
@@ -300,7 +304,7 @@ export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: Clust
         />
       </Dialog>
 
-      {pipelineDeployRepo && azureContext && (
+      {pipelineEnabled && pipelineDeployRepo && azureContext && (
         <PipelineDeployDialog
           open
           onClose={() => setPipelineDeployRepo(null)}

--- a/plugins/aks-desktop/src/index.tsx
+++ b/plugins/aks-desktop/src/index.tsx
@@ -364,11 +364,11 @@ if (Headlamp.isRunningAsApp()) {
     label: 'Deploy',
     icon: 'mdi:cloud-upload',
     isEnabled: isAksProject,
+    // DeployTab supplies its own GitHubAuthProvider, but only when pipeline
+    // deployment is enabled — manual deploy/edit needs no GitHub auth.
     component: ({ project }) => (
       <TelemetryErrorBoundary>
-        <GitHubAuthProvider>
-          <DeployTab project={project} />
-        </GitHubAuthProvider>
+        <DeployTab project={project} />
       </TelemetryErrorBoundary>
     ),
   });


### PR DESCRIPTION
## What

The Deploy tab short-circuited to an "Enable GitHub Pipelines in Settings → Preview Features" placeholder whenever the `githubPipelines` preview feature was off. That guard also hid the **Manual Deploy** button and the per-deployment **Edit** action, neither of which touches GitHub — so a user who deployed an app through the wizard had no way back into it except the YAML editor.

Fixes the reopened scope of #264.

## Changes

- `DeployTab.tsx`: drop the early return; the workload list always renders.
- Pass `pipelineEnabled={githubPipelines && settings.githubPipelineEnabled}` to `ClusterDeployCard`, so only the "Deploy via Pipeline" buttons stay behind the preview flag. Without the `githubPipelines` term these would leak out of preview, since `githubPipelineEnabled` defaults to `true`.
- Move `GitHubAuthProvider` from the tab registration in `index.tsx` into `DeployTab`, mounted only when pipelines are enabled. `PipelineDeployDialog` is its only consumer inside the tab and can only open from the pipeline buttons, so with pipelines off no GitHub token validation runs.
- New `DeployTab.test.tsx` covering the four flag combinations.
- `npm run i18n` + `npm run i18n:collect` drop the now-unused string from `Localize/locales/en/plugin-translation.json`.

## Scope

Edit remains limited to deployments with `provenance === 'manual'` (the `aks-project/deployed-by` annotation), i.e. AKS Desktop–deployed apps. Deployments created by `kubectl`/Helm still show no edit action — confirmed as intended, since `extractContainerConfigFromDeployment` models only a fixed field set and re-applying would drop volumes, sidecars, non-HTTP probes, and similar.

## Verification

From `plugins/aks-desktop/`:

- `npm run tsc` — clean
- `npm test -- --run` — 110 files, 1595 tests passed
- `npm run lint` — clean
- `npm run format -- --check` — clean
- `npm run build` — succeeded
