### PR TITLE
Remove deterministic Azure authentication delay

### DIFF
--- a/Localize/locales/en/plugin-translation.json
+++ b/Localize/locales/en/plugin-translation.json
@@ -545,7 +545,6 @@
   "periodSeconds": "periodSeconds",
   "Pipeline": "Pipeline",
   "Pipeline configured": "Pipeline configured",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Please complete the authentication in your browser. This window will automatically redirect once login is complete.",
   "Please review all the settings before creating your AKS project": "Please review all the settings before creating your AKS project",
   "Please select a deployment to view metrics": "Please select a deployment to view metrics",
   "Please select a subscription first": "Please select a subscription first",

--- a/plugins/aks-desktop/locales/cs/translation.json
+++ b/plugins/aks-desktop/locales/cs/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Probíhá registrace",
   "Register Cluster": "Zaregistrovat cluster",
   "Initiating Azure login": "Zahajuje se přihlášení k Azure.",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Dokončete prosím ověření v prohlížeči. Toto okno se po dokončení přihlášení automaticky přesměruje.",
   "Login successful! Redirecting": "Přihlášení bylo úspěšné. Přesměrování",
   "Login timeout. Please try again.": "Vypršel časový limit přihlášení. Zkuste to prosím znovu.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Čeká se na dokončení přihlášení... (zbývající počet minut: {{minutes}})",

--- a/plugins/aks-desktop/locales/de/translation.json
+++ b/plugins/aks-desktop/locales/de/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Wird registriert",
   "Register Cluster": "Cluster registrieren",
   "Initiating Azure login": "Die Azure-Anmeldung wird initiiert",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Schließen Sie die Authentifizierung in Ihrem Browser ab. Dieses Fenster wird automatisch umgeleitet, sobald die Anmeldung abgeschlossen ist.",
   "Login successful! Redirecting": "Die Anmeldung war erfolgreich! Umleitung",
   "Login timeout. Please try again.": "Anmeldetimeout. Versuchen Sie es bitte noch mal.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Es wird auf den Abschluss der Anmeldung gewartet... ({{minutes}} Minuten verbleibend)",

--- a/plugins/aks-desktop/locales/en/translation.json
+++ b/plugins/aks-desktop/locales/en/translation.json
@@ -34,7 +34,6 @@
   "Registering": "Registering",
   "Register Cluster": "Register Cluster",
   "Initiating Azure login": "Initiating Azure login",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Please complete the authentication in your browser. This window will automatically redirect once login is complete.",
   "Login successful! Redirecting": "Login successful! Redirecting",
   "Login timeout. Please try again.": "Login timeout. Please try again.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Waiting for login completion... ({{minutes}} minutes remaining)",

--- a/plugins/aks-desktop/locales/es/translation.json
+++ b/plugins/aks-desktop/locales/es/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Registrando",
   "Register Cluster": "Registrar clúster",
   "Initiating Azure login": "Iniciando sesión en Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Complete la autenticación en su navegador. Esta ventana se redirigirá automáticamente cuando finalice el inicio de sesión.",
   "Login successful! Redirecting": "Inicio de sesión correcto Redirigiendo",
   "Login timeout. Please try again.": "Se agotó el tiempo de expiración de inicio de sesión. Inténtelo de nuevo.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Esperando a que se complete el inicio de sesión... ({{minutes}}\u00a0minutos restantes)",

--- a/plugins/aks-desktop/locales/fr/translation.json
+++ b/plugins/aks-desktop/locales/fr/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Inscription",
   "Register Cluster": "Inscrire le cluster",
   "Initiating Azure login": "Initialisation de la connexion Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Veuillez terminer l’authentification dans votre navigateur. Cette fenêtre sera automatiquement redirigée une fois la connexion terminée.",
   "Login successful! Redirecting": "Connexion réussie\u00a0! Redirection",
   "Login timeout. Please try again.": "Délai d’expiration de la connexion dépassé. Veuillez réessayer.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "En attente de la fin de la connexion... ({{minutes}}\u00a0minutes restantes)",

--- a/plugins/aks-desktop/locales/hu/translation.json
+++ b/plugins/aks-desktop/locales/hu/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Regisztrálás folyamatban",
   "Register Cluster": "Fürt regisztrálása",
   "Initiating Azure login": "Azure-bejelentkezés kezdeményezése",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Végezze el a hitelesítést a böngészőben. Ez az ablak automatikusan átirányítja a bejelentkezés befejezése után.",
   "Login successful! Redirecting": "Sikeres bejelentkezés! Átirányítás",
   "Login timeout. Please try again.": "Bejelentkezési időtúllépés. Próbálkozzon újra.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Várakozás a bejelentkezés befejezésére... ({{minutes}} perc van hátra)",

--- a/plugins/aks-desktop/locales/id/translation.json
+++ b/plugins/aks-desktop/locales/id/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Mendaftarkan",
   "Register Cluster": "Daftarkan Kluster",
   "Initiating Azure login": "Memulai proses masuk Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Selesaikan autentikasi di browser Anda. Jendela ini akan otomatis dialihkan setelah proses masuk selesai.",
   "Login successful! Redirecting": "Berhasil masuk! Mengalihkan",
   "Login timeout. Please try again.": "Waktu masuk habis. Coba lagi.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Menunggu penyelesaian proses masuk... ({{minutes}} menit tersisa)",

--- a/plugins/aks-desktop/locales/it/translation.json
+++ b/plugins/aks-desktop/locales/it/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Registrazione",
   "Register Cluster": "Registra cluster",
   "Initiating Azure login": "Avvio dell'accesso ad Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Completare l'autenticazione nel browser. Questa finestra verrà reindirizzata automaticamente una volta completato l'accesso.",
   "Login successful! Redirecting": "Accesso riuscito. Reindirizzamento",
   "Login timeout. Please try again.": "Timeout di accesso. Riprovare.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "In attesa del completamento dell'accesso... ({{minutes}} minuti rimanenti)",

--- a/plugins/aks-desktop/locales/ja/translation.json
+++ b/plugins/aks-desktop/locales/ja/translation.json
@@ -23,7 +23,6 @@
   "Registering": "登録しています",
   "Register Cluster": "クラスターの登録",
   "Initiating Azure login": "Azure ログインを開始しています",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "ブラウザーで認証を完了してください。ログイン完了後、このウィンドウは自動的にリダイレクトされます。",
   "Login successful! Redirecting": "ログインに成功しました。リダイレクトしています",
   "Login timeout. Please try again.": "ログインがタイムアウトしました。もう一度お試しください。",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "ログインの完了を待機しています...(残り {{minutes}} 分)",

--- a/plugins/aks-desktop/locales/ko/translation.json
+++ b/plugins/aks-desktop/locales/ko/translation.json
@@ -23,7 +23,6 @@
   "Registering": "등록 중",
   "Register Cluster": "클러스터 등록",
   "Initiating Azure login": "Azure 로그인을 시작하는 중",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "브라우저에서 인증을 완료하세요. 로그인이 완료되면 이 창이 자동으로 리디렉션됩니다.",
   "Login successful! Redirecting": "로그인 성공! 리디렉션 중",
   "Login timeout. Please try again.": "로그인 시간이 초과되었습니다. 다시 시도하세요.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "로그인 완료를 기다리는 중... ({{minutes}}분 남음)",

--- a/plugins/aks-desktop/locales/nl/translation.json
+++ b/plugins/aks-desktop/locales/nl/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Registreren",
   "Register Cluster": "Cluster registreren",
   "Initiating Azure login": "Azure-aanmelding starten",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Rond de verificatie af in je browser. Dit venster wordt automatisch doorgestuurd zodra je bent ingelogd.",
   "Login successful! Redirecting": "Je bent aangemeld! Omleiden",
   "Login timeout. Please try again.": "Time-out voor aanmelding. Probeer het opnieuw.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Wachten op voltooiing van aanmelding... ({{minutes}} minuten resterend)",

--- a/plugins/aks-desktop/locales/pl/translation.json
+++ b/plugins/aks-desktop/locales/pl/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Rejestrowanie",
   "Register Cluster": "Zarejestruj klaster",
   "Initiating Azure login": "Inicjowanie logowania do platformy Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Ukończ uwierzytelnianie w przeglądarce. To okno zostanie automatycznie przekierowane po zakończeniu logowania.",
   "Login successful! Redirecting": "Logowanie pomyślne! Przekierowywanie",
   "Login timeout. Please try again.": "Limit czasu logowania. Spróbuj ponownie.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Trwa oczekiwanie na ukończenie logowania... (pozostałe minuty {{minutes}})",

--- a/plugins/aks-desktop/locales/pt-BR/translation.json
+++ b/plugins/aks-desktop/locales/pt-BR/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Registrando",
   "Register Cluster": "Registrar Cluster",
   "Initiating Azure login": "Iniciando logon\u00a0no Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Conclua a autenticação no navegador. Esta janela será redirecionada automaticamente quando o\u00a0logon for concluído.",
   "Login successful! Redirecting": "Logon bem-sucedido! Redirecionando",
   "Login timeout. Please try again.": "Tempo limite de\u00a0logon. Tente novamente.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Aguardando conclusão do logon... ({{minutes}} minutos restantes)",

--- a/plugins/aks-desktop/locales/pt-PT/translation.json
+++ b/plugins/aks-desktop/locales/pt-PT/translation.json
@@ -23,7 +23,6 @@
   "Registering": "A registar",
   "Register Cluster": "Registar Cluster",
   "Initiating Azure login": "A iniciar sessão no Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Conclua a autenticação no seu browser. Esta janela será automaticamente redirecionada assim que o início de sessão estiver concluído.",
   "Login successful! Redirecting": "Início de sessão bem-sucedido! A redirecionar",
   "Login timeout. Please try again.": "Tempo limite de início de sessão. Tente novamente.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "A aguardar a conclusão do início de sessão... ({{minutes}} minutos restantes)",

