### PR TITLE
upstreamable: don't navigate away or strand the details pane on delete

### DIFF
--- a/frontend/src/components/common/Resource/DeleteButton.test.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+import { TestContext } from '../../../test';
+import DeleteButton from './DeleteButton';
+
+const { mockClusterAction } = vi.hoisted(() => ({ mockClusterAction: vi.fn() }));
+
+vi.mock('../../../redux/clusterActionSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../redux/clusterActionSlice')>()),
+  clusterAction: (...args: any[]) => {
+    mockClusterAction(...args);
+    // clusterAction returns a thunk; a no-op one keeps dispatch happy.
+    return () => {};
+  },
+}));
+
+// AuthVisible performs a real SelfSubjectAccessReview; the button's visibility
+// is not what these tests are about.
+vi.mock('./AuthVisible', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const DETAILS_LINK = '/c/mycluster/deployments/default/my-app';
+const LIST_LINK = '/c/mycluster/deployments';
+
+function makeItem() {
+  return {
+    kind: 'Deployment',
+    metadata: { name: 'my-app', namespace: 'default', uid: 'abc' },
+    delete: vi.fn(),
+    getDetailsLink: () => DETAILS_LINK,
+    getListLink: () => LIST_LINK,
+  } as unknown as KubeObject;
+}
+
+/** Renders the button at `pathname` and clicks through the confirm dialog. */
+function deleteFrom(pathname: string, extraProps: Record<string, any> = {}) {
+  render(
+    <TestContext urlPrefix={pathname}>
+      <DeleteButton item={makeItem()} {...extraProps} />
+    </TestContext>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const dialog = screen.getByRole('dialog');
+  const confirm = within(dialog)
+    .getAllByRole('button')
+    .find(b => b.textContent?.trim() === 'Delete')!;
+  fireEvent.click(confirm);
+  return mockClusterAction.mock.calls.at(-1)?.[1];
+}
+
+describe('DeleteButton', () => {
+  beforeEach(() => {
+    mockClusterAction.mockClear();
+  });
+
+  it('navigates to the list when deleting from the item’s own details page', () => {
+    // That page would 404 once the object is gone, so leaving it is correct.
+    const options = deleteFrom(DETAILS_LINK);
+    expect(options.startUrl).toBe(LIST_LINK);
+    expect(options.errorUrl).toBe(LIST_LINK);
+  });
+
+  it('stays put when deleting from somewhere else', () => {
+    // Regression test for #852: deleting a resource from inside a project view
+    // used to throw the user out to the cluster-wide resource list.
+    const projectPage = '/c/mycluster/projects/my-project';
+    const options = deleteFrom(projectPage);
+    expect(options.startUrl).toBe(projectPage);
+    expect(options.errorUrl).toBe(projectPage);
+  });
+
+  it('lets an explicit options prop win over the computed url', () => {
+    const options = deleteFrom('/c/mycluster/projects/my-project', {
+      options: { startUrl: '/somewhere/else' },
+    });
+    expect(options.startUrl).toBe('/somewhere/else');
+  });
+});

--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -53,6 +53,17 @@ export default function DeleteButton(props: DeleteButtonProps) {
   const { t } = useTranslation(['translation']);
   const dispatchDeleteEvent = useEventCallback(HeadlampEventType.DELETE_RESOURCE);
 
+  // Deleting only warrants navigating away when the page being viewed *is* the
+  // object's own details page, which would 404 once the object is gone. From a
+  // list, a project view, or a details pane, the user asked to delete a row —
+  // not to leave the page they are on.
+  const fallbackUrl = React.useMemo(() => {
+    const detailsLink = item?.getDetailsLink();
+    return detailsLink && location.pathname === detailsLink
+      ? item!.getListLink()
+      : location.pathname;
+  }, [item, location.pathname]);
+
   const deleteFunc = React.useCallback(
     () => {
       if (!item) {
@@ -76,14 +87,14 @@ export default function DeleteButton(props: DeleteButtonProps) {
             successMessage: t('Deleted item {{ itemName }}.', { itemName }),
             errorMessage: t('Error deleting item {{ itemName }}.', { itemName }),
             cancelUrl: location.pathname,
-            startUrl: item!.getListLink(),
-            errorUrl: item!.getListLink(),
+            startUrl: fallbackUrl,
+            errorUrl: fallbackUrl,
             ...options,
           })
         );
     },
     // eslint-disable-next-line
-    [item, forceDelete]
+    [item, forceDelete, fallbackUrl]
   );
 
   if (!item) {

--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.test.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { KubeObject } from '../../../../lib/k8s/KubeObject';
+import { createMuiTheme } from '../../../../lib/themes';
+import { TestContext } from '../../../../test';
+import { MainInfoHeader } from './MainInfoSectionHeader';
+
+const { mockActivityClose, mockUseActivity } = vi.hoisted(() => ({
+  mockActivityClose: vi.fn(),
+  mockUseActivity: vi.fn(),
+}));
+
+vi.mock('../../../activity/Activity', () => ({
+  Activity: { close: mockActivityClose, launch: vi.fn() },
+  useActivity: () => mockUseActivity(),
+}));
+
+vi.mock('../../../../redux/clusterActionSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../../redux/clusterActionSlice')>()),
+  clusterAction: () => () => {},
+}));
+
+vi.mock('../AuthVisible', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Not under test here, and they need more of a real KubeObject than this stub.
+vi.mock('../RestartButton', () => ({ RestartButton: () => null }));
+vi.mock('../ScaleButton', () => ({ default: () => null }));
+vi.mock('../EditButton', () => ({ default: () => null }));
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+const resource = {
+  kind: 'Deployment',
+  metadata: { name: 'my-app', namespace: 'default', uid: 'abc' },
+  delete: vi.fn(),
+  getName: () => 'my-app',
+  getDetailsLink: () => '/c/mycluster/deployments/default/my-app',
+  getListLink: () => '/c/mycluster/deployments',
+} as unknown as KubeObject;
+
+function renderAndConfirmDelete() {
+  render(
+    <TestContext urlPrefix="/c/mycluster/projects/my-project">
+      <ThemeProvider theme={theme}>
+        <MainInfoHeader resource={resource} />
+      </ThemeProvider>
+    </TestContext>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const dialog = screen.getByRole('dialog');
+  const confirm = within(dialog)
+    .getAllByRole('button')
+    .find(b => b.textContent?.trim() === 'Delete')!;
+  fireEvent.click(confirm);
+}
+
+describe('MainInfoHeader delete action', () => {
+  beforeEach(() => {
+    mockActivityClose.mockClear();
+  });
+
+  it('dismisses the enclosing details pane when the object is deleted', () => {
+    // Regression test for #852: the split-right details pane used to stay open
+    // on a resource that was on its way out.
+    mockUseActivity.mockReturnValue([{ id: 'detailsDeployment my-app' }, vi.fn()]);
+    renderAndConfirmDelete();
+    expect(mockActivityClose).toHaveBeenCalledWith('detailsDeployment my-app');
+  });
+
+  it('closes nothing when the details view is a route, not a pane', () => {
+    // Route-level details pages render outside any activity.
+    mockUseActivity.mockReturnValue([{}, vi.fn()]);
+    renderAndConfirmDelete();
+    expect(mockActivityClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
@@ -24,6 +24,7 @@ import {
   HeaderActionType,
 } from '../../../../redux/actionButtonsSlice';
 import { useTypedSelector } from '../../../../redux/hooks';
+import { Activity, useActivity } from '../../../activity/Activity';
 import ErrorBoundary from '../../ErrorBoundary';
 import SectionHeader, { HeaderStyle } from '../../SectionHeader';
 import CopyButton from '../CopyButton';
@@ -31,6 +32,24 @@ import DeleteButton from '../DeleteButton';
 import EditButton from '../EditButton';
 import { RestartButton } from '../RestartButton';
 import ScaleButton from '../ScaleButton';
+
+/**
+ * The details view can be rendered either as a route or inside an activity (the
+ * split-right details pane). In the latter case the pane is showing an object
+ * that is on its way out, so deleting should dismiss it. Route-level details
+ * pages render outside any activity, where this is a no-op.
+ */
+function DetailsDeleteButton<T extends KubeObject>({ item }: { item: T }) {
+  const [activity] = useActivity();
+  const activityId = activity?.id;
+
+  return (
+    <DeleteButton
+      item={item}
+      afterConfirm={activityId ? () => Activity.close(activityId) : undefined}
+    />
+  );
+}
 
 export interface MainInfoHeaderProps<T extends KubeObject> {
   resource: T | null;
@@ -68,7 +87,7 @@ export function MainInfoHeader<T extends KubeObject>(props: MainInfoHeaderProps<
           Action = EditButton;
           break;
         case DefaultHeaderAction.DELETE:
-          Action = DeleteButton;
+          Action = DetailsDeleteButton;
           break;
         default:
           break;


### PR DESCRIPTION
Fixes the two behaviours reported in #852: deleting a resource from inside a project threw the user back to the cluster-wide resource list, and left the details pane open on the deleted object.

Both are general Headlamp behaviour rather than anything AKS-specific, hence `upstreamable:` — this is a candidate for kubernetes-sigs/headlamp.

## Bug 1 — delete navigates you off the page you're on

`DeleteButton` hardcoded `startUrl`/`errorUrl` to `item.getListLink()`. `executeClusterAction` copies that into the action's `url`, and `ActionsNotifier` turns it into a `history.push()`. So delete always navigated to the cluster-wide list, no matter where it was triggered from.

Now it navigates away only when the page being viewed *is* the object's own details page — the one case that would 404 once the object is gone. Everywhere else (a list, a project view, the details pane) the user stays put. This is what `DeleteMultipleButton` already does with `startUrl: location.pathname`. An explicit `options` prop still wins, so callers and plugins keep control.

## Bug 2 — the details pane stays open

Worth noting for reviewers: the issue thread originally attributed this to `drawerMode.selectedResource` never being cleared. That state is actually **dead** — the only `dispatch(setSelectedResource(...))` in the tree is `DetailsDrawer.tsx:39` setting it to `undefined`, so `DetailsDrawer` never renders at all.

The pane is an **Activity**, launched by `Link.tsx` with `location: 'split-right'`, `temporary: true` — which is what `ProjectResourcesTab` renders resource names through. Nothing closed it on delete.

`MainInfoSectionHeader` is the one place that knows it is rendering the very object being deleted, so it now dismisses the enclosing activity on confirm via `useActivity()` + `Activity.close()`. Route-level details pages render outside any activity (`RouteSwitcher` and `ActivitiesRenderer` are siblings in `Layout`), so this is a no-op there, and row-level delete buttons are unaffected.

The pane closes immediately on confirm. Note this is inside the 5s undo grace period: cancelling restores the location but does not reopen the pane. That was a deliberate call over closing on success.

## Tests

New `DeleteButton.test.tsx` and `MainInfoSectionHeader.test.tsx`. The two behaviour-preservation cases (navigate away from a real details page; explicit `options` wins) were written to pass *before* the fix, so they guard against over-correction.

## Verification

- `npm test -- --run` — 107 files passed, 1 skipped; 1644 tests passed, 0 failed (includes 553 storyshots)
- `npm run ci-lint` (`--max-warnings 0`) — clean
- `npm run format-check` — clean
- `npx tsc --noEmit` — 4 errors, byte-identical to the unmodified branch tip; all pre-existing missing-dep resolution failures. `npm run tsc` could not be used: `tsgo` (`@typescript/native-preview`) is declared in `package.json` but missing from the installed tree.

Full suite verified at the branch tip; not re-run per-commit.

## Reviewer focus

The fix compares `location.pathname === item.getDetailsLink()`. If a multi-cluster details URL is ever formatted differently from `getDetailsLink()`'s output, the effect is that the user stays on a now-empty details page instead of being sent to the list — degraded rather than broken, but worth a second pair of eyes.

Does **not** bump the superproject submodule pointer, which is currently 9 commits behind `headlamp-downstream`. That's a separate PR.