### PR TITLE
DeployWizard: Surface azure context loading state

### DIFF
--- a/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
+++ b/plugins/aks-desktop/src/components/Deploy/DeployButton.tsx
@@ -54,7 +54,11 @@ function DeployDialogContent({
   initialApplicationName,
   onClose,
 }: DeployDialogContentProps) {
-  const { azureContext, error: azureContextError } = useAzureContext(cluster);
+  const {
+    azureContext,
+    error: azureContextError,
+    isLoading: azureContextLoading,
+  } = useAzureContext(cluster);
   const { isManagedNamespace, azureRbacEnabled } = useNamespaceCapabilities({
     subscriptionId: azureContext?.subscriptionId,
     resourceGroup: azureContext?.resourceGroup,
@@ -80,6 +84,7 @@ function DeployDialogContent({
           : undefined
       }
       azureContextError={azureContextError ?? undefined}
+      azureContextLoading={azureContextLoading}
     />
   );
 }

--- a/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
+++ b/plugins/aks-desktop/src/components/DeployTab/components/ClusterDeployCard.tsx
@@ -82,7 +82,11 @@ interface ClusterDeployCardProps {
 
 export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: ClusterDeployCardProps) {
   const { t } = useTranslation();
-  const { azureContext } = useAzureContext(cluster);
+  const {
+    azureContext,
+    error: azureContextError,
+    isLoading: azureContextLoading,
+  } = useAzureContext(cluster);
   const pipelineStatus = usePipelineStatus(cluster, namespace);
   // Pipeline actions stay behind the preview flag; with them disabled there is
   // no GitHubAuthProvider above this card, so nothing may open a dialog that
@@ -301,6 +305,8 @@ export function ClusterDeployCard({ cluster, namespace, pipelineEnabled }: Clust
                 }
               : undefined
           }
+          azureContextError={azureContextError ?? undefined}
+          azureContextLoading={azureContextLoading}
         />
       </Dialog>
 

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
@@ -26,6 +26,8 @@ type DeployWizardProps = {
   azureContext?: DeployAzureContext;
   /** Error message from resolving the Azure context, if any. */
   azureContextError?: string;
+  /** True while the Azure context is still being resolved. */
+  azureContextLoading?: boolean;
 };
 
 /**
@@ -74,6 +76,7 @@ export default function DeployWizard(props: DeployWizardProps) {
                 containerConfig={containerConfig}
                 azureContext={props.azureContext}
                 azureContextError={props.azureContextError}
+                azureContextLoading={props.azureContextLoading}
                 namespace={props.namespace}
               />
             )}

--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
@@ -25,6 +25,8 @@ interface ConfigureContainerProps {
   azureContext?: DeployAzureContext;
   /** Error message from resolving the Azure context, if any. */
   azureContextError?: string;
+  /** True while the Azure context is still being resolved. */
+  azureContextLoading?: boolean;
   /** Target namespace for workload identity setup */
   namespace?: string;
 }
@@ -34,6 +36,7 @@ export default function ConfigureContainer({
   requireContainerImage = true,
   azureContext,
   azureContextError,
+  azureContextLoading,
   namespace,
 }: ConfigureContainerProps) {
   const { t } = useTranslation();
@@ -96,6 +99,7 @@ export default function ConfigureContainer({
               containerConfig={containerConfig}
               azureContext={azureContext}
               azureContextError={azureContextError}
+              azureContextLoading={azureContextLoading}
               namespace={namespace}
             />
           </StepContent>

--- a/plugins/aks-desktop/src/components/DeployWizard/components/WorkloadIdentityStep.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/WorkloadIdentityStep.tsx
@@ -36,6 +36,8 @@ interface WorkloadIdentityStepProps {
   azureContext?: DeployAzureContext;
   /** Error message from resolving the Azure context, if any. */
   azureContextError?: string;
+  /** True while the Azure context is still being resolved. */
+  azureContextLoading?: boolean;
   namespace?: string;
 }
 
@@ -43,6 +45,7 @@ export default function WorkloadIdentityStep({
   containerConfig,
   azureContext,
   azureContextError,
+  azureContextLoading,
   namespace,
 }: WorkloadIdentityStepProps) {
   const { t } = useTranslation();
@@ -118,9 +121,17 @@ export default function WorkloadIdentityStep({
         }
       />
       {!azureContext && (
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', ml: 5 }}>
-          {azureContextError ?? t('Azure sign-in is required to configure workload identity.')}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 5 }}>
+          {azureContextLoading && <CircularProgress size={14} />}
+          <Typography
+            variant="caption"
+            color={!azureContextLoading && azureContextError ? 'error' : 'text.secondary'}
+          >
+            {azureContextLoading
+              ? t('Loading Azure context...')
+              : azureContextError ?? t('Azure sign-in is required to configure workload identity.')}
+          </Typography>
+        </Box>
       )}
       {containerConfig.config.enableWorkloadIdentity && azureContext && (
         <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/plugins/aks-desktop/src/hooks/useAzureContext.test.ts
+++ b/plugins/aks-desktop/src/hooks/useAzureContext.test.ts
@@ -65,6 +65,17 @@ describe('useAzureContext', () => {
     expect(mockGetClusterInfo).not.toHaveBeenCalled();
   });
 
+  it('reports loading, not a sign-in error, while the auth check is still running', () => {
+    mockAuth({ isLoggedIn: false, isChecking: true, tenantId: undefined });
+
+    const { result } = renderHook(() => useAzureContext('my-cluster'));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.azureContext).toBeNull();
+    expect(mockGetClusterInfo).not.toHaveBeenCalled();
+  });
+
   it('resolves context when cluster info is available', async () => {
     mockAuth();
     mockGetClusterInfo.mockResolvedValue({
@@ -83,6 +94,7 @@ describe('useAzureContext', () => {
       });
     });
     expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('sets error when getClusterInfo fails', async () => {
@@ -95,6 +107,7 @@ describe('useAzureContext', () => {
       expect(result.current.error).toBe('network error');
     });
     expect(result.current.azureContext).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('sets error when required fields are missing', async () => {
@@ -111,6 +124,7 @@ describe('useAzureContext', () => {
       expect(result.current.error).toContain('Missing required Azure context');
     });
     expect(result.current.azureContext).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('clears context when cluster changes to undefined', async () => {

--- a/plugins/aks-desktop/src/hooks/useAzureContext.ts
+++ b/plugins/aks-desktop/src/hooks/useAzureContext.ts
@@ -17,25 +17,38 @@ export interface AzureContext {
 
 export const useAzureContext = (
   cluster: string | undefined
-): { azureContext: AzureContext | null; error: string | null } => {
+): { azureContext: AzureContext | null; error: string | null; isLoading: boolean } => {
   const { t } = useTranslation();
   const azureAuth = useAzureAuth();
   const [azureContext, setAzureContext] = useState<AzureContext | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Match what the effect sets, so the first render doesn't show a stale state.
+  const [isLoading, setIsLoading] = useState(
+    () => Boolean(cluster) && (azureAuth.isChecking || azureAuth.isLoggedIn)
+  );
 
   useEffect(() => {
     if (!cluster) {
       setAzureContext(null);
+      setIsLoading(false);
       setError(t('No cluster is associated with this project.'));
+      return;
+    }
+    // isLoggedIn is only meaningful once isChecking clears.
+    if (azureAuth.isChecking) {
+      setIsLoading(true);
+      setError(null);
       return;
     }
     if (!azureAuth.isLoggedIn) {
       setAzureContext(null);
+      setIsLoading(false);
       setError(t('Please sign in to Azure to continue.'));
       return;
     }
     setAzureContext(null); // clear stale context during fetch
     setError(null);
+    setIsLoading(true);
     let cancelled = false;
     (async () => {
       try {
@@ -71,12 +84,16 @@ export const useAzureContext = (
           console.error('Failed to resolve Azure context:', err);
           setError(err instanceof Error ? err.message : t('Failed to load Azure context'));
         }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [cluster, azureAuth.isLoggedIn, azureAuth.tenantId]);
+  }, [cluster, azureAuth.isChecking, azureAuth.isLoggedIn, azureAuth.tenantId]);
 
-  return { azureContext, error };
+  return { azureContext, error, isLoading };
 };


### PR DESCRIPTION
## Description

Observed Issue: 

The 'Enable Workload Identity' toggle on step 7 of the deploy wizard stays disabled with "Azure sign-in is required to configure workload identity", with no way to determine whether Azure is still resolving, unreachable, or the user is signed out. They're all rendered to the user identically.

Context: 

Resolving the context takes three serial `az` calls, and the first ones after a fresh build or app launch are often slow. So on a cold start we can reach that apparently disabled state, but on subsequent runs we tend to reach that after the context is already resolved. 

Fix: 

Error handling for context resolution already existed, so this adds the missing in-between state. `useAzureContext` now exposes `isLoading`, and the step now shows a spinner with "Loading Azure context…" while resolving, after which done it enables the toggle. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: \***\*\_\_\_\*\***

## Changes Made

- `useAzureContext`:  now returns `isLoading`, and treats `isChecking` as its own state so a sign-in check that's still running isn't reported as signed out. 
- Added `azureContextLoading` to be passed down from `DeployButton` through `DeployWizard ` and `ConfigureContainer` to `WorkloadIdentityStep`.
- `ClusterDeployCard` now forwards `azureContextError`. 
- Added test & assertions to `useAzureContext.test.ts` 

## Testing

- [x ] Unit tests pass
- [ ] Integration tests pass
- [x ] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

The core issue is something that I could only reproduce on my first attempt naturally- Thus, you might not see the actual loading state when testing since it's likely to resolve before reaching the step. If indefinite loading is repeatedly observed, that indicates a larger issue that should definitely be logged.

Thus to test you can:

1. Restart the app for a cold start
2. Open a project, select deploy an application
3. Click straight to step 7 . - If loading still, you should see a spinner with the loading azure context message. Otherwise, the toggle should be enabled. We should not observe a disabled toggle with no loading indicator. 