--- a/plugins/aks-desktop/locales/ru/translation.json
+++ b/plugins/aks-desktop/locales/ru/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Выполняется регистрация",
   "Register Cluster": "Регистрация кластера",
   "Initiating Azure login": "Инициируется вход в Azure",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Завершите проверку подлинности в браузере. Это окно будет автоматически перенаправлено после входа.",
   "Login successful! Redirecting": "Вход успешно выполнен! Выполняется перенаправление",
   "Login timeout. Please try again.": "Время ожидания входа истекло. Повторите попытку.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Ждем завершения входа... ( осталось{{minutes}} мин.)",

--- a/plugins/aks-desktop/locales/sv/translation.json
+++ b/plugins/aks-desktop/locales/sv/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Registrering",
   "Register Cluster": "Registrera kluster",
   "Initiating Azure login": "Initierar Azure-inloggning",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Slutför autentiseringen i webbläsaren. Det här fönstret omdirigeras automatiskt när inloggningen är klar.",
   "Login successful! Redirecting": "Inloggningen lyckades! Omdirigering",
   "Login timeout. Please try again.": "Inloggningstiden gick ut. Försök igen.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Väntar på att inloggningen ska slutföras... ({{minutes}} minuter kvar)",

--- a/plugins/aks-desktop/locales/tr/translation.json
+++ b/plugins/aks-desktop/locales/tr/translation.json
@@ -23,7 +23,6 @@
   "Registering": "Kaydediliyor",
   "Register Cluster": "Kümeyi Kaydet",
   "Initiating Azure login": "Azure oturumu açma başlatılıyor",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "Lütfen kimlik doğrulamasını tarayıcınızda tamamlayın. Oturum açma tamamlandığında bu pencere otomatik olarak yeniden yönlendirilir.",
   "Login successful! Redirecting": "Oturum açıldı! Yeniden yönlendiriyor",
   "Login timeout. Please try again.": "Oturum açma zaman aşımı. Lütfen yeniden deneyin.",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "Oturum açma işleminin tamamlanması bekleniyor... ({{minutes}} dakika kaldı)",

--- a/plugins/aks-desktop/locales/zh-Hans/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hans/translation.json
@@ -23,7 +23,6 @@
   "Registering": "正在注册",
   "Register Cluster": "注册群集",
   "Initiating Azure login": "正在启动 Azure 登录",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "请在浏览器中完成身份验证。登录完成后，此窗口将自动重定向。",
   "Login successful! Redirecting": "登录成功!正在重定向",
   "Login timeout. Please try again.": "登录超时。请重试。",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "正在等待登录完成...(剩余 {{minutes}} 分钟)",

--- a/plugins/aks-desktop/locales/zh-Hant/translation.json
+++ b/plugins/aks-desktop/locales/zh-Hant/translation.json
@@ -23,7 +23,6 @@
   "Registering": "正在註冊",
   "Register Cluster": "註冊叢集",
   "Initiating Azure login": "正在起始 Azure 登入",
-  "Please complete the authentication in your browser. This window will automatically redirect once login is complete.": "請在瀏覽器中完成驗證。登入完成後，此視窗會自動重新導向。",
   "Login successful! Redirecting": "登入成功!正在重新導向",
   "Login timeout. Please try again.": "登入逾時。請再試一次。",
   "Waiting for login completion... ({{minutes}} minutes remaining)": "正在等待登入完成...(剩餘 {{minutes}} 分鐘)",

--- a/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.test.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   LOGIN_POLL_INTERVAL_MS,
-  LOGIN_REDIRECT_DELAY_MS,
+  LOGIN_RETRY_DELAY_MS,
   LOGIN_TIMEOUT_MS,
 } from '../../utils/constants/timing';
 
@@ -95,6 +95,26 @@ describe('AzureLoginPage telemetry', () => {
     expect(mocks.useTelemetryFeatureOpened).toHaveBeenCalledWith('aksd.auth-login');
   });
 
