### PR TITLE
build: stage the amd64 aks-mcp asset for both macOS targets

### DIFF
--- a/build/aks-mcp-config.test.ts
+++ b/build/aks-mcp-config.test.ts
@@ -113,12 +113,33 @@ test('maps node platform and arch onto the published asset names', () => {
   );
   assert.equal(
     resolveAksMcpTarget(rootDir, 'darwin', 'arm64').downloadUrl,
-    'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-arm64'
+    'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-amd64'
   );
   assert.equal(
     resolveAksMcpTarget(rootDir, 'win32', 'arm64').downloadUrl,
     'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-windows-arm64.exe'
   );
+});
+
+test('stages the amd64 asset for both mac targets so the DMG stays notarizable', () => {
+  const rootDir = createRoot();
+
+  // Go ad-hoc signs its darwin/arm64 output, and that signature survives into the
+  // DMG because build.mac.signIgnore excludes external-tools from signing. Apple's
+  // notary service rejects ad-hoc signed code, which failed the 0.10.0 arm64
+  // release build while x64 passed. Pin both mac targets to the amd64 asset so a
+  // version bump cannot silently reintroduce an arm64 binary.
+  for (const arch of ['arm64', 'x64']) {
+    const target = resolveAksMcpTarget(rootDir, 'darwin', arch);
+
+    assert.equal(
+      target.downloadUrl,
+      'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-amd64'
+    );
+    assert.equal(target.expectedChecksum, 'darwin-amd64-sum');
+    // The staged target still records the architecture actually being packaged.
+    assert.equal(target.arch, arch);
+  }
 });
 
 test('selects the checksum for the requested architecture', () => {

--- a/build/aks-mcp-config.ts
+++ b/build/aks-mcp-config.ts
@@ -23,6 +23,28 @@ const ASSET_ARCH: Record<string, string> = {
   x64: 'amd64',
 };
 
+/**
+ * Resolves which published asset to stage for a build target.
+ *
+ * macOS always takes the amd64 asset, including for Apple Silicon builds. Two
+ * reasons, both load bearing:
+ *
+ * 1. Apple's notary service rejects ad-hoc signatures. Go signs its darwin/arm64
+ *    output ad-hoc (Apple Silicon will not execute unsigned code), and this binary
+ *    lands under resources/external-tools, which build.mac.signIgnore excludes from
+ *    signing -- so the ad-hoc signature survives into the DMG and fails
+ *    notarization. The unsigned amd64 asset notarizes cleanly.
+ * 2. The mac bundle is already x86_64 throughout: config.externalTools.python pins
+ *    a single x86_64-apple-darwin CPython for both mac targets, and Azure CLI runs
+ *    on it, so Apple Silicon already depends on Rosetta.
+ *
+ * Shipping a native arm64 aks-mcp requires stripping or replacing that ad-hoc
+ * signature before packaging; until then this keeps the mac builds notarizable.
+ */
+function assetArchFor(platform: string, targetArch: string): string {
+  return platform === 'darwin' ? ASSET_ARCH.x64 : ASSET_ARCH[targetArch];
+}
+
 /** Records which platform/arch was staged so later build steps can verify it. */
 const STAGED_TARGET_FILE = path.join('headlamp', 'app', 'resources', '.aks-mcp-target.json');
 
@@ -94,7 +116,7 @@ export function resolveAksMcpTarget(
     );
   }
 
-  const assetArch = ASSET_ARCH[targetArch];
+  const assetArch = assetArchFor(platform, targetArch);
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8')
   );


### PR DESCRIPTION
## Description

Unblocks the mac arm64 release build for 0.10.0, which fails at ESRP notarization while linux, win, and mac x64 all pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Root cause

`aks-mcp` (new in 0.10.0) is the only new native binary in the mac bundle, and it is the first arm64 Mach-O ever staged under `resources/external-tools`. Inspecting the pinned v0.0.20 release assets (checksums match `package.json`):

| Asset | Arch | Code signature |
| --- | --- | --- |
| `aks-mcp-darwin-arm64` | arm64 | `LC_CODE_SIGNATURE` present — **ad-hoc** |
| `aks-mcp-darwin-amd64` | x86_64 | none |

Go's linker ad-hoc signs darwin/arm64 output because Apple Silicon will not execute unsigned code. That directory is excluded from signing by `build.mac.signIgnore` in `headlamp/app/package.json`, so the ad-hoc signature survives into the DMG. Apple's notary service rejects ad-hoc signed code, which is why arm64 fails and x64 — carrying the *unsigned* amd64 asset — succeeds.

This also explains why 0.9.0 notarized: `config.externalTools.python` pins a single `x86_64-apple-darwin` CPython for both mac targets, so before `aks-mcp` there was no arm64 code under `external-tools` at all.

Failing run: [build 243865](https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build/results?buildId=243865) — `Notarize (arm64)` failed at `ESRP Notarization` (`MacSignFailed`, `FailDoNotRetry`); every other stage green on both architectures.

## Changes Made

- `build/aks-mcp-config.ts`: new `assetArchFor()` resolves darwin to the `amd64` asset for both mac targets; `resolveAksMcpTarget` uses it instead of indexing `ASSET_ARCH` directly.
- `build/aks-mcp-config.test.ts`: regression test pinning both mac targets to `aks-mcp-darwin-amd64`, plus the updated existing assertion.

`target.arch` still reports the real packaging architecture — only asset selection changed, so the staged-target checksum comparison in `verify-bundled-tools.ts` stays consistent and needed no change.

## Trade-off

`aks-mcp` runs under Rosetta on Apple Silicon. This adds no new requirement: the bundled Azure CLI already runs on an x86_64 CPython there. Shipping a native arm64 binary means stripping or replacing the ad-hoc signature before packaging — deliberately left as follow-up rather than done in an rc.

## Testing

- [x] Unit tests pass
- [x] New and existing unit tests pass locally with my changes

### Test Cases

1. `npm run test:build` — 19/19 pass.
2. Red-green: reverted `assetArchFor` to the previous behavior and re-ran — the new test fails (`not ok 8`), then passes on restore. The test is a real guard, not a tautology.
3. `npx tsc --noEmit` on the changed file — exit 0.

**Not verified locally:** `npm run test:post-build` (needs a real build) and the mac build itself. The confirming evidence is the requeued arm64 notarization.

## Reviewer Notes

The root cause is inferred from the arm64/x64 differential plus the Mach-O headers, not from Apple's notary log — ESRP returned `errorDetails: ""`. The chain is tight and this ships the exact asset that notarized in build 243865, but if the requeued run still fails, the next step is ESRP support quoting `OperationId 3566d444-f938-47cc-969f-73d5e807b96d` to retrieve the notary log.

`config.externalTools.aksMcp.darwin.arm64.checksum` is now unused. Left in place deliberately — it is the pinned hash needed for the native-arm64 follow-up.
