### PR TITLE
build: bring rc-0.10.0 release changes back to main

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -149,6 +149,7 @@ extends:
                 displayName: "Install binutils"
               # Build the Windows application
               - bash: |
+                  set -e  # fail the step when the build fails
                   echo "=== BUILD DEBUG START ==="
                   echo "Current working directory: $(pwd)"
                   echo "Node version: $(node --version)"

--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -103,6 +103,7 @@ extends:
                 displayName: "Debug: Checkout"
               # Build the Windows application
               - bash: |
+                  set -e  # fail the step when the build fails
                   echo "=== BUILD DEBUG START ==="
                   echo "Current working directory: $(pwd)"
                   echo "Node version: $(node --version)"

--- a/build/aks-mcp-config.test.ts
+++ b/build/aks-mcp-config.test.ts
@@ -113,12 +113,33 @@ test('maps node platform and arch onto the published asset names', () => {
   );
   assert.equal(
     resolveAksMcpTarget(rootDir, 'darwin', 'arm64').downloadUrl,
-    'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-arm64'
+    'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-amd64'
   );
   assert.equal(
     resolveAksMcpTarget(rootDir, 'win32', 'arm64').downloadUrl,
     'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-windows-arm64.exe'
   );
+});
+
+test('stages the amd64 asset for both mac targets so the DMG stays notarizable', () => {
+  const rootDir = createRoot();
+
+  // Go ad-hoc signs its darwin/arm64 output, and that signature survives into the
+  // DMG because build.mac.signIgnore excludes external-tools from signing. Apple's
+  // notary service rejects ad-hoc signed code, which failed the 0.10.0 arm64
+  // release build while x64 passed. Pin both mac targets to the amd64 asset so a
+  // version bump cannot silently reintroduce an arm64 binary.
+  for (const arch of ['arm64', 'x64']) {
+    const target = resolveAksMcpTarget(rootDir, 'darwin', arch);
+
+    assert.equal(
+      target.downloadUrl,
+      'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-amd64'
+    );
+    assert.equal(target.expectedChecksum, 'darwin-amd64-sum');
+    // The staged target still records the architecture actually being packaged.
+    assert.equal(target.arch, arch);
+  }
 });
 
 test('selects the checksum for the requested architecture', () => {

--- a/build/aks-mcp-config.ts
+++ b/build/aks-mcp-config.ts
@@ -23,6 +23,28 @@ const ASSET_ARCH: Record<string, string> = {
   x64: 'amd64',
 };
 
+/**
+ * Resolves which published asset to stage for a build target.
+ *
+ * macOS always takes the amd64 asset, including for Apple Silicon builds. Two
+ * reasons, both load bearing:
+ *
+ * 1. Apple's notary service rejects ad-hoc signatures. Go signs its darwin/arm64
+ *    output ad-hoc (Apple Silicon will not execute unsigned code), and this binary
+ *    lands under resources/external-tools, which build.mac.signIgnore excludes from
+ *    signing -- so the ad-hoc signature survives into the DMG and fails
+ *    notarization. The unsigned amd64 asset notarizes cleanly.
+ * 2. The mac bundle is already x86_64 throughout: config.externalTools.python pins
+ *    a single x86_64-apple-darwin CPython for both mac targets, and Azure CLI runs
+ *    on it, so Apple Silicon already depends on Rosetta.
+ *
+ * Shipping a native arm64 aks-mcp requires stripping or replacing that ad-hoc
+ * signature before packaging; until then this keeps the mac builds notarizable.
+ */
+function assetArchFor(platform: string, targetArch: string): string {
+  return platform === 'darwin' ? ASSET_ARCH.x64 : ASSET_ARCH[targetArch];
+}
+
 /** Records which platform/arch was staged so later build steps can verify it. */
 const STAGED_TARGET_FILE = path.join('headlamp', 'app', 'resources', '.aks-mcp-target.json');
 
@@ -94,7 +116,7 @@ export function resolveAksMcpTarget(
     );
   }
 
-  const assetArch = ASSET_ARCH[targetArch];
+  const assetArch = assetArchFor(platform, targetArch);
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8')
   );

--- a/build/azure-cli-verification.test.ts
+++ b/build/azure-cli-verification.test.ts
@@ -67,6 +67,20 @@ test("returns no required extensions for missing or malformed configuration", ()
   assert.deepEqual(readRequiredAzureCliExtensions(missingRoot), []);
 });
 
