### PR TITLE
frontend: ContactUsButton: Fix color contrast for contact us button

### DIFF
--- a/plugins/aks-desktop/src/components/ContactUs/ContactUsButton.tsx
+++ b/plugins/aks-desktop/src/components/ContactUs/ContactUsButton.tsx
@@ -21,6 +21,7 @@ export default function ContactUsButton() {
       description={t('Contact us')}
       longDescription={t('Get help, share feedback, or reach the AKS Desktop team')}
       icon="mdi:message-question-outline"
+      iconButtonProps={{ color: 'inherit' }}
       // Deliberately the default 'action' style at every width, matching
       // Headlamp's own app-bar actions (see SettingsButton). Below `sm` TopBar
       // moves actions into an overflow menu and wraps each one in its own


### PR DESCRIPTION
## Description

The Contact Us button in the app bar was hard to see against the top bar background — the icon rendered in the default `ActionButton` color instead of picking up the app bar's foreground color, so it blended in. This PR sets `iconButtonProps={{ color: 'inherit' }}` so the icon inherits the app bar text color and stays visible in both light and dark themes, matching the other top-bar actions (e.g. `SettingsButton`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes
- [ ] Other: ______

## Related Issues

#843 

## Changes Made

- Pass `iconButtonProps={{ color: 'inherit' }}` to `ActionButton` in `plugins/aks-desktop/src/components/ContactUs/ContactUsButton.tsx` so the icon inherits the app bar's foreground color.
- No new dependencies, no API changes.

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [x] Accessibility tested (if applicable)

### Test Cases

1. Open AKS Desktop and confirm the Contact Us icon is clearly visible in the app bar in light theme.
2. Switch to dark theme and confirm the icon is still clearly visible and matches the color of neighboring app-bar actions.
3. Resize the window below the `sm` breakpoint so actions collapse into the overflow menu, and confirm the Contact Us entry is still reachable and activates the feedback URL.

## Screenshots/Videos

<img width="249" height="119" alt="image" src="https://github.com/user-attachments/assets/7cf33e39-e25b-4f43-9cfb-0c620e762475" />


AKS
<img width="258" height="53" alt="image" src="https://github.com/user-attachments/assets/a2d369a4-947b-4357-b4ba-30c223152e2d" />

Light
<img width="312" height="52" alt="image" src="https://github.com/user-attachments/assets/765626fb-9c0d-446e-bb1b-99da7a9cb2bc" />

Dark
<img width="294" height="49" alt="image" src="https://github.com/user-attachments/assets/00d61856-bc58-4367-87b1-15e1ed516f9a" />

Lights out
<img width="230" height="48" alt="image" src="https://github.com/user-attachments/assets/30bb856d-56d4-4705-a5e7-c6fa66f1e1ab" />



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Breaking Changes

N/A — visual-only fix, no API or behavior changes.

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why this is acceptable)

## Documentation Updates

- [ ] README.md updated
- [ ] API documentation updated
- [ ] Code comments updated
- [ ] User guide updated
- [x] No documentation updates needed

## Reviewer Notes

Focus on the `iconButtonProps={{ color: 'inherit' }}` line — please confirm the Contact Us icon renders with the expected contrast in both themes on your machine, especially if you have a custom app-bar background. The surrounding comment about `buttonStyle` and the overflow menu is unchanged.