### PR TITLE
build: skip bundled az extension check on Windows

### DIFF
--- a/build/azure-cli-verification.test.ts
+++ b/build/azure-cli-verification.test.ts
@@ -10,6 +10,7 @@ import { afterEach, test } from "node:test";
 import {
   getExtensionTimeoutResult,
   readRequiredAzureCliExtensions,
+  shouldVerifyBundledExtensions,
 } from "./azure-cli-verification";
 
 const tempDirs: string[] = [];
@@ -64,4 +65,10 @@ test("returns no required extensions for missing or malformed configuration", ()
 
   assert.deepEqual(readRequiredAzureCliExtensions(malformedRoot), []);
   assert.deepEqual(readRequiredAzureCliExtensions(missingRoot), []);
+});
+
+test("verifies bundled extensions only on platforms that pre-install them", () => {
+  assert.equal(shouldVerifyBundledExtensions("linux"), true);
+  assert.equal(shouldVerifyBundledExtensions("darwin"), true);
+  assert.equal(shouldVerifyBundledExtensions("win32"), false);
 });

--- a/build/azure-cli-verification.ts
+++ b/build/azure-cli-verification.ts
@@ -32,6 +32,21 @@ export function readRequiredAzureCliExtensions(rootDir: string): string[] {
 }
 
 /**
+ * Whether the bundled Azure CLI is expected to carry the required extensions.
+ *
+ * Windows ships the plain Azure CLI ZIP — the Windows install path in
+ * download-az-cli.ts has no extension step — and the app installs required
+ * extensions at runtime instead (src/utils/azure/az-extensions.ts). Only the
+ * Linux/macOS bundles pre-install extensions, so only they are verified.
+ *
+ * @param platform - The build platform, as reported by `process.platform`.
+ * @returns True when the platform's bundle should contain the extensions.
+ */
+export function shouldVerifyBundledExtensions(platform: string): boolean {
+  return platform !== "win32";
+}
+
+/**
  * Builds the failed extension result used when `az version` times out.
  *
  * @param requiredExtensions - Extensions whose bundled versions could not be verified.

--- a/build/verify-bundled-tools.ts
+++ b/build/verify-bundled-tools.ts
@@ -22,6 +22,7 @@ import {
 import {
   getExtensionTimeoutResult,
   readRequiredAzureCliExtensions,
+  shouldVerifyBundledExtensions,
 } from './azure-cli-verification';
 
 const SCRIPT_DIR = __dirname;
@@ -372,17 +373,23 @@ function testAzureCliInvocation(): void {
     // Every extension the build configures must actually be there. Installation
     // failures are non-fatal in download-az-cli.ts, so without checking here a
     // release can ship missing one: without `connectedk8s`, for instance, no AKS
-    // Hybrid & Edge cluster can be discovered or connected at all.
-    const bundledExtensions = versionData.extensions ?? {};
-    const missingExtensions = requiredExtensions.filter(name => !bundledExtensions[name]);
+    // Hybrid & Edge cluster can be discovered or connected at all. Windows is
+    // the exception — its bundle never carries extensions; the app installs
+    // them at runtime.
+    if (shouldVerifyBundledExtensions(CURRENT_PLATFORM)) {
+      const bundledExtensions = versionData.extensions ?? {};
+      const missingExtensions = requiredExtensions.filter(name => !bundledExtensions[name]);
 
-    addResult(
-      'Azure CLI extensions',
-      missingExtensions.length === 0,
-      missingExtensions.length === 0
-        ? `All required extensions bundled: ${requiredExtensions.join(', ')}`
-        : `Missing required extension(s): ${missingExtensions.join(', ')}`
-    );
+      addResult(
+        'Azure CLI extensions',
+        missingExtensions.length === 0,
+        missingExtensions.length === 0
+          ? `All required extensions bundled: ${requiredExtensions.join(', ')}`
+          : `Missing required extension(s): ${missingExtensions.join(', ')}`
+      );
+    } else {
+      logInfo('Skipping Azure CLI extensions check on Windows (extensions install at runtime)');
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     // Don't fail the test on timeout in CI, just warn
@@ -393,8 +400,10 @@ function testAzureCliInvocation(): void {
         true,
         'Skipped due to timeout (executable exists and is valid)'
       );
-      const extensionResult = getExtensionTimeoutResult(requiredExtensions);
-      addResult(extensionResult.name, extensionResult.passed, extensionResult.message);
+      if (shouldVerifyBundledExtensions(CURRENT_PLATFORM)) {
+        const extensionResult = getExtensionTimeoutResult(requiredExtensions);
+        addResult(extensionResult.name, extensionResult.passed, extensionResult.message);
+      }
     } else {
       addResult(
         'Azure CLI invocation',


### PR DESCRIPTION
## Problem

The Windows release pipeline (build 244348) fails post-build verification:

```
❌ Azure CLI extensions: Missing required extension(s): aks-preview, resource-graph, alertsmanagement, connectedk8s
❌ Post-build verification FAILED!
make: *** [Makefile:83: app-build] Error 1
```

This aborts `make app-build` before electron-builder packages the NSIS installer, so `headlamp/app/dist` ends up with only `win-unpacked` and the "Copy built EXE" step fails.

## Root cause

#782 made post-build verification fail when a configured az CLI extension is missing from the bundle (`38ab5e854`). That check is unsatisfiable on Windows: `installAzCliWindows()` in `build/download-az-cli.ts` just extracts the Azure CLI ZIP — only the Linux/macOS path (`installAzCliWithPython`) has an extension-install step. On Windows the app instead installs required extensions at runtime (`plugins/aks-desktop/src/utils/azure/az-extensions.ts`), which is how shipped Windows builds have always worked.

## Fix

- New `shouldVerifyBundledExtensions(platform)` helper in `build/azure-cli-verification.ts` (false for `win32`).
- Guard both extension-check sites in `build/verify-bundled-tools.ts` (success path and the `az version` timeout path); on Windows log a skip notice, matching the existing skip-on-Windows idiom used for the Python checks.
- Linux/macOS behavior unchanged — the check stays fatal there.
- Unit test covering all three platforms.

## Verification

`npm run test:build` — 23/23 pass, including the new test. Also exercised `verify-bundled-tools.ts` under tsx to confirm it loads and runs.

## Follow-ups (not in this PR)

- The "Build AKS desktop (Windows)" step in `.github/workflows/1es-pipeline.yml` lacks `set -e`, so the `make` failure showed the step green and surfaced three steps later.
- Same commit should be cherry-picked to `main`, since `38ab5e854` is on both branches.