+  test('shows sign in when the initial status check hangs past the timeout', async () => {
+    const statusDeferred = createDeferred<{ isLoggedIn: boolean }>();
+    mocks.getLoginStatus.mockReturnValue(statusDeferred.promise);
+
+    render(<AzureLoginPage />);
+    expect(await screen.findByText('Checking authentication status...')).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS);
+    });
+
+    expect(screen.getByRole('button', { name: 'Sign in with Azure' })).toBeTruthy();
+
+    await act(async () => {
+      statusDeferred.resolve({ isLoggedIn: true });
+      await statusDeferred.promise;
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
   test('emits started at the beginning of an explicit login attempt', async () => {
     mocks.initiateLogin.mockReturnValue(new Promise(() => {}));
     await renderLoggedOutPage();
@@ -102,9 +122,24 @@ describe('AzureLoginPage telemetry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
 
     expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'started');
+    expect(screen.getByText('Initiating Azure login...')).toBeTruthy();
     expect(mocks.trackAksFeature.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.initiateLogin.mock.invocationCallOrder[0]
     );
+  });
+
+  test('starts only one login attempt on repeated clicks', async () => {
+    mocks.initiateLogin.mockReturnValue(new Promise(() => {}));
+    await renderLoggedOutPage();
+    const signInButton = screen.getByRole('button', { name: 'Sign in with Azure' });
+
+    await act(async () => {
+      signInButton.click();
+      signInButton.click();
+    });
+
+    expect(mocks.initiateLogin).toHaveBeenCalledTimes(1);
+    expect(mocks.trackAksFeature).toHaveBeenCalledTimes(1);
   });
 
   test('ignores an unsuccessful initiation result after the attempt is cancelled', async () => {
@@ -179,12 +214,17 @@ describe('AzureLoginPage telemetry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    const signInButton = screen.getByRole('button', { name: 'Sign in with Azure' });
+    expect((signInButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(signInButton);
+    expect(mocks.initiateLogin).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       firstAttempt.resolve({ success: false, message: 'stale failure' });
       await firstAttempt.promise;
     });
+    await waitFor(() => expect((signInButton as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(signInButton);
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
 
     mocks.getLoginStatus.mockResolvedValueOnce({ isLoggedIn: true });
@@ -205,29 +245,91 @@ describe('AzureLoginPage telemetry', () => {
     expect(mocks.trackError).not.toHaveBeenCalled();
   });
 
-  test('emits succeeded before navigating after polling confirms login', async () => {
-    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+  test('offers retry only after the previous login command completes', async () => {
+    const firstAttempt = createDeferred<{ success: boolean; message: string }>();
+    const secondAttempt = createDeferred<{ success: boolean; message: string }>();
+    mocks.initiateLogin
+      .mockReturnValueOnce(firstAttempt.promise)
+      .mockReturnValueOnce(secondAttempt.promise);
     await renderLoggedOutPage();
-    mocks.getLoginStatus.mockResolvedValueOnce({
-      isLoggedIn: true,
-      username: 'sensitive-user@contoso.com',
-      tenantId: 'sensitive-tenant',
-      subscriptionId: 'sensitive-subscription',
-    });
+    mocks.getLoginStatus.mockClear();
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
-    await act(async () => {});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_RETRY_DELAY_MS);
+    });
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+
+    mocks.getLoginStatus.mockResolvedValueOnce({ isLoggedIn: false, error: 'Not logged in' });
+    await act(async () => {
+      firstAttempt.resolve({ success: true, message: 'browser opened' });
+      await firstAttempt.promise;
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_RETRY_DELAY_MS);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(mocks.initiateLogin).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(mocks.trackAksFeature.mock.calls).toEqual([
+      ['aksd.auth-login', 'started'],
+      ['aksd.auth-login', 'cancelled'],
+      ['aksd.auth-login', 'started'],
+    ]);
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  test('keeps one timeout budget across login initiation and status checks', async () => {
+    const firstAttempt = createDeferred<{ success: boolean; message: string }>();
+    mocks.initiateLogin.mockReturnValue(firstAttempt.promise);
+    await renderLoggedOutPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS - LOGIN_POLL_INTERVAL_MS);
+    });
+
+    mocks.getLoginStatus.mockResolvedValue({ isLoggedIn: false, error: 'Not logged in' });
+    await act(async () => {
+      firstAttempt.resolve({ success: true, message: 'browser opened' });
+      await firstAttempt.promise;
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
     });
 
-    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'succeeded');
+    expect(await screen.findByText('Login timeout. Please try again.')).toBeTruthy();
+    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
     expect(mocks.push).not.toHaveBeenCalled();
+  });
 
+  test('checks for login completion and redirects without waiting for the polling interval', async () => {
+    const statusDeferred = createDeferred<{
+      isLoggedIn: boolean;
+      username: string;
+      tenantId: string;
+      subscriptionId: string;
+    }>();
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus.mockReturnValueOnce(statusDeferred.promise);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    expect(await screen.findByText('Checking authentication status')).toBeTruthy();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(LOGIN_REDIRECT_DELAY_MS);
+      statusDeferred.resolve({
+        isLoggedIn: true,
+        username: 'sensitive-user@contoso.com',
+        tenantId: 'sensitive-tenant',
+        subscriptionId: 'sensitive-subscription',
+      });
+      await statusDeferred.promise;
     });
 
+    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'succeeded');
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
     expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
     const successCall = mocks.trackAksFeature.mock.calls.findIndex(
       call => call[0] === 'aksd.auth-login' && call[1] === 'succeeded'
@@ -238,6 +340,112 @@ describe('AzureLoginPage telemetry', () => {
     expect(JSON.stringify(mocks.trackAksFeature.mock.calls)).not.toContain('sensitive-');
   });
 
+  test('starts polling only when the immediate status check is logged out', async () => {
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus
+      .mockResolvedValueOnce({ isLoggedIn: false, error: 'Not logged in' })
+      .mockResolvedValueOnce({ isLoggedIn: true });
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    await act(async () => {});
+
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(2);
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), LOGIN_POLL_INTERVAL_MS);
+    expect(
+      screen.getByText('Waiting for login completion... (5.0 minutes remaining)')
+    ).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+    });
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(3);
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
+  });
+
+  test('stops immediately when account status reports a command failure', async () => {
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus.mockResolvedValueOnce({
+      isLoggedIn: false,
+      error: 'Command execution error: bridge disconnected',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+
+    expect(await screen.findByText('Command execution error: bridge disconnected')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sign in with Azure' })).toBeTruthy();
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(2);
+    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
+    expect(mocks.trackError).toHaveBeenCalledWith({
+      area: 'auth-login',
+      errorClass: 'UnknownError',
+      phase: 'failed',
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('polls when account status still reflects the pre-login state', async () => {
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus
+      .mockResolvedValueOnce({
+        isLoggedIn: false,
+        needsRelogin: true,
+        error: 'Please run "az login" to setup account.',
+      })
+      .mockResolvedValueOnce({ isLoggedIn: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+
+    expect(
+      await screen.findByText('Waiting for login completion... (5.0 minutes remaining)')
+    ).toBeTruthy();
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(2);
+    expect(mocks.push).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+    });
+
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(3);
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
+  });
+
+  test('waits for a slow status check before scheduling the next poll', async () => {
+    const statusDeferred = createDeferred<{ isLoggedIn: boolean }>();
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus
+      .mockResolvedValueOnce({ isLoggedIn: false })
+      .mockReturnValueOnce(statusDeferred.promise)
+      .mockResolvedValueOnce({ isLoggedIn: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    await act(async () => {});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+    });
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS * 3);
+    });
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      statusDeferred.resolve({ isLoggedIn: false });
+      await statusDeferred.promise;
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+    });
+
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(4);
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
+  });
+
   test('does not emit cancelled after polling has already emitted succeeded', async () => {
     mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
     await renderLoggedOutPage();
@@ -245,20 +453,13 @@ describe('AzureLoginPage telemetry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
     await act(async () => {});
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
-    });
 
     expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'succeeded');
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(mocks.trackAksFeature).not.toHaveBeenCalledWith('aksd.auth-login', 'cancelled');
-    expect(mocks.push).not.toHaveBeenCalled();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(LOGIN_REDIRECT_DELAY_MS);
-    });
-    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
+    expect(mocks.push).toHaveBeenCalledTimes(1);
   });
 
   test('unmount during an in-flight poll prevents all later effects', async () => {
@@ -279,7 +480,7 @@ describe('AzureLoginPage telemetry', () => {
     await act(async () => {
       statusDeferred.resolve({ isLoggedIn: true });
       await statusDeferred.promise;
-      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS + LOGIN_REDIRECT_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS);
     });
 
     expect(mocks.trackAksFeature.mock.calls).toEqual([['aksd.auth-login', 'started']]);
@@ -289,7 +490,7 @@ describe('AzureLoginPage telemetry', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  test('unmount after success clears the pending redirect without later effects', async () => {
+  test('unmount after success has no later effects', async () => {
     mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
     const { unmount } = await renderLoggedOutPage();
     mocks.getLoginStatus.mockResolvedValueOnce({ isLoggedIn: true });
@@ -297,18 +498,16 @@ describe('AzureLoginPage telemetry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
     await act(async () => {});
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
-    });
     expect(mocks.trackAksFeature.mock.calls).toEqual([
       ['aksd.auth-login', 'started'],
       ['aksd.auth-login', 'succeeded'],
     ]);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
 
     unmount();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(LOGIN_REDIRECT_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
     });
 
     expect(mocks.trackAksFeature.mock.calls).toEqual([
@@ -316,7 +515,7 @@ describe('AzureLoginPage telemetry', () => {
       ['aksd.auth-login', 'succeeded'],
     ]);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.push).toHaveBeenCalledTimes(1);
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -330,6 +529,7 @@ describe('AzureLoginPage telemetry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
 
     await screen.findByText('sensitive result message');
+    expect(screen.queryByText('Initiating Azure login...')).toBeNull();
     expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
     expect(mocks.trackError).toHaveBeenCalledWith({
       area: 'auth-login',
@@ -348,6 +548,7 @@ describe('AzureLoginPage telemetry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
 
     await screen.findByText('Failed to initiate login: sensitive thrown exception');
+    expect(screen.queryByText('Initiating Azure login...')).toBeNull();
     expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
     expect(mocks.trackError).toHaveBeenCalledWith({
       area: 'auth-login',
@@ -357,6 +558,84 @@ describe('AzureLoginPage telemetry', () => {
     expect(
       JSON.stringify([mocks.trackAksFeature.mock.calls, mocks.trackError.mock.calls])
     ).not.toContain('sensitive thrown exception');
+  });
+
+  test('times out when login initiation hangs', async () => {
+    const deferred = createDeferred<{ success: boolean; message: string }>();
+    mocks.initiateLogin.mockReturnValue(deferred.promise);
+    await renderLoggedOutPage();
+    mocks.getLoginStatus.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS);
+    });
+
+    expect(await screen.findByText('Login timeout. Please try again.')).toBeTruthy();
+    expect(screen.queryByText('Initiating Azure login...')).toBeNull();
+    const signInButton = screen.getByRole('button', { name: 'Sign in with Azure' });
+    expect((signInButton as HTMLButtonElement).disabled).toBe(true);
+    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
+    expect(mocks.trackError).toHaveBeenCalledWith({
+      area: 'auth-login',
+      errorClass: 'TimeoutError',
+      phase: 'failed',
+    });
+
+    await act(async () => {
+      deferred.resolve({ success: true, message: 'late success' });
+      await deferred.promise;
+    });
+    await waitFor(() => expect((signInButton as HTMLButtonElement).disabled).toBe(false));
+    expect(mocks.getLoginStatus).not.toHaveBeenCalled();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  test('times out when the immediate status check hangs', async () => {
+    const statusDeferred = createDeferred<{ isLoggedIn: boolean }>();
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus.mockReturnValueOnce(statusDeferred.promise);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    expect(await screen.findByText('Checking authentication status')).toBeTruthy();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT_MS);
+    });
+
+    expect(await screen.findByText('Login timeout. Please try again.')).toBeTruthy();
+    expect(screen.queryByText('Checking authentication status')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Sign in with Azure' })).toBeTruthy();
+
+    await act(async () => {
+      statusDeferred.resolve({ isLoggedIn: true });
+      await statusDeferred.promise;
+    });
+    expect(mocks.trackAksFeature).not.toHaveBeenCalledWith('aksd.auth-login', 'succeeded');
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  test('ignores a successful status check that completes after cancellation', async () => {
+    const statusDeferred = createDeferred<{ isLoggedIn: boolean }>();
+    mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
+    await renderLoggedOutPage();
+    mocks.getLoginStatus.mockReturnValueOnce(statusDeferred.promise);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await act(async () => {
+      statusDeferred.resolve({ isLoggedIn: true });
+      await statusDeferred.promise;
+      await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+    });
+
+    expect(mocks.trackAksFeature.mock.calls).toEqual([
+      ['aksd.auth-login', 'started'],
+      ['aksd.auth-login', 'cancelled'],
+    ]);
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(2);
   });
 
   test('emits failed and TimeoutError when polling times out', async () => {
@@ -371,6 +650,7 @@ describe('AzureLoginPage telemetry', () => {
     });
 
     expect(await screen.findByText('Login timeout. Please try again.')).toBeTruthy();
+    expect(screen.queryByText(/Waiting for login completion/)).toBeNull();
     expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'failed');
     expect(mocks.trackError).toHaveBeenCalledWith({
       area: 'auth-login',
@@ -395,7 +675,9 @@ describe('AzureLoginPage telemetry', () => {
   test('does not emit terminal telemetry for a transient polling error', async () => {
     mocks.initiateLogin.mockResolvedValue({ success: true, message: 'browser opened' });
     await renderLoggedOutPage();
-    mocks.getLoginStatus.mockRejectedValueOnce(new Error('transient sensitive error'));
+    mocks.getLoginStatus
+      .mockRejectedValueOnce(new Error('transient sensitive error'))
+      .mockResolvedValueOnce({ isLoggedIn: true });
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with Azure' }));
     await act(async () => {});
@@ -403,10 +685,13 @@ describe('AzureLoginPage telemetry', () => {
       await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
     });
 
-    expect(mocks.trackAksFeature).toHaveBeenCalledTimes(1);
-    expect(mocks.trackAksFeature).toHaveBeenCalledWith('aksd.auth-login', 'started');
+    expect(mocks.trackAksFeature.mock.calls).toEqual([
+      ['aksd.auth-login', 'started'],
+      ['aksd.auth-login', 'succeeded'],
+    ]);
     expect(mocks.trackError).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    expect(mocks.getLoginStatus).toHaveBeenCalledTimes(3);
+    expect(mocks.push).toHaveBeenCalledWith('/azure/profile');
   });
 
   test('emits cancelled only when cancelling an active login attempt', async () => {

--- a/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.tsx
+++ b/plugins/aks-desktop/src/components/AzureAuth/AzureLoginPage.tsx
@@ -20,16 +20,23 @@ import { trackAksFeature } from '../../telemetry/aksFeature';
 import { getLoginStatus, initiateLogin } from '../../utils/azure/az-auth';
 import {
   LOGIN_POLL_INTERVAL_MS,
-  LOGIN_REDIRECT_DELAY_MS,
+  LOGIN_RETRY_DELAY_MS,
   LOGIN_TIMEOUT_MS,
 } from '../../utils/constants/timing';
 
 interface AzureLoginPageProps {
+  /** Route to open after authentication when no redirect query parameter is set. */
   redirectTo?: string;
 }
 
 type LoginAttemptOutcome = 'idle' | 'active' | 'succeeded' | 'failed' | 'cancelled';
 
+/**
+ * Records a terminal Azure login failure without exposing error details.
+ *
+ * @param errorClass - Privacy-safe category for the login failure.
+ * @returns Nothing.
+ */
 function trackLoginFailure(errorClass: 'TimeoutError' | 'UnknownError') {
   trackAksFeature('aksd.auth-login', 'failed');
   try {
@@ -37,6 +44,13 @@ function trackLoginFailure(errorClass: 'TimeoutError' | 'UnknownError') {
   } catch {}
 }
 
+/**
+ * Starts Azure CLI authentication and redirects as soon as the account is available.
+ *
+ * @param props - Login page configuration.
+ * @param props.redirectTo - Fallback route to open after authentication.
+ * @returns Azure authentication page.
+ */
 export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
   useTelemetryFeatureOpened('aksd.auth-login');
   const history = useHistory();
@@ -46,19 +60,126 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
   const [checking, setChecking] = useState(true);
   const [statusMessage, setStatusMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showRetry, setShowRetry] = useState(false);
+  const [loginCommandPending, setLoginCommandPending] = useState(false);
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loginRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loginTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loginAttemptOutcomeRef = useRef<LoginAttemptOutcome>('idle');
   const loginAttemptGenerationRef = useRef(0);
+  const loginCommandPendingRef = useRef(false);
   const mountedRef = useRef(true);
 
+  /**
+   * Checks whether an asynchronous result belongs to the latest mounted attempt.
+   *
+   * @param attemptGeneration - Generation captured when the attempt started.
+   * @returns Whether the attempt is current and the page is mounted.
+   */
   const isCurrentAttempt = (attemptGeneration: number) =>
     mountedRef.current && loginAttemptGenerationRef.current === attemptGeneration;
 
+  /**
+   * Checks whether an asynchronous result belongs to the active login attempt.
+   *
+   * @param attemptGeneration - Generation captured when the attempt started.
+   * @returns Whether the attempt is current, mounted, and active.
+   */
   const isActiveAttempt = (attemptGeneration: number) =>
     isCurrentAttempt(attemptGeneration) && loginAttemptOutcomeRef.current === 'active';
 
-  // Get redirect target from URL query parameter or prop, fallback to profile page
+  /**
+   * Cancels the timeout that schedules the next account-status poll.
+   *
+   * @returns Nothing.
+   */
+  const clearPollingTimeout = () => {
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+  };
+
+  /**
+   * Cancels the timeout that bounds the complete login attempt.
+   *
+   * @returns Nothing.
+   */
+  const clearLoginTimeout = () => {
+    if (loginTimeoutRef.current) {
+      clearTimeout(loginTimeoutRef.current);
+      loginTimeoutRef.current = null;
+    }
+  };
+
+  /**
+   * Cancels the timeout that reveals the retry action.
+   *
+   * @returns Nothing.
+   */
+  const clearLoginRetryTimeout = () => {
+    if (loginRetryTimeoutRef.current) {
+      clearTimeout(loginRetryTimeoutRef.current);
+      loginRetryTimeoutRef.current = null;
+    }
+  };
+
+  /**
+   * Marks an active attempt as timed out and resets its UI state.
+   *
+   * @param attemptGeneration - Generation captured when the attempt started.
+   * @returns Nothing.
+   */
+  const handleLoginTimeout = (attemptGeneration: number) => {
+    if (!isActiveAttempt(attemptGeneration)) {
+      return;
+    }
+    clearPollingTimeout();
+    clearLoginRetryTimeout();
+    clearLoginTimeout();
+    loginAttemptOutcomeRef.current = 'failed';
+    trackLoginFailure('TimeoutError');
+    setStatusMessage('');
+    setErrorMessage(t('Login timeout. Please try again.'));
+    setLoading(false);
+    setShowRetry(false);
+  };
+
+  /**
+   * Starts or restarts the timeout that bounds a login attempt.
+   *
+   * @param attemptGeneration - Generation captured when the attempt started.
+   * @returns Nothing.
+   */
+  const startLoginTimeout = (attemptGeneration: number) => {
+    clearLoginTimeout();
+    loginTimeoutRef.current = setTimeout(
+      () => handleLoginTimeout(attemptGeneration),
+      LOGIN_TIMEOUT_MS
+    );
+  };
+
+  /**
+   * Starts the delay after which the retry action becomes available.
+   *
+   * @param attemptGeneration - Generation captured when the attempt started.
+   * @returns Nothing.
+   */
+  const startLoginRetryTimeout = (attemptGeneration: number) => {
+    clearLoginRetryTimeout();
+    loginRetryTimeoutRef.current = setTimeout(() => {
+      loginRetryTimeoutRef.current = null;
+      if (isActiveAttempt(attemptGeneration)) {
+        setShowRetry(true);
+      }
+    }, LOGIN_RETRY_DELAY_MS);
+  };
+
+  /**
+   * Resolves the post-login route from the query, component prop, or default.
+   *
+   * @returns Route to open after authentication.
+   */
   const getRedirectTarget = () => {
     const params = new URLSearchParams(location.search);
     const redirectParam = params.get('redirect');
@@ -72,24 +193,30 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
     return () => {
       mountedRef.current = false;
       loginAttemptGenerationRef.current++;
-      if (pollingIntervalRef.current) {
-        clearInterval(pollingIntervalRef.current);
-        pollingIntervalRef.current = null;
-      }
-      if (redirectTimeoutRef.current) {
-        clearTimeout(redirectTimeoutRef.current);
-        redirectTimeoutRef.current = null;
-      }
+      clearPollingTimeout();
+      clearLoginRetryTimeout();
+      clearLoginTimeout();
     };
   }, []);
 
+  /**
+   * Checks the existing Azure session and redirects authenticated users.
+   *
+   * @returns Promise that resolves after the initial status check completes.
+   */
   const checkLoginStatus = async () => {
+    let statusCheckTimeout: ReturnType<typeof setTimeout> | null = null;
     try {
-      const status = await getLoginStatus();
+      const status = await Promise.race([
+        getLoginStatus(),
+        new Promise<null>(resolve => {
+          statusCheckTimeout = setTimeout(() => resolve(null), LOGIN_TIMEOUT_MS);
+        }),
+      ]);
       if (!mountedRef.current) {
         return;
       }
-      if (status.isLoggedIn) {
+      if (status?.isLoggedIn) {
         // Trigger update event for sidebar label
         window.dispatchEvent(new CustomEvent('azure-auth-update'));
         // Already logged in, redirect to original target
@@ -101,63 +228,90 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
         console.error('Error checking login status:', error);
       }
     } finally {
+      if (statusCheckTimeout) clearTimeout(statusCheckTimeout);
       if (mountedRef.current) {
         setChecking(false);
       }
     }
   };
 
+  /**
+   * Starts Azure CLI login, verifies status immediately, and polls if needed.
+   *
+   * @returns Promise that resolves after login initiation and its immediate check.
+   */
   const handleLogin = async () => {
+    if (loginAttemptOutcomeRef.current === 'active' || loginCommandPendingRef.current) {
+      return;
+    }
     const attemptGeneration = ++loginAttemptGenerationRef.current;
     loginAttemptOutcomeRef.current = 'active';
     trackAksFeature('aksd.auth-login', 'started');
     setLoading(true);
+    setShowRetry(false);
     setErrorMessage('');
     setStatusMessage(`${t('Initiating Azure login')}...`);
+    startLoginTimeout(attemptGeneration);
 
     try {
-      const result = await initiateLogin();
+      loginCommandPendingRef.current = true;
+      setLoginCommandPending(true);
+      let result: Awaited<ReturnType<typeof initiateLogin>>;
+      try {
+        result = await initiateLogin();
+      } finally {
+        loginCommandPendingRef.current = false;
+        if (mountedRef.current) setLoginCommandPending(false);
+      }
 
       if (!isActiveAttempt(attemptGeneration)) {
         return;
       }
 
       if (!result.success) {
+        clearLoginRetryTimeout();
+        clearLoginTimeout();
         loginAttemptOutcomeRef.current = 'failed';
         trackLoginFailure('UnknownError');
+        setStatusMessage('');
         setErrorMessage(result.message);
         setLoading(false);
+        setShowRetry(false);
         return;
       }
 
-      setStatusMessage(
-        t(
-          'Please complete the authentication in your browser. This window will automatically redirect once login is complete.'
-        )
-      );
+      startLoginRetryTimeout(attemptGeneration);
+      setStatusMessage(t('Checking authentication status'));
 
-      // Start polling for login completion
+      // Check immediately, then poll for login completion
       let pollCount = 0;
       const maxPolls = Math.ceil(LOGIN_TIMEOUT_MS / LOGIN_POLL_INTERVAL_MS);
 
-      const interval = setInterval(async () => {
+      /**
+       * Checks Azure account state for the current login attempt.
+       *
+       * @param countTowardTimeout - Whether this check consumes one polling attempt.
+       * @returns Promise that resolves after account state is processed.
+       */
+      const pollLoginStatus = async (countTowardTimeout = true) => {
         if (!isActiveAttempt(attemptGeneration)) {
-          clearInterval(interval);
           return;
         }
-        pollCount++;
+        if (countTowardTimeout) {
+          pollCount++;
+        }
 
         try {
           const status = await getLoginStatus();
 
           if (!isActiveAttempt(attemptGeneration)) {
-            clearInterval(interval);
             return;
           }
 
           if (status.isLoggedIn) {
-            clearInterval(interval);
-            pollingIntervalRef.current = null;
+            clearPollingTimeout();
+            clearLoginRetryTimeout();
+            clearLoginTimeout();
             loginAttemptOutcomeRef.current = 'succeeded';
             trackAksFeature('aksd.auth-login', 'succeeded');
             setStatusMessage(`${t('Login successful! Redirecting')}...`);
@@ -165,23 +319,20 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
             // Trigger update event for sidebar label
             window.dispatchEvent(new CustomEvent('azure-auth-update'));
 
-            // Wait a moment before redirecting
-            redirectTimeoutRef.current = setTimeout(() => {
-              if (
-                isCurrentAttempt(attemptGeneration) &&
-                loginAttemptOutcomeRef.current === 'succeeded'
-              ) {
-                const target = getRedirectTarget();
-                history.push(target);
-              }
-            }, LOGIN_REDIRECT_DELAY_MS);
-          } else if (pollCount >= maxPolls) {
-            clearInterval(interval);
-            pollingIntervalRef.current = null;
+            const target = getRedirectTarget();
+            history.push(target);
+          } else if (status.error && !status.needsRelogin && status.error !== 'Not logged in') {
+            clearPollingTimeout();
+            clearLoginRetryTimeout();
+            clearLoginTimeout();
             loginAttemptOutcomeRef.current = 'failed';
-            trackLoginFailure('TimeoutError');
-            setErrorMessage(t('Login timeout. Please try again.'));
+            trackLoginFailure('UnknownError');
+            setStatusMessage('');
+            setErrorMessage(status.error);
             setLoading(false);
+            setShowRetry(false);
+          } else if (pollCount >= maxPolls) {
+            handleLoginTimeout(attemptGeneration);
           } else {
             const remaining = ((maxPolls - pollCount) * LOGIN_POLL_INTERVAL_MS) / 60_000;
             setStatusMessage(
@@ -192,30 +343,56 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
           }
         } catch (error) {
           if (!isActiveAttempt(attemptGeneration)) {
-            clearInterval(interval);
             return;
           }
           console.error('Error polling login status:', error);
         }
-      }, LOGIN_POLL_INTERVAL_MS);
+      };
 
-      pollingIntervalRef.current = interval;
+      /**
+       * Schedules the next non-overlapping account-status poll.
+       *
+       * @returns Nothing.
+       */
+      const scheduleNextPoll = () => {
+        pollingTimeoutRef.current = setTimeout(async () => {
+          pollingTimeoutRef.current = null;
+          await pollLoginStatus();
+          if (isActiveAttempt(attemptGeneration)) {
+            scheduleNextPoll();
+          }
+        }, LOGIN_POLL_INTERVAL_MS);
+      };
+
+      await pollLoginStatus(false);
+      if (isActiveAttempt(attemptGeneration)) {
+        scheduleNextPoll();
+      }
     } catch (error) {
       if (!isActiveAttempt(attemptGeneration)) {
         return;
       }
       console.error('Error initiating login:', error);
+      clearLoginRetryTimeout();
+      clearLoginTimeout();
       loginAttemptOutcomeRef.current = 'failed';
       trackLoginFailure('UnknownError');
+      setStatusMessage('');
       setErrorMessage(
         t('Failed to initiate login: {{message}}', {
           message: error instanceof Error ? error.message : t('Unknown error'),
         })
       );
       setLoading(false);
+      setShowRetry(false);
     }
   };
 
+  /**
+   * Cancels the active login attempt and clears its pending timers and messages.
+   *
+   * @returns Nothing.
+   */
   const handleCancel = () => {
     if (loginAttemptOutcomeRef.current !== 'active') {
       return;
@@ -223,13 +400,26 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
     loginAttemptGenerationRef.current++;
     loginAttemptOutcomeRef.current = 'cancelled';
     trackAksFeature('aksd.auth-login', 'cancelled');
-    if (pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current);
-      pollingIntervalRef.current = null;
-    }
+    clearPollingTimeout();
+    clearLoginRetryTimeout();
+    clearLoginTimeout();
     setLoading(false);
+    setShowRetry(false);
     setStatusMessage('');
     setErrorMessage('');
+  };
+
+  /**
+   * Cancels the current attempt and starts a fresh Azure login attempt.
+   *
+   * @returns Promise that resolves after the replacement attempt is initiated.
+   */
+  const handleRetry = async () => {
+    if (loginAttemptOutcomeRef.current !== 'active') {
+      return;
+    }
+    handleCancel();
+    await handleLogin();
   };
 
   const rootSx = {
@@ -294,6 +484,7 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
                 variant="contained"
                 color="primary"
                 onClick={handleLogin}
+                disabled={loginCommandPending}
                 startIcon={<Icon icon="mdi:login" />}
                 sx={{
                   minWidth: 200,
@@ -306,20 +497,38 @@ export default function AzureLoginPage({ redirectTo }: AzureLoginPageProps) {
                 {t('Sign in with Azure')}
               </Button>
             ) : (
-              <Button
-                variant="outlined"
-                color="secondary"
-                onClick={handleCancel}
-                sx={{
-                  minWidth: 200,
-                  py: 1.5,
-                  px: 4,
-                  textTransform: 'none',
-                  fontSize: 16,
-                }}
-              >
-                {t('Cancel')}
-              </Button>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 2 }}>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  onClick={handleCancel}
+                  sx={{
+                    minWidth: 200,
+                    py: 1.5,
+                    px: 4,
+                    textTransform: 'none',
+                    fontSize: 16,
+                  }}
+                >
+                  {t('Cancel')}
+                </Button>
+                {showRetry && (
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleRetry}
+                    sx={{
+                      minWidth: 200,
+                      py: 1.5,
+                      px: 4,
+                      textTransform: 'none',
+                      fontSize: 16,
+                    }}
+                  >
+                    {t('Retry')}
+                  </Button>
+                )}
+              </Box>
             )}
 
             {statusMessage && (

--- a/plugins/aks-desktop/src/utils/azure/az-auth-relogin.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-auth-relogin.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runCommandAsync: vi.fn(),
+}));
+
+vi.mock('../shared/runCommandAsync', () => ({
+  runCommandAsync: mocks.runCommandAsync,
+}));
+
+vi.mock('./az-cli-path', () => ({
+  getAzCommand: () => 'az',
+  getInstallationInstructions: () => 'Install Azure CLI.',
+}));
+
+import { getLoginStatus } from './az-auth';
+
+describe('getLoginStatus relogin detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  test('recognizes the standard signed-out Azure CLI response', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: 'Please run "az login" to setup account.',
+    });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Please run "az login" to setup account.',
+      isLoggedIn: false,
+      needsRelogin: true,
+    });
+  });
+});

--- a/plugins/aks-desktop/src/utils/azure/az-auth.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-auth.test.ts
@@ -1,0 +1,497 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { LOGIN_POLL_INTERVAL_MS } from '../constants/timing';
+
+const mocks = vi.hoisted(() => ({
+  isAzCliLoggedIn: vi.fn(),
+  needsRelogin: vi.fn(),
+  runCommandAsync: vi.fn(),
+}));
+
+vi.mock('./az-cli-core', () => ({
+  debugLog: vi.fn(),
+  getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : 'Unknown error'),
+  isAzCliLoggedIn: mocks.isAzCliLoggedIn,
+  isAzError: (stderr: string) => stderr.includes('ERROR: '),
+  isCliNotFoundError: (output: string) =>
+    output.includes('command not found') || output.includes('Azure CLI (az) command not found'),
+  needsRelogin: mocks.needsRelogin,
+  runCommandAsync: mocks.runCommandAsync,
+}));
+
+vi.mock('./az-cli-path', () => ({
+  getAzCommand: () => 'az',
+  getInstallationInstructions: () => 'Install Azure CLI.',
+}));
+
+import {
+  getAccessToken,
+  getLoginStatus,
+  getUserAccountInfo,
+  initiateLogin,
+  login,
+  monitorLoginStatus,
+} from './az-auth';
+
+describe('getLoginStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.needsRelogin.mockReturnValue(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns Azure account details for valid output', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: JSON.stringify({
+        id: 'subscription-id',
+        tenantId: 'tenant-id',
+        user: { name: 'user@example.com' },
+      }),
+      stderr: '',
+    });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      isLoggedIn: true,
+      subscriptionId: 'subscription-id',
+      tenantId: 'tenant-id',
+      username: 'user@example.com',
+    });
+  });
+
+  test('does not trust account output when the command reports a fatal error', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: JSON.stringify({
+        id: 'stale-subscription-id',
+        tenantId: 'stale-tenant-id',
+        user: { name: 'stale-user@example.com' },
+      }),
+      stderr: 'ERROR: The refresh token has expired.',
+    });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'ERROR: The refresh token has expired.',
+      isLoggedIn: false,
+      needsRelogin: false,
+    });
+  });
+
+  test('reports missing Azure CLI output', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: 'az: command not found',
+    });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Azure CLI not found. Please install Azure CLI first.',
+      isLoggedIn: false,
+    });
+  });
+
+  test('reports when Azure CLI requires login again', async () => {
+    mocks.needsRelogin.mockReturnValue(true);
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr: 'Please run az login' });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Please run az login',
+      isLoggedIn: false,
+      needsRelogin: true,
+    });
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('uses a default message when account output is empty', async () => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Not logged in',
+      isLoggedIn: false,
+      needsRelogin: false,
+    });
+  });
+
+  test('treats whitespace-only account output as logged out', async () => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout: ' \n', stderr: ' \n' });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Not logged in',
+      isLoggedIn: false,
+      needsRelogin: false,
+    });
+  });
+
+  test.each(['{}', '[]', '"unexpected"'])('rejects an invalid account shape: %s', async stdout => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout, stderr: '' });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Failed to parse account information',
+      isLoggedIn: false,
+    });
+  });
+
+  test('reports malformed account output', async () => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '{invalid', stderr: '' });
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Failed to parse account information',
+      isLoggedIn: false,
+    });
+  });
+
+  test('reports command exceptions without exposing non-error values', async () => {
+    mocks.runCommandAsync
+      .mockRejectedValueOnce(new Error('bridge failed'))
+      .mockRejectedValueOnce('private rejection');
+
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'bridge failed',
+      isLoggedIn: false,
+    });
+    await expect(getLoginStatus()).resolves.toEqual({
+      error: 'Unknown error',
+      isLoggedIn: false,
+    });
+  });
+});
+
+describe('Azure account data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.needsRelogin.mockReturnValue(false);
+  });
+
+  test('returns account and access-token JSON', async () => {
+    mocks.runCommandAsync
+      .mockResolvedValueOnce({ stdout: '{"id":"subscription-id"}', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '{"accessToken":"token"}', stderr: '' });
+
+    await expect(getUserAccountInfo()).resolves.toEqual({ id: 'subscription-id' });
+    await expect(getAccessToken()).resolves.toEqual({ accessToken: 'token' });
+  });
+
+  test.each([
+    ['account information', getUserAccountInfo],
+    ['access token', getAccessToken],
+  ])('marks %s failures that require login again', async (_label, operation) => {
+    mocks.needsRelogin.mockReturnValue(true);
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr: 'Please run az login' });
+
+    await expect(operation()).rejects.toMatchObject({
+      message: 'Please run az login',
+      needsRelogin: true,
+    });
+  });
+
+  test.each([
+    ['account information', getUserAccountInfo, 'Failed to get account info'],
+    ['access token', getAccessToken, 'Failed to get access token'],
+  ])('reports empty %s output clearly', async (_label, operation, expectedMessage) => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout: ' \n', stderr: ' \n' });
+
+    await expect(operation()).rejects.toThrow(expectedMessage);
+  });
+
+  test.each([
+    ['account information', getUserAccountInfo, '{"id":"stale-subscription-id"}'],
+    ['access token', getAccessToken, '{"accessToken":"stale-token"}'],
+  ])('rejects fatal %s errors even when stdout is present', async (_label, operation, stdout) => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout,
+      stderr: 'ERROR: The refresh token has expired.',
+    });
+
+    await expect(operation()).rejects.toThrow('ERROR: The refresh token has expired.');
+  });
+});
+
+describe('initiateLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.needsRelogin.mockReturnValue(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('accepts successful login output with warnings', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '[{"isDefault":true}]',
+      stderr: 'WARNING: The login output has changed.',
+    });
+
+    await expect(initiateLogin()).resolves.toEqual({
+      success: true,
+      message: 'Login process initiated. Please complete authentication in your browser.',
+    });
+  });
+
+  test('accepts usable login output with a tenant-specific error', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '[{"isDefault":true}]',
+      stderr: "ERROR: Failed to authenticate tenant 'unavailable-tenant'.",
+    });
+
+    await expect(initiateLogin()).resolves.toMatchObject({ success: true });
+  });
+
+  test.each([
+    'ERROR: The user canceled the authentication',
+    'Command exited with code 1',
+    'Command exited with code null',
+    'Command execution error: bridge disconnected',
+    'Failed to execute command: bridge not ready',
+    'pluginRunCommand is not available.',
+  ])('reports a command failure immediately: %s', async stderr => {
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr });
+
+    await expect(initiateLogin()).resolves.toEqual({
+      success: false,
+      message: `Failed to initiate login: ${stderr}`,
+    });
+  });
+
+  test('trims command failure output before displaying it', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: '  Command execution error: bridge disconnected\n',
+    });
+
+    await expect(initiateLogin()).resolves.toEqual({
+      success: false,
+      message: 'Failed to initiate login: Command execution error: bridge disconnected',
+    });
+  });
+
+  test('does not treat whitespace stdout as a successful command', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: ' \n',
+      stderr: 'Command exited with code 1',
+    });
+
+    await expect(initiateLogin()).resolves.toEqual({
+      success: false,
+      message: 'Failed to initiate login: Command exited with code 1',
+    });
+  });
+
+  test('preserves Azure CLI installation guidance for ENOENT', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: 'Command execution error: spawn az ENOENT',
+    });
+
+    const result = await initiateLogin();
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Azure CLI not found.');
+    expect(result.message).toContain('Install Azure CLI.');
+  });
+
+  test('preserves Azure CLI installation guidance for a thrown ENOENT error', async () => {
+    mocks.runCommandAsync.mockRejectedValue(new Error('spawn az ENOENT'));
+
+    const result = await initiateLogin();
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Azure CLI not found.');
+    expect(result.message).toContain('Install Azure CLI.');
+  });
+
+  test('reports thrown login errors', async () => {
+    mocks.runCommandAsync.mockRejectedValue(new Error('bridge failed'));
+
+    await expect(initiateLogin()).resolves.toEqual({
+      success: false,
+      message: 'Failed to initiate login: bridge failed',
+    });
+  });
+});
+
+describe('monitorLoginStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.needsRelogin.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('reports a completed login', async () => {
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '{"id":"subscription-id","tenantId":"tenant-id"}',
+      stderr: '',
+    });
+    const onStatusChange = vi.fn();
+
+    const stop = monitorLoginStatus(onStatusChange);
+
+    await vi.waitFor(() =>
+      expect(onStatusChange).toHaveBeenCalledWith({
+        isLoggedIn: true,
+        message: 'Login successful!',
+      })
+    );
+    stop();
+  });
+
+  test('reports progress and eventually times out', async () => {
+    vi.useFakeTimers();
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr: 'Not logged in' });
+    const onStatusChange = vi.fn();
+
+    monitorLoginStatus(onStatusChange, 1);
+    await vi.runAllTimersAsync();
+
+    expect(onStatusChange).toHaveBeenCalledWith({
+      isLoggedIn: false,
+      message: 'Login timeout. Please try again.',
+    });
+    expect(mocks.runCommandAsync).toHaveBeenCalledTimes(60);
+  });
+
+  test('stops before scheduling another poll', async () => {
+    vi.useFakeTimers();
+    let resolveStatus!: (value: { stdout: string; stderr: string }) => void;
+    const statusResult = new Promise<{ stdout: string; stderr: string }>(resolve => {
+      resolveStatus = resolve;
+    });
+    mocks.runCommandAsync.mockReturnValue(statusResult);
+    const onStatusChange = vi.fn();
+
+    const stop = monitorLoginStatus(onStatusChange, 1);
+    stop();
+    resolveStatus({ stdout: '', stderr: 'Not logged in' });
+    await statusResult;
+    await vi.runAllTimersAsync();
+
+    expect(onStatusChange).not.toHaveBeenCalled();
+    expect(mocks.runCommandAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops immediately when account status reports a command failure', async () => {
+    vi.useFakeTimers();
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: 'Command execution error: bridge disconnected',
+    });
+    const onStatusChange = vi.fn();
+
+    monitorLoginStatus(onStatusChange, 1);
+    await vi.runAllTimersAsync();
+
+    expect(onStatusChange).toHaveBeenCalledOnce();
+    expect(onStatusChange).toHaveBeenCalledWith({
+      isLoggedIn: false,
+      message: 'Command execution error: bridge disconnected',
+    });
+    expect(mocks.runCommandAsync).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('cancels a scheduled status check when monitoring stops', async () => {
+    vi.useFakeTimers();
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '', stderr: 'Not logged in' });
+    const onStatusChange = vi.fn();
+
+    const stop = monitorLoginStatus(onStatusChange, 1_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onStatusChange).toHaveBeenCalledOnce();
+
+    stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(mocks.runCommandAsync).toHaveBeenCalledOnce();
+    expect(onStatusChange).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.needsRelogin.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns immediately for an existing Azure CLI session', async () => {
+    mocks.isAzCliLoggedIn.mockResolvedValue(true);
+
+    await expect(login()).resolves.toBe(true);
+    expect(mocks.runCommandAsync).not.toHaveBeenCalled();
+  });
+
+  test('returns false when login initiation fails', async () => {
+    mocks.isAzCliLoggedIn.mockResolvedValue(false);
+    mocks.runCommandAsync.mockResolvedValue({
+      stdout: '',
+      stderr: 'Command exited with code 1',
+    });
+
+    await expect(login()).resolves.toBe(false);
+  });
+
+  test('polls until Azure CLI reports a session', async () => {
+    mocks.isAzCliLoggedIn
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '[{"isDefault":true}]', stderr: '' });
+
+    const result = login();
+    await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+
+    await expect(result).resolves.toBe(true);
+  });
+
+  test('returns false after the login timeout', async () => {
+    mocks.isAzCliLoggedIn.mockResolvedValue(false);
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '[{"isDefault":true}]', stderr: '' });
+
+    const result = login(1);
+    await vi.advanceTimersByTimeAsync(LOGIN_POLL_INTERVAL_MS);
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  test('returns false when an Azure CLI status check hangs past the timeout', async () => {
+    mocks.isAzCliLoggedIn.mockReturnValue(new Promise(() => {}));
+
+    const result = login(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toBe(false);
+  });
+
+  test('returns false when Azure CLI login initiation hangs past the timeout', async () => {
+    mocks.isAzCliLoggedIn.mockResolvedValue(false);
+    mocks.runCommandAsync.mockReturnValue(new Promise(() => {}));
+
+    const result = login(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toBe(false);
+  });
+
+  test('returns false when the post-login status check hangs past the timeout', async () => {
+    mocks.isAzCliLoggedIn.mockResolvedValueOnce(false).mockReturnValueOnce(new Promise(() => {}));
+    mocks.runCommandAsync.mockResolvedValue({ stdout: '[{"isDefault":true}]', stderr: '' });
+
+    const result = login(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toBe(false);
+  });
+});

--- a/plugins/aks-desktop/src/utils/azure/az-auth.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-auth.ts
@@ -5,42 +5,137 @@ import {
   debugLog,
   getErrorMessage,
   isAzCliLoggedIn,
+  isAzError,
   isCliNotFoundError,
   needsRelogin,
   runCommandAsync,
 } from './az-cli-core';
 import { getAzCommand, getInstallationInstructions } from './az-cli-path';
 
-export async function getLoginStatus(): Promise<{
+/** Azure CLI account state used by authentication flows. */
+export interface AzureLoginStatus {
+  /** Whether Azure CLI has a usable current account. */
   isLoggedIn: boolean;
+  /** Signed-in account name when available. */
   username?: string;
+  /** Current Azure tenant identifier when available. */
   tenantId?: string;
+  /** Current Azure subscription identifier when available. */
   subscriptionId?: string;
+  /** Whether Azure CLI explicitly requires another login. */
   needsRelogin?: boolean;
+  /** Actionable status error when account lookup fails. */
   error?: string;
-}> {
+}
+
+/** Result returned after invoking the Azure CLI login command. */
+export interface AzureLoginResult {
+  /** Whether the login command completed without a terminal command error. */
+  success: boolean;
+  /** User-facing description of the result. */
+  message: string;
+}
+
+/** Account-status update emitted by {@link monitorLoginStatus}. */
+export interface AzureLoginStatusUpdate {
+  /** Whether login has completed. */
+  isLoggedIn: boolean;
+  /** User-facing progress, success, or failure message. */
+  message: string;
+}
+
+const OPERATION_TIMED_OUT = Symbol('operation-timed-out');
+
+/**
+ * Waits for an operation until a shared deadline is reached.
+ *
+ * @param operation - Promise to wait for.
+ * @param deadline - Absolute deadline in milliseconds since the Unix epoch.
+ * @returns Operation result, or a timeout sentinel when the deadline wins.
+ */
+async function waitUntilDeadline<T>(
+  operation: Promise<T>,
+  deadline: number
+): Promise<T | typeof OPERATION_TIMED_OUT> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<typeof OPERATION_TIMED_OUT>(resolve => {
+    timeout = setTimeout(() => resolve(OPERATION_TIMED_OUT), Math.max(0, deadline - Date.now()));
+  });
+
+  try {
+    return await Promise.race([operation, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+/**
+ * Determines whether raw stderr represents a failed command.
+ *
+ * @param stderr - Raw Azure CLI or command-bridge error output.
+ * @returns Whether the command failed before producing usable output.
+ */
+function isCommandFailure(stderr: string): boolean {
+  const error = stderr.trim();
+  return (
+    isAzError(error) ||
+    error.startsWith('Command exited with code ') ||
+    error.startsWith('Command execution error:') ||
+    error.startsWith('Failed to execute command:') ||
+    error === 'pluginRunCommand is not available.'
+  );
+}
+
+/**
+ * Reads and validates the current Azure CLI account.
+ *
+ * @returns Validated login status. Command and parsing failures are returned in `error`.
+ */
+export async function getLoginStatus(): Promise<AzureLoginStatus> {
   try {
     const { stdout, stderr } = await runCommandAsync('az', ['account', 'show', '-o', 'json']);
+    const accountOutput = stdout.trim();
+    const errorOutput = stderr.trim();
 
-    if (stderr && isCliNotFoundError(stderr)) {
+    if (errorOutput && isCliNotFoundError(errorOutput)) {
       return {
         isLoggedIn: false,
         error: 'Azure CLI not found. Please install Azure CLI first.',
       };
     }
 
-    if (!stdout) {
-      const needsReloginFlag = needsRelogin(stderr);
+    if (errorOutput && isCommandFailure(errorOutput)) {
+      const needsReloginFlag = needsRelogin(errorOutput);
+      return {
+        isLoggedIn: false,
+        needsRelogin: needsReloginFlag,
+        error: errorOutput,
+      };
+    }
+
+    if (!accountOutput) {
+      const needsReloginFlag = needsRelogin(errorOutput);
       if (needsReloginFlag) console.warn('AKS-plugin: Azure CLI requires re-login');
       return {
         isLoggedIn: false,
         needsRelogin: needsReloginFlag,
-        error: stderr || 'Not logged in',
+        error: errorOutput || 'Not logged in',
       };
     }
 
     try {
-      const account = JSON.parse(stdout);
+      const account = JSON.parse(accountOutput);
+      if (
+        !account ||
+        typeof account !== 'object' ||
+        Array.isArray(account) ||
+        typeof account.id !== 'string' ||
+        !account.id ||
+        typeof account.tenantId !== 'string' ||
+        !account.tenantId
+      ) {
+        return { isLoggedIn: false, error: 'Failed to parse account information' };
+      }
       return {
         isLoggedIn: true,
         username: account.user?.name,
@@ -59,27 +154,58 @@ export async function getLoginStatus(): Promise<{
   }
 }
 
+/**
+ * Reads the complete current Azure CLI account payload.
+ *
+ * @returns Parsed `az account show` response.
+ * @throws When the command fails, requires login, returns no output, or returns malformed JSON.
+ */
 export async function getUserAccountInfo(): Promise<any> {
   const { stdout, stderr } = await runCommandAsync('az', ['account', 'show', '-o', 'json']);
-  if (!stdout) {
-    const err: any = new Error(stderr || 'Failed to get account info');
+  const accountOutput = stdout.trim();
+  const errorOutput = stderr.trim();
+  if (errorOutput && isCommandFailure(errorOutput)) {
+    const err: any = new Error(errorOutput);
+    if (needsRelogin(errorOutput)) err.needsRelogin = true;
+    throw err;
+  }
+  if (!accountOutput) {
+    const err: any = new Error(errorOutput || 'Failed to get account info');
     if (needsRelogin(stderr)) err.needsRelogin = true;
     throw err;
   }
-  return JSON.parse(stdout);
+  return JSON.parse(accountOutput);
 }
 
+/**
+ * Requests an access token from Azure CLI.
+ *
+ * @returns Parsed `az account get-access-token` response.
+ * @throws When the command fails, requires login, returns no output, or returns malformed JSON.
+ */
 export async function getAccessToken(): Promise<any> {
   const { stdout, stderr } = await runCommandAsync('az', ['account', 'get-access-token']);
-  if (!stdout) {
-    const err: any = new Error(stderr || 'Failed to get access token');
+  const tokenOutput = stdout.trim();
+  const errorOutput = stderr.trim();
+  if (errorOutput && isCommandFailure(errorOutput)) {
+    const err: any = new Error(errorOutput);
+    if (needsRelogin(errorOutput)) err.needsRelogin = true;
+    throw err;
+  }
+  if (!tokenOutput) {
+    const err: any = new Error(errorOutput || 'Failed to get access token');
     if (needsRelogin(stderr)) err.needsRelogin = true;
     throw err;
   }
-  return JSON.parse(stdout);
+  return JSON.parse(tokenOutput);
 }
 
-export async function initiateLogin(): Promise<{ success: boolean; message: string }> {
+/**
+ * Runs Azure CLI login and classifies command-level failures.
+ *
+ * @returns Login initiation result with a user-facing message.
+ */
+export async function initiateLogin(): Promise<AzureLoginResult> {
   try {
     debugLog('[AZ-CLI] ===== INITIATING LOGIN =====');
     debugLog('[AZ-CLI] Resolved command:', getAzCommand());
@@ -100,6 +226,13 @@ export async function initiateLogin(): Promise<{ success: boolean; message: stri
       return {
         success: false,
         message: `Azure CLI not found. Please install Azure CLI first.\n\n${instructions}`,
+      };
+    }
+
+    if (!stdout.trim() && stderr && isCommandFailure(stderr)) {
+      return {
+        success: false,
+        message: `Failed to initiate login: ${stderr.trim()}`,
       };
     }
 
@@ -130,22 +263,39 @@ export async function initiateLogin(): Promise<{ success: boolean; message: stri
   }
 }
 
+/**
+ * Polls Azure CLI account state and emits progress until success, failure, timeout, or cancellation.
+ *
+ * @param onStatusChange - Receives each progress or terminal status update.
+ * @param intervalMs - Delay between status checks in milliseconds.
+ * @returns Function that cancels pending and in-flight monitoring effects.
+ */
 export function monitorLoginStatus(
-  onStatusChange: (status: { isLoggedIn: boolean; message: string }) => void,
+  onStatusChange: (status: AzureLoginStatusUpdate) => void,
   intervalMs = LOGIN_POLL_INTERVAL_MS
 ): () => void {
   let isPolling = true;
   let pollCount = 0;
+  let pollingTimeout: ReturnType<typeof setTimeout> | null = null;
   const maxPolls = 60;
 
+  /** Checks account state once and schedules the next check when appropriate. */
   const poll = async () => {
     if (!isPolling) return;
     pollCount++;
 
     try {
       const status = await getLoginStatus();
+      if (!isPolling) return;
+
       if (status.isLoggedIn) {
         onStatusChange({ isLoggedIn: true, message: 'Login successful!' });
+        isPolling = false;
+      } else if (status.error && !status.needsRelogin && status.error !== 'Not logged in') {
+        onStatusChange({ isLoggedIn: false, message: status.error });
+        isPolling = false;
+      } else if (pollCount >= maxPolls) {
+        onStatusChange({ isLoggedIn: false, message: 'Login timeout. Please try again.' });
         isPolling = false;
       } else {
         const remaining = ((maxPolls - pollCount) * intervalMs) / 1000;
@@ -155,14 +305,10 @@ export function monitorLoginStatus(
             remaining % 60
           ).padStart(2, '0')})`,
         });
-        if (pollCount >= maxPolls) {
-          onStatusChange({ isLoggedIn: false, message: 'Login timeout. Please try again.' });
-          isPolling = false;
-        } else {
-          setTimeout(poll, intervalMs);
-        }
+        pollingTimeout = setTimeout(poll, intervalMs);
       }
     } catch (error) {
+      if (!isPolling) return;
       onStatusChange({ isLoggedIn: false, message: 'Error checking login status' });
       isPolling = false;
     }
@@ -171,20 +317,38 @@ export function monitorLoginStatus(
   poll();
   return () => {
     isPolling = false;
+    if (pollingTimeout) {
+      clearTimeout(pollingTimeout);
+      pollingTimeout = null;
+    }
   };
 }
 
+/**
+ * Completes Azure CLI login within one shared deadline.
+ *
+ * @param timeoutMs - Maximum duration for status checks, login initiation, and polling.
+ * @returns Whether a usable Azure CLI session was established before the deadline.
+ */
 export async function login(timeoutMs = LOGIN_TIMEOUT_MS): Promise<boolean> {
-  if (await isAzCliLoggedIn()) return true;
-  const init = await initiateLogin();
-  if (!init.success) return false;
+  const deadline = Date.now() + timeoutMs;
+  const initialStatus = await waitUntilDeadline(isAzCliLoggedIn(), deadline);
+  if (initialStatus === OPERATION_TIMED_OUT) return false;
+  if (initialStatus) return true;
 
-  const start = Date.now();
+  const init = await waitUntilDeadline(initiateLogin(), deadline);
+  if (init === OPERATION_TIMED_OUT || !init.success) return false;
+
   return new Promise(resolve => {
+    /** Checks login status once and schedules another bounded check when needed. */
     const poll = async () => {
-      if (await isAzCliLoggedIn()) return resolve(true);
-      if (Date.now() - start > timeoutMs) return resolve(false);
-      setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+      const status = await waitUntilDeadline(isAzCliLoggedIn(), deadline);
+      if (status === OPERATION_TIMED_OUT) return resolve(false);
+      if (status) return resolve(true);
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return resolve(false);
+      setTimeout(poll, Math.min(LOGIN_POLL_INTERVAL_MS, remaining));
     };
     poll();
   });

--- a/plugins/aks-desktop/src/utils/azure/az-cli-core.test.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-cli-core.test.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execCommand: vi.fn(),
+  getAzCommand: vi.fn(() => '/bundled/az'),
+}));
+
+vi.mock('../shared/runCommandAsync', () => ({
+  runCommandAsync: mocks.execCommand,
+}));
+
+vi.mock('./az-cli-path', () => ({
+  getAzCommand: mocks.getAzCommand,
+}));
+
+import {
+  getErrorMessage,
+  isAzCliInstalled,
+  isAzCliLoggedIn,
+  isAzError,
+  isCliNotFoundError,
+  isValidGuid,
+  needsRelogin,
+  runAzCommand,
+  runCommandAsync,
+} from './az-cli-core';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('needsRelogin', () => {
+  test.each([
+    'Interactive authentication is needed. Please run: az login',
+    'AADSTS700082: The refresh token has expired.',
+    'AADSTS50173: The provided grant has expired.',
+    'Please run "az login" to setup account.',
+    'ERROR: Please run az login',
+  ])('recognizes Azure CLI login guidance: %s', error => {
+    expect(needsRelogin(error)).toBe(true);
+  });
+
+  test('does not classify unrelated command failures as relogin guidance', () => {
+    expect(needsRelogin('Command execution error: bridge disconnected')).toBe(false);
+  });
+});
+
+describe('command helpers', () => {
+  test('resolves Azure CLI commands through the bundled path', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: 'ok', stderr: '' });
+
+    await expect(runCommandAsync('az', ['version'])).resolves.toEqual({
+      stdout: 'ok',
+      stderr: '',
+    });
+    expect(mocks.execCommand).toHaveBeenCalledWith('/bundled/az', ['version']);
+  });
+
+  test('passes non-Azure commands through unchanged', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: 'ok', stderr: '' });
+
+    await runCommandAsync('kubectl', ['version']);
+
+    expect(mocks.execCommand).toHaveBeenCalledWith('kubectl', ['version']);
+  });
+
+  test('validates GUIDs', () => {
+    expect(isValidGuid('12345678-1234-1234-1234-123456789abc')).toBe(true);
+    expect(isValidGuid('not-a-guid')).toBe(false);
+  });
+
+  test('classifies Azure and missing-command errors', () => {
+    expect(isAzError('ERROR: command failed')).toBe(true);
+    expect(isAzError('WARNING: retrying')).toBe(false);
+    expect(isCliNotFoundError('az: command not found')).toBe(true);
+    expect(isCliNotFoundError('Azure CLI (az) command not found')).toBe(true);
+    expect(isCliNotFoundError('bridge disconnected')).toBe(false);
+  });
+
+  test('normalizes thrown error messages', () => {
+    expect(getErrorMessage(new Error('failed'))).toBe('failed');
+    expect(getErrorMessage('private value')).toBe('Unknown error');
+  });
+});
+
+describe('Azure CLI status', () => {
+  test.each([
+    [{ stdout: '{"azure-cli":"2.78.0"}', stderr: '' }, true],
+    [{ stdout: '{"extensions":[]}', stderr: '' }, false],
+    [{ stdout: '{invalid', stderr: '' }, false],
+    [{ stdout: '', stderr: '' }, false],
+    [{ stdout: '', stderr: 'az: command not found' }, false],
+  ])('reports installation status for %o', async (result, expected) => {
+    mocks.execCommand.mockResolvedValue(result);
+
+    await expect(isAzCliInstalled()).resolves.toBe(expected);
+  });
+
+  test('reports Azure CLI as unavailable when the bridge rejects', async () => {
+    mocks.execCommand.mockRejectedValue(new Error('bridge failed'));
+
+    await expect(isAzCliInstalled()).resolves.toBe(false);
+  });
+
+  test('reports a usable logged-in account', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: 'user@example.com\n', stderr: '' });
+
+    await expect(isAzCliLoggedIn()).resolves.toBe(true);
+  });
+
+  test.each([
+    'az: command not found',
+    'Please run "az login" to setup account.',
+    'No active account',
+  ])('reports logged out for stderr: %s', async stderr => {
+    mocks.execCommand.mockResolvedValue({ stdout: '', stderr });
+
+    await expect(isAzCliLoggedIn()).resolves.toBe(false);
+  });
+
+  test('reports logged out when the bridge rejects', async () => {
+    mocks.execCommand.mockRejectedValue(new Error('bridge failed'));
+
+    await expect(isAzCliLoggedIn()).resolves.toBe(false);
+  });
+});
+
+describe('runAzCommand', () => {
+  test('returns parsed command output', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: '{"value":42}', stderr: '' });
+
+    await expect(
+      runAzCommand(['mock'], 'Running:', 'run mock', stdout => JSON.parse(stdout).value)
+    ).resolves.toEqual({ success: true, data: 42 });
+  });
+
+  test('returns success without a parser', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: '', stderr: 'WARNING: harmless' });
+
+    await expect(runAzCommand(['mock'], 'Running:', 'run mock')).resolves.toEqual({
+      success: true,
+      data: undefined,
+    });
+  });
+
+  test('returns an authentication error for relogin guidance', async () => {
+    mocks.execCommand.mockResolvedValue({
+      stdout: '',
+      stderr: 'Please run "az login" to setup account.',
+    });
+
+    await expect(runAzCommand(['mock'], 'Running:', 'run mock')).resolves.toEqual({
+      success: false,
+      error: 'Authentication required. Please log in to Azure CLI: az login',
+    });
+  });
+
+  test('allows a stderr callback to return a domain result', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: '', stderr: 'WARNING: partial result' });
+
+    await expect(
+      runAzCommand(['mock'], 'Running:', 'run mock', undefined, () => ({
+        success: true,
+        warning: true,
+      }))
+    ).resolves.toEqual({ success: true, warning: true });
+  });
+
+  test('falls through when a stderr callback declines the result', async () => {
+    mocks.execCommand.mockResolvedValue({ stdout: '', stderr: 'ERROR: failed' });
+
+    await expect(
+      runAzCommand(['mock'], 'Running:', 'run mock', undefined, () => null)
+    ).resolves.toEqual({
+      success: false,
+      error: 'Failed to run mock: ERROR: failed',
+    });
+  });
+
+  test('reports parser and command exceptions', async () => {
+    mocks.execCommand
+      .mockResolvedValueOnce({ stdout: '{invalid', stderr: '' })
+      .mockRejectedValueOnce('private failure');
+
+    await expect(
+      runAzCommand(['mock'], 'Running:', 'parse output', stdout => JSON.parse(stdout))
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('Failed to parse output'),
+    });
+    await expect(runAzCommand(['mock'], 'Running:', 'run mock')).resolves.toEqual({
+      success: false,
+      error: 'Failed to run mock: Unknown error',
+    });
+  });
+});

--- a/plugins/aks-desktop/src/utils/azure/az-cli-core.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-cli-core.ts
@@ -28,7 +28,8 @@ export function needsRelogin(error: string): boolean {
   return (
     error.includes('Interactive authentication is needed') ||
     error.includes('AADSTS700082') ||
-    error.includes('AADSTS50173')
+    error.includes('AADSTS50173') ||
+    /please run\s+["']?az login["']?/i.test(error)
   );
 }
 

--- a/plugins/aks-desktop/src/utils/constants/timing.ts
+++ b/plugins/aks-desktop/src/utils/constants/timing.ts
@@ -19,8 +19,8 @@ export const PROMETHEUS_STEP_SECONDS = 60;
 /** How often to poll for login completion (ms). */
 export const LOGIN_POLL_INTERVAL_MS = 5_000;
 
-/** Delay before redirecting after successful login (ms). */
-export const LOGIN_REDIRECT_DELAY_MS = 1_000;
+/** Delay before offering to retry an Azure CLI login attempt (ms). */
+export const LOGIN_RETRY_DELAY_MS = 20_000;
 
 /** TTL for access-tab role-assignment cache (ms). */
 export const ACCESS_TAB_CACHE_TTL_MS = 60_000;


### PR DESCRIPTION
## Summary

- Check Azure account state immediately after `az login` completes.
- Poll only while authentication state is still propagating, with bounded timeout,
  retry, cancellation, and duplicate-click handling.
- Report Azure CLI and desktop command-bridge failures without waiting for timeout.
- Add focused unit coverage for authentication success and failure paths.

## Coverage

- `AzureLoginPage.tsx`: 82.50% branch coverage
- `az-auth.ts`: 93.33% branch coverage
- `az-cli-core.ts`: 97.67% branch coverage

## Validation

- `npm run tsc`
- `npm run lint`
- 99 focused unit tests with Istanbul coverage
- 1,440 full plugin unit tests
- `npm run build`
- `npm run i18n:collect`
- `npm ci --dry-run --offline --ignore-scripts --no-audit --no-fund`

## Manual steps to reproduce

1. Start AKS desktop while the Azure CLI is signed out.
2. Open the Azure account page and select **Sign in with Azure**.
3. Complete authentication in the browser window.
4. Confirm AKS desktop checks authentication status immediately and redirects to
   the Azure profile without waiting for the five-second polling interval.
5. Repeat with delayed account propagation and confirm polling, retry, cancel,
   and timeout behavior remain available.

Assisted by copilot