+test("returns no required extensions when configuration is not a list", () => {
+  const nonArrayRoot = createRoot(
+    JSON.stringify({
+      config: {
+        externalTools: {
+          azureCli: { extensions: "aks-preview" },
+        },
+      },
+    })
+  );
+
+  assert.deepEqual(readRequiredAzureCliExtensions(nonArrayRoot), []);
+});
+
 test("verifies bundled extensions only on platforms that pre-install them", () => {
   assert.equal(shouldVerifyBundledExtensions("linux"), true);
   assert.equal(shouldVerifyBundledExtensions("darwin"), true);

--- a/build/azure-cli-verification.test.ts
+++ b/build/azure-cli-verification.test.ts
@@ -10,6 +10,7 @@ import { afterEach, test } from "node:test";
 import {
   getExtensionTimeoutResult,
   readRequiredAzureCliExtensions,
+  shouldVerifyBundledExtensions,
 } from "./azure-cli-verification";
 
 const tempDirs: string[] = [];
@@ -64,4 +65,10 @@ test("returns no required extensions for missing or malformed configuration", ()
 
   assert.deepEqual(readRequiredAzureCliExtensions(malformedRoot), []);
   assert.deepEqual(readRequiredAzureCliExtensions(missingRoot), []);
+});
+
+test("verifies bundled extensions only on platforms that pre-install them", () => {
+  assert.equal(shouldVerifyBundledExtensions("linux"), true);
+  assert.equal(shouldVerifyBundledExtensions("darwin"), true);
+  assert.equal(shouldVerifyBundledExtensions("win32"), false);
 });

--- a/build/azure-cli-verification.ts
+++ b/build/azure-cli-verification.ts
@@ -32,6 +32,21 @@ export function readRequiredAzureCliExtensions(rootDir: string): string[] {
 }
 
 /**
+ * Whether the bundled Azure CLI is expected to carry the required extensions.
+ *
+ * Windows ships the plain Azure CLI ZIP — the Windows install path in
+ * download-az-cli.ts has no extension step — and the app installs required
+ * extensions at runtime instead (src/utils/azure/az-extensions.ts). Only the
+ * Linux/macOS bundles pre-install extensions, so only they are verified.
+ *
+ * @param platform - The build platform, as reported by `process.platform`.
+ * @returns True when the platform's bundle should contain the extensions.
+ */
+export function shouldVerifyBundledExtensions(platform: string): boolean {
+  return platform !== "win32";
+}
+
+/**
  * Builds the failed extension result used when `az version` times out.
  *
  * @param requiredExtensions - Extensions whose bundled versions could not be verified.

--- a/build/azure-cli-verification.ts
+++ b/build/azure-cli-verification.ts
@@ -18,14 +18,16 @@ export interface ToolVerificationResult {
  * Reads the Azure CLI extensions required by the repository build configuration.
  *
  * @param rootDir - Repository root containing `package.json`.
- * @returns Configured extension names, or an empty array when config cannot be read.
+ * @returns Configured extension names, or an empty array when config cannot be read
+ *   or is not a list.
  */
 export function readRequiredAzureCliExtensions(rootDir: string): string[] {
   try {
     const rootPackageJson = JSON.parse(
       fs.readFileSync(path.join(rootDir, "package.json"), "utf-8")
     );
-    return rootPackageJson?.config?.externalTools?.azureCli?.extensions ?? [];
+    const extensions = rootPackageJson?.config?.externalTools?.azureCli?.extensions;
+    return Array.isArray(extensions) ? extensions : [];
   } catch {
     return [];
   }

--- a/build/verify-bundled-tools.ts
+++ b/build/verify-bundled-tools.ts
@@ -22,6 +22,7 @@ import {
 import {
   getExtensionTimeoutResult,
   readRequiredAzureCliExtensions,
+  shouldVerifyBundledExtensions,
 } from './azure-cli-verification';
 
 const SCRIPT_DIR = __dirname;
@@ -372,17 +373,23 @@ function testAzureCliInvocation(): void {
     // Every extension the build configures must actually be there. Installation
     // failures are non-fatal in download-az-cli.ts, so without checking here a
     // release can ship missing one: without `connectedk8s`, for instance, no AKS
-    // Hybrid & Edge cluster can be discovered or connected at all.
-    const bundledExtensions = versionData.extensions ?? {};
-    const missingExtensions = requiredExtensions.filter(name => !bundledExtensions[name]);
+    // Hybrid & Edge cluster can be discovered or connected at all. Windows is
+    // the exception — its bundle never carries extensions; the app installs
+    // them at runtime.
+    if (shouldVerifyBundledExtensions(CURRENT_PLATFORM)) {
+      const bundledExtensions = versionData.extensions ?? {};
+      const missingExtensions = requiredExtensions.filter(name => !bundledExtensions[name]);
 
-    addResult(
-      'Azure CLI extensions',
-      missingExtensions.length === 0,
-      missingExtensions.length === 0
-        ? `All required extensions bundled: ${requiredExtensions.join(', ')}`
-        : `Missing required extension(s): ${missingExtensions.join(', ')}`
-    );
+      addResult(
+        'Azure CLI extensions',
+        missingExtensions.length === 0,
+        missingExtensions.length === 0
+          ? `All required extensions bundled: ${requiredExtensions.join(', ')}`
+          : `Missing required extension(s): ${missingExtensions.join(', ')}`
+      );
+    } else {
+      logInfo('Skipping Azure CLI extensions check on Windows (extensions install at runtime)');
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     // Don't fail the test on timeout in CI, just warn
@@ -393,8 +400,10 @@ function testAzureCliInvocation(): void {
         true,
         'Skipped due to timeout (executable exists and is valid)'
       );
-      const extensionResult = getExtensionTimeoutResult(requiredExtensions);
-      addResult(extensionResult.name, extensionResult.passed, extensionResult.message);
+      if (shouldVerifyBundledExtensions(CURRENT_PLATFORM)) {
+        const extensionResult = getExtensionTimeoutResult(requiredExtensions);
+        addResult(extensionResult.name, extensionResult.passed, extensionResult.message);
+      }
     } else {
       addResult(
         'Azure CLI invocation',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aks-desktop-monorepo",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aks-desktop-monorepo",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aks-desktop-monorepo",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AKS desktop - Headlamp Plugin Monorepo",
   "private": true,
   "scripts": {

--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aks-desktop",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aks-desktop",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@azure/arm-resourcegraph": "^4.2.1",
         "@azure/arm-subscriptions": "^5.1.0",

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aks-desktop",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AKS Headlamp plugin",
   "scripts": {
     "start": "headlamp-plugin start",


### PR DESCRIPTION
> [!IMPORTANT]
> **Please squash-merge.** Two of the underlying release-branch commits don't follow the repo's commit conventions (an unwrapped body on the aks-mcp commit; subject-only release bumps), so this PR should land on `main` as a single clean commit. Suggested squash commit body below.

## Suggested squash commit message

```
build: bring rc-0.10.0 release changes back to main

- Update the version to 0.10.0 and point the headlamp submodule at
  the headlamp-downstream tip used for the release.
- Stage the amd64 aks-mcp asset for both macOS targets: Go ad-hoc
  signs darwin/arm64 output, the signature survived into the DMG
  under the signing-ignored external-tools path, and notarization
  rejected it. The bundle already targets x64 (Rosetta) via the
  pinned x86_64 CPython.
- Skip the bundled az extension check on Windows (#904): the Windows
  CLI ZIP carries no extensions and the app installs them at runtime,
  so the fatal check from #782 broke every Windows release build.
- Add set -e to the Windows and Linux pipeline build steps (#906) so
  a build failure fails the build step instead of surfacing later in
  the copy-artifact step.
```

## Context

The Windows release pipeline (build 244348) failed post-build verification (`Missing required extension(s): aks-preview, resource-graph, alertsmanagement, connectedk8s`), aborting `make app-build` before the NSIS installer was packaged. #904 fixes the check, #906 fixes the pipeline step that hid the failure. Both are merged into `rc-0.10.0`; this PR brings them — plus the 0.10.0 release commits — back onto `main`.

`rc-0.10.0` is a fast-forward of `main`, so the merge is conflict-free.

Verification: `npm run test:build` passes (23 tests, including the new platform-guard test); CodeRabbit CLI review of the two fix commits returned zero findings.