### PR TITLE
ci: fail the build step when the app build fails

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -149,6 +149,7 @@ extends:
                 displayName: "Install binutils"
               # Build the Windows application
               - bash: |
+                  set -e  # fail the step when the build fails
                   echo "=== BUILD DEBUG START ==="
                   echo "Current working directory: $(pwd)"
                   echo "Node version: $(node --version)"

--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -103,6 +103,7 @@ extends:
                 displayName: "Debug: Checkout"
               # Build the Windows application
               - bash: |
+                  set -e  # fail the step when the build fails
                   echo "=== BUILD DEBUG START ==="
                   echo "Current working directory: $(pwd)"
                   echo "Node version: $(node --version)"


### PR DESCRIPTION
## Problem

The Windows and Linux "Build AKS desktop" pipeline steps have no `set -e`, so when `npm run build:win-ci` / `build:linux` fails, the script continues to `echo "✅ Build complete"` and the step reports **success**. The pipeline then only fails later, in the copy-artifact step, pointing at the wrong log.

Build 244348 demonstrated this: post-build verification failed (`make: *** [Makefile:83: app-build] Error 1`) but the build step showed green, and the reported failure was "No aks-desktop .exe file found" three steps later.

## Fix

Add `set -e` to the top of both build steps, matching the copy steps that already use it. The debug commands in these steps all guard expected failures with `|| echo` fallbacks, so `set -e` only propagates the build's own exit code.

The macOS pipeline wraps its build in an explicit `if npm run build:mac; then ... fi` and needs no change.

Once merged to `rc-0.10.0`, this flows into `main` via #905.