### PR TITLE
plugins: Show headlamp org plugins when AKS optimized filter is off

### DIFF
--- a/plugins/plugin-catalog/src/components/plugins/List.tsx
+++ b/plugins/plugin-catalog/src/components/plugins/List.tsx
@@ -179,11 +179,12 @@ async function processPlugins(onlyAksOptimized: boolean) {
     // Reorder so plugins with logos show first.
     .sort((a, b) => (!!b.logo_image_id ? 1 : 0) - (!!a.logo_image_id ? 1 : 0));
 
-  // When the "AKS Desktop optimized" filter is on, only show plugins that are
-  // part of the curated allowlist.
+  // When the "AKS Desktop optimized" filter is on, only show plugins from the
+  // curated allowlist. When off, fall back to plugins whose ArtifactHub org is
+  // ORGANIZATION_NAME ('headlamp', i.e. headlamp-k8s on GitHub) — known-safe.
   const visiblePlugins = onlyAksOptimized
     ? pluginsWithInstallStatus.filter(isAksOptimizedPlugin)
-    : pluginsWithInstallStatus;
+    : pluginsWithInstallStatus.filter(p => p.repository?.organization_name === ORGANIZATION_NAME);
 
   const totalPages = Math.ceil(visiblePlugins.length / PAGE_SIZE);
 
@@ -372,7 +373,7 @@ export function PluginList() {
     setPage(1);
   };
 
-  const handlePageChange = (event: React.ChangeEvent<unknown>, newPage: number) => {
+  const handlePageChange = (_event: React.ChangeEvent<unknown>, newPage: number) => {
     setPage(newPage);
   };
 


### PR DESCRIPTION
## Description

When the AKS Desktop optimized toggle is disabled, show only plugins from the headlamp org (headlamp-k8s/plugins) instead of the full ArtifactHub catalog. These are known-safe plugins from Headlamp maintainers, making the disabled state a safer fallback.

Before:
<img width="1710" height="1073" alt="image" src="https://github.com/user-attachments/assets/c11d6f5b-5150-4547-9ad6-ff92a388e087" />


After:
<img width="1710" height="1073" alt="image" src="https://github.com/user-attachments/assets/c67054ad-3de0-45f8-99cc-9c5e866b09c8" />
