### PR TITLE
build: tolerate a non-list az extensions config entry

### DIFF
--- a/build/azure-cli-verification.test.ts
+++ b/build/azure-cli-verification.test.ts
@@ -67,6 +67,20 @@ test("returns no required extensions for missing or malformed configuration", ()
   assert.deepEqual(readRequiredAzureCliExtensions(missingRoot), []);
 });
 
+test("returns no required extensions when configuration is not a list", () => {
+  const nonArrayRoot = createRoot(
+    JSON.stringify({
+      config: {
+        externalTools: {
+          azureCli: { extensions: "aks-preview" },
+        },
+      },
+    })
+  );
+
+  assert.deepEqual(readRequiredAzureCliExtensions(nonArrayRoot), []);
+});
+
 test("verifies bundled extensions only on platforms that pre-install them", () => {
   assert.equal(shouldVerifyBundledExtensions("linux"), true);
   assert.equal(shouldVerifyBundledExtensions("darwin"), true);

--- a/build/azure-cli-verification.ts
+++ b/build/azure-cli-verification.ts
@@ -18,14 +18,16 @@ export interface ToolVerificationResult {
  * Reads the Azure CLI extensions required by the repository build configuration.
  *
  * @param rootDir - Repository root containing `package.json`.
- * @returns Configured extension names, or an empty array when config cannot be read.
+ * @returns Configured extension names, or an empty array when config cannot be read
+ *   or is not a list.
  */
 export function readRequiredAzureCliExtensions(rootDir: string): string[] {
   try {
     const rootPackageJson = JSON.parse(
       fs.readFileSync(path.join(rootDir, "package.json"), "utf-8")
     );
-    return rootPackageJson?.config?.externalTools?.azureCli?.extensions ?? [];
+    const extensions = rootPackageJson?.config?.externalTools?.azureCli?.extensions;
+    return Array.isArray(extensions) ? extensions : [];
   } catch {
     return [];
   }


### PR DESCRIPTION
Addresses the Copilot finding on #905: `readRequiredAzureCliExtensions` types its result as `string[]` but returned whatever `JSON.parse` produced. If `config.externalTools.azureCli.extensions` in root `package.json` were set to a non-array value, `requiredExtensions.filter(...)` in `verify-bundled-tools.ts` would throw a TypeError, crashing post-build verification instead of producing a clean result.

Guard with `Array.isArray` and fall back to an empty list — the same fallback the function already uses for missing or malformed configuration (with the same known tradeoff: a bad config disables the extension check rather than failing it).

Verification: `npm run test:build` — 24/24 pass, including the new non-list test.

Targets `rc-0.10.0` so it flows into `main` via #905, like #904/#906.