### PR TITLE
DeployWizard: Allow direct navigation to previous configure steps

### DIFF
--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.test.tsx
@@ -240,3 +240,43 @@ describe('DeployWizard handleDeploy', () => {
     });
   });
 });
+
+describe('DeployWizard container step navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('can jump back to an earlier step and forward again', async () => {
+    render(<DeployWizard cluster="test-cluster" namespace="default" onClose={vi.fn()} />);
+    const stepButton = (name: RegExp) => screen.getByRole('button', { name });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Container Image' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    fireEvent.change(screen.getByLabelText('Application name'), { target: { value: 'my-app' } });
+    fireEvent.change(screen.getByLabelText('Container image'), { target: { value: 'my-image' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(stepButton(/Networking/)).toHaveAttribute('aria-current', 'step'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(stepButton(/Healthchecks/)).toHaveAttribute('aria-current', 'step'));
+
+    // Never-visited steps stay disabled.
+    expect(stepButton(/Advanced/)).toBeDisabled();
+
+    fireEvent.click(stepButton(/Basics/));
+    await waitFor(() => expect(screen.getByLabelText('Application name')).toHaveValue('my-app'));
+
+    // Going back must not re-gate the steps that were already visited.
+    expect(stepButton(/Healthchecks/)).not.toBeDisabled();
+
+    // Leaving and re-entering the Configure step must not re-gate them either.
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Configure' }).pop()!);
+    await waitFor(() => expect(stepButton(/Healthchecks/)).not.toBeDisabled());
+
+    fireEvent.click(stepButton(/Healthchecks/));
+    await waitFor(() => expect(stepButton(/Healthchecks/)).toHaveAttribute('aria-current', 'step'));
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureContainer.tsx
@@ -2,9 +2,9 @@
 // Licensed under the Apache 2.0.
 
 import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { Step, StepContent, StepLabel, Stepper, Typography } from '@mui/material';
+import { Step, StepButton, StepContent, Stepper, Typography } from '@mui/material';
 import React from 'react';
-import { ContainerConfig } from '../hooks/useContainerConfiguration';
+import { CONTAINER_STEPS, type ContainerConfig } from '../hooks/useContainerConfiguration';
 import AdvancedStep from './AdvancedStep';
 import BasicsStep from './BasicsStep';
 import type { DeployAzureContext } from './configureContainerUtils';
@@ -19,6 +19,8 @@ interface ConfigureContainerProps {
   containerConfig: {
     config: ContainerConfig;
     setConfig: React.Dispatch<React.SetStateAction<ContainerConfig>>;
+    /** Highest step reached so far; steps up to it stay navigable. */
+    furthestStep: number;
   };
   /** When false, containerImage is not required to proceed past the Basics step. Default: true. */
   requireContainerImage?: boolean;
@@ -39,16 +41,20 @@ export default function ConfigureContainer({
   azureContextLoading,
   namespace,
 }: ConfigureContainerProps) {
+  const { config, setConfig, furthestStep } = containerConfig;
   const { t } = useTranslation();
+
+  /** Returns a click handler that jumps the stepper to the given step. */
+  const goToStep = (containerStep: number) => () => setConfig(c => ({ ...c, containerStep }));
 
   return (
     <>
       <Typography variant="h6" component="h2" gutterBottom>
         {t('Configure Container Deployment')}
       </Typography>
-      <Stepper activeStep={containerConfig.config.containerStep} orientation="vertical">
+      <Stepper activeStep={config.containerStep} orientation="vertical">
         <Step>
-          <StepLabel>{t('Basics')}</StepLabel>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.BASICS)}>{t('Basics')}</StepButton>
           <StepContent>
             <BasicsStep
               containerConfig={containerConfig}
@@ -57,43 +63,51 @@ export default function ConfigureContainer({
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Networking')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.NETWORKING > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.NETWORKING)}>{t('Networking')}</StepButton>
           <StepContent>
             <NetworkingStep containerConfig={containerConfig} />
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Healthchecks')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.HEALTHCHECKS > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.HEALTHCHECKS)}>
+            {t('Healthchecks')}
+          </StepButton>
           <StepContent>
             <HealthchecksStep containerConfig={containerConfig} />
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Resource Limits')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.RESOURCES > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.RESOURCES)}>
+            {t('Resource Limits')}
+          </StepButton>
           <StepContent>
             <ResourcesStep containerConfig={containerConfig} />
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Environment Variables')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.ENV_VARS > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.ENV_VARS)}>
+            {t('Environment Variables')}
+          </StepButton>
           <StepContent>
             <EnvVarsStep containerConfig={containerConfig} />
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{'HPA'}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.HPA > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.HPA)}>{'HPA'}</StepButton>
           <StepContent>
             <HpaStep containerConfig={containerConfig} />
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Workload Identity')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.WORKLOAD_IDENTITY > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.WORKLOAD_IDENTITY)}>
+            {t('Workload Identity')}
+          </StepButton>
           <StepContent>
             <WorkloadIdentityStep
               containerConfig={containerConfig}
@@ -105,8 +119,8 @@ export default function ConfigureContainer({
           </StepContent>
         </Step>
 
-        <Step>
-          <StepLabel>{t('Advanced')}</StepLabel>
+        <Step disabled={CONTAINER_STEPS.ADVANCED > furthestStep}>
+          <StepButton onClick={goToStep(CONTAINER_STEPS.ADVANCED)}>{t('Advanced')}</StepButton>
           <StepContent>
             <AdvancedStep containerConfig={containerConfig} />
           </StepContent>

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployWizardPure.stories.tsx
@@ -63,6 +63,7 @@ const containerConfigStub = {
     containerPreviewYaml: '',
   },
   setConfig: noOp as any,
+  furthestStep: 0,
 };
 
 const baseArgs: DeployWizardPureProps = {

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useContainerConfiguration.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useContainerConfiguration.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Flat configuration state for the container deployment wizard.
@@ -173,5 +173,9 @@ export function useContainerConfiguration(
     }
   }, [config.targetPort, config.useCustomServicePort]);
 
-  return { config, setConfig };
+  /** Used to keep every step already visited clickable after jumping back to an earlier one. */
+  const furthestStep = useRef(config.containerStep);
+  furthestStep.current = Math.max(furthestStep.current, config.containerStep);
+
+  return { config, setConfig, furthestStep: furthestStep.current };
 }

--- a/plugins/aks-desktop/src/components/GitHubPipeline/components/AgentSetupReview.tsx
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/components/AgentSetupReview.tsx
@@ -26,6 +26,8 @@ interface AgentSetupReviewProps {
   containerConfig?: {
     config: ContainerConfig;
     setConfig: React.Dispatch<React.SetStateAction<ContainerConfig>>;
+    /** Highest step reached so far; steps up to it stay navigable. */
+    furthestStep: number;
   };
 }
 

--- a/plugins/aks-desktop/src/components/GitHubPipeline/components/GitHubPipelineWizardPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/GitHubPipeline/components/GitHubPipelineWizardPure.stories.tsx
@@ -261,6 +261,7 @@ function makeContainerConfig(): ReturnType<typeof useContainerConfiguration> {
       containerPreviewYaml: '',
     },
     setConfig: noop,
+    furthestStep: 0,
   };
 }
 


### PR DESCRIPTION
## Description

**Context:**

Currently in the Deploy wizard's Configure step, the container config stepper can only be navigated one step at a time. 

Thus, editing a single field on Basics from step 7 meant clicking `Back` six times, then `Continue` six times again to return.

This PR updates our navigation so that steps are now clickable in both directions, while keeping steps that were never reached gated. Added a few handlers and refs to orchestrate this alongside corresponding tests for validation.

## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/263
- https://github.com/Azure/aks-desktop/issues/263

## Changes Made

- Replaced step labels with `StepButton`s that set `containerStep` directly.
- Added `furthestStep` ref to track the highest step reached. Each step then passes `disabled={STEP > furthestStep.current}`.
- Added `'DeployWizard container step navigation'` suite to `DeployWizard.test.tsx` to validate step & gating logic

Visited steps are now clickable in both directions, and steps that were never reached stay gated.


## Testing

- [x ] Unit tests pass
- [ ] Integration tests pass
- [x ] Manual testing completed
- [ ] Performance tested (if applicable)
- [ ] Accessibility tested (if applicable)

**To Test:**

1. Navigate to a project
2. Click deploy
3. Select container image on page 1
4. Once on page 2, proceed with at least one of the steps by entering information then clicking 'next'. Then click any of the previous steps.
5. Once successfully back on a previous step, click a further un-visited step to assert that un-visited steps are still disabled.
6. Then, click a further previously-visited step to assert we're able to jump back to where we left off. 