### PR TITLE
fix Azure CLI bundling across platforms

### DIFF
--- a/.github/workflows/1es-pipeline-linux.yml
+++ b/.github/workflows/1es-pipeline-linux.yml
@@ -175,7 +175,10 @@ extends:
                   echo "=== END GO ENVIRONMENT ==="
 
                   echo "Building AKS desktop Linux application..."
-                  npm run build:linux
+                  # This pool is amd64, and the bundled Python runs during
+                  # assembly, so only x64 can be built here. Linux arm64 is
+                  # built on a native arm64 runner in build-app-linux.yml.
+                  npm run build:linux:x64
                   echo "✅ Build complete"
 
                   echo "=== POST-BUILD DEBUG ==="

--- a/.github/workflows/build-app-linux.yml
+++ b/.github/workflows/build-app-linux.yml
@@ -16,7 +16,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Install golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -35,10 +43,13 @@ jobs:
           submodules: recursive
 
       - name: Setup AKS desktop and Build Headlamp (Linux)
-        run: npm run build:linux
+        run: npm run build:linux:${{ matrix.arch }}
 
       - name: Upload Linux build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: aks-desktop-linux
-          path: headlamp/app/dist/aks-desktop*.deb
+          name: aks-desktop-linux-${{ matrix.arch }}
+          path: |
+            headlamp/app/dist/aks-desktop*.AppImage
+            headlamp/app/dist/aks-desktop*.tar.gz
+            headlamp/app/dist/aks-desktop*.deb

--- a/.github/workflows/build-app-mac.yml
+++ b/.github/workflows/build-app-mac.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
     runs-on: macos-latest
     steps:
       - name: Install golang
@@ -35,10 +39,10 @@ jobs:
           submodules: recursive
 
       - name: Setup AKS desktop and Build Headlamp (macOS)
-        run: npm run build:mac
+        run: npm run build:mac:${{ matrix.arch }}
 
       - name: Upload macOS build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: aks-desktop-mac-dmgs
+          name: aks-desktop-mac-${{ matrix.arch }}
           path: headlamp/app/dist/aks-desktop*.dmg

--- a/build/aks-mcp-config.test.ts
+++ b/build/aks-mcp-config.test.ts
@@ -121,25 +121,14 @@ test('maps node platform and arch onto the published asset names', () => {
   );
 });
 
-test('stages the amd64 asset for both mac targets so the DMG stays notarizable', () => {
+test('stages the notarizable amd64 asset for each mac target', () => {
   const rootDir = createRoot();
 
-  // Go ad-hoc signs its darwin/arm64 output, and that signature survives into the
-  // DMG because build.mac.signIgnore excludes external-tools from signing. Apple's
-  // notary service rejects ad-hoc signed code, which failed the 0.10.0 arm64
-  // release build while x64 passed. Pin both mac targets to the amd64 asset so a
-  // version bump cannot silently reintroduce an arm64 binary.
-  for (const arch of ['arm64', 'x64']) {
-    const target = resolveAksMcpTarget(rootDir, 'darwin', arch);
-
-    assert.equal(
-      target.downloadUrl,
-      'https://github.com/Azure/aks-mcp/releases/download/v1.2.3/aks-mcp-darwin-amd64'
-    );
-    assert.equal(target.expectedChecksum, 'darwin-amd64-sum');
-    // The staged target still records the architecture actually being packaged.
-    assert.equal(target.arch, arch);
-  }
+  assert.equal(
+    resolveAksMcpTarget(rootDir, 'darwin', 'arm64').expectedChecksum,
+    'darwin-amd64-sum'
+  );
+  assert.equal(resolveAksMcpTarget(rootDir, 'darwin', 'x64').expectedChecksum, 'darwin-amd64-sum');
 });
 
 test('selects the checksum for the requested architecture', () => {

--- a/build/aks-mcp-config.ts
+++ b/build/aks-mcp-config.ts
@@ -23,24 +23,6 @@ const ASSET_ARCH: Record<string, string> = {
   x64: 'amd64',
 };
 
-/**
- * Resolves which published asset to stage for a build target.
- *
- * macOS always takes the amd64 asset, including for Apple Silicon builds. Two
- * reasons, both load bearing:
- *
- * 1. Apple's notary service rejects ad-hoc signatures. Go signs its darwin/arm64
- *    output ad-hoc (Apple Silicon will not execute unsigned code), and this binary
- *    lands under resources/external-tools, which build.mac.signIgnore excludes from
- *    signing -- so the ad-hoc signature survives into the DMG and fails
- *    notarization. The unsigned amd64 asset notarizes cleanly.
- * 2. The mac bundle is already x86_64 throughout: config.externalTools.python pins
- *    a single x86_64-apple-darwin CPython for both mac targets, and Azure CLI runs
- *    on it, so Apple Silicon already depends on Rosetta.
- *
- * Shipping a native arm64 aks-mcp requires stripping or replacing that ad-hoc
- * signature before packaging; until then this keeps the mac builds notarizable.
- */
 function assetArchFor(platform: string, targetArch: string): string {
   return platform === 'darwin' ? ASSET_ARCH.x64 : ASSET_ARCH[targetArch];
 }

--- a/build/az-cli-config.test.ts
+++ b/build/az-cli-config.test.ts
@@ -6,267 +6,133 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, test } from 'node:test';
-
 import {
-  azCliBinaryPath,
-  azCliTargetDir,
-  azCliTargetDirHasContent,
-  expectedAzCliExtensions,
+  azureCliTargetDirHasContent,
   generateWindowsAzWrapperScript,
-  isAzCliStagedForTarget,
-  readAzureCliConfig,
-  readStagedAzCli,
-  resolveAzCliVersion,
-  sameExtensionSet,
+  isAzureCliStagedForTarget,
+  readStagedAzureCliTarget,
+  resolveAzureCliBundleArch,
+  resolveAzureCliTarget,
   WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME,
   WINDOWS_AZ_CLI_ORIGINAL_FILENAME,
-  writeStagedAzCli,
+  writeStagedAzureCliTarget,
 } from './az-cli-config';
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  tempDirs.splice(0).forEach(dir => fs.rmSync(dir, { recursive: true, force: true }));
-});
-
-const AZURE_CLI_CONFIG = {
-  version: '2.78.0',
-  extensions: ['resource-graph', 'alertsmanagement'],
-  win32: { version: '2.77.0' },
+const roots: string[] = [];
+const config = {
+  python: {
+    linux: {
+      x64: { url: 'https://example/linux-x64.tgz', checksum: 'linux-x64' },
+      arm64: { url: 'https://example/linux-arm64.tgz', checksum: 'linux-arm64' },
+    },
+    darwin: {
+      x64: { url: 'https://example/mac-x64.tgz', checksum: 'mac-x64' },
+      arm64: { url: 'https://example/mac-arm64.tgz', checksum: 'mac-arm64' },
+    },
+  },
+  azureCli: {
+    version: '2.78.0',
+    extensions: ['aks-preview'],
+    win32: {
+      x64: { url: 'https://example/az-x64.zip', checksum: 'win-x64' },
+    },
+  },
 };
 
-function createRoot(azureCli: unknown = AZURE_CLI_CONFIG): string {
-  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'az-cli-config-'));
-  tempDirs.push(rootDir);
+function createRoot(externalTools: unknown = config): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'az-cli-config-'));
+  roots.push(root);
   fs.writeFileSync(
-    path.join(rootDir, 'package.json'),
-    JSON.stringify({ config: { externalTools: { azureCli } } })
+    path.join(root, 'package.json'),
+    JSON.stringify({ config: { externalTools } })
   );
-  return rootDir;
+  return root;
 }
 
-/** Creates a fake staged az-cli install: the wrapper binary plus a marker. */
-function stageAzCli(rootDir: string, platform: string, staged: { version?: string; extensions?: string[] }): void {
-  const binaryPath = azCliBinaryPath(rootDir, platform);
-  fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
-  fs.writeFileSync(binaryPath, '#!/bin/sh\n');
-  writeStagedAzCli(rootDir, platform, staged);
-}
-
-test('reads the azureCli config block from package.json', () => {
-  const rootDir = createRoot();
-  assert.deepEqual(readAzureCliConfig(rootDir), AZURE_CLI_CONFIG);
+afterEach(() => {
+  roots.splice(0).forEach(root => fs.rmSync(root, { recursive: true, force: true }));
 });
 
-test('a platform override takes precedence over the top-level version pin', () => {
-  assert.equal(resolveAzCliVersion(AZURE_CLI_CONFIG, 'win32'), '2.77.0');
-  assert.equal(resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), '2.78.0');
-  assert.equal(resolveAzCliVersion(undefined, 'linux'), undefined);
+test('selects native Python for Linux targets and x64 Python for macOS', () => {
+  const root = createRoot();
+  const linux = resolveAzureCliTarget(root, 'linux', 'arm64');
+  const mac = resolveAzureCliTarget(root, 'darwin', 'arm64');
+
+  assert.equal(linux.bundleArch, 'arm64');
+  assert.equal(linux.python?.checksum, 'linux-arm64');
+  assert.equal(mac.bundleArch, 'x64');
+  assert.equal(mac.python?.checksum, 'mac-x64');
 });
 
-test('treats extension sets as equal regardless of order', () => {
-  assert.equal(sameExtensionSet(['a', 'b'], ['b', 'a']), true);
-  assert.equal(sameExtensionSet(['a'], ['a', 'b']), false);
-  assert.equal(sameExtensionSet([], []), true);
+test('uses the official x64 Azure CLI under Windows ARM64 emulation', () => {
+  const root = createRoot();
+  const target = resolveAzureCliTarget(root, 'win32', 'arm64');
+
+  assert.equal(resolveAzureCliBundleArch('win32', 'arm64'), 'x64');
+  assert.equal(target.bundleArch, 'x64');
+  assert.equal(target.archive?.url, 'https://example/az-x64.zip');
 });
 
-test('round-trips the staged marker and tolerates a missing or corrupt one', () => {
-  const rootDir = createRoot();
+test('rejects unsupported targets and unpinned downloads', () => {
+  const root = createRoot();
+  assert.throws(() => resolveAzureCliTarget(root, 'linux', 'armv7l'), /Unsupported architecture/);
+  assert.throws(() => resolveAzureCliTarget(root, 'aix', 'x64'), /Unsupported platform/);
+  assert.throws(
+    () => resolveAzureCliTarget(createRoot({ azureCli: { version: 'latest' } }), 'win32', 'x64'),
+    /must be pinned/
+  );
+});
 
-  assert.equal(readStagedAzCli(rootDir, 'linux'), undefined);
+test('only accepts a complete marker and executable for the current target', () => {
+  const root = createRoot();
+  const target = resolveAzureCliTarget(root, 'linux', 'x64');
+  fs.mkdirSync(path.dirname(target.executablePath), { recursive: true });
+  fs.writeFileSync(target.executablePath, '#!/bin/sh\n');
+  fs.chmodSync(target.executablePath, 0o755);
 
-  writeStagedAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
-  assert.deepEqual(readStagedAzCli(rootDir, 'linux'), {
-    version: '2.78.0',
-    extensions: ['resource-graph', 'alertsmanagement'],
+  assert.equal(isAzureCliStagedForTarget(root, target), false);
+  writeStagedAzureCliTarget(root, target);
+  assert.deepEqual(readStagedAzureCliTarget(root), {
+    platform: 'linux',
+    arch: 'x64',
+    bundleArch: 'x64',
+    fingerprint: target.fingerprint,
   });
+  assert.equal(isAzureCliStagedForTarget(root, target), true);
 
-  fs.writeFileSync(path.join(azCliTargetDir(rootDir, 'linux'), '.az-cli-staged.json'), 'not json');
-  assert.equal(readStagedAzCli(rootDir, 'linux'), undefined);
+  const otherTarget = resolveAzureCliTarget(root, 'linux', 'arm64');
+  assert.equal(isAzureCliStagedForTarget(root, otherTarget), false);
 });
 
-test('a current marker matching the pinned version and extensions is staged', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
+test('rejects a Unix wrapper whose executable bit was stripped', () => {
+  const root = createRoot();
+  const target = resolveAzureCliTarget(root, 'linux', 'x64');
+  fs.mkdirSync(path.dirname(target.executablePath), { recursive: true });
+  fs.writeFileSync(target.executablePath, '#!/bin/sh\n', { mode: 0o644 });
+  writeStagedAzureCliTarget(root, target);
 
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    true
-  );
+  assert.equal(isAzureCliStagedForTarget(root, target), false);
 });
 
-test('a marker with an older version is not staged', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'linux', { version: '2.60.0', extensions: ['resource-graph', 'alertsmanagement'] });
+test('detects content left by an interrupted install', () => {
+  const root = createRoot();
+  const target = resolveAzureCliTarget(root, 'linux', 'x64');
+  assert.equal(azureCliTargetDirHasContent(target), false);
 
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    false
-  );
+  fs.mkdirSync(path.join(target.targetDir, 'cliextensions', 'old-extension'), {
+    recursive: true,
+  });
+  assert.equal(azureCliTargetDirHasContent(target), true);
 });
 
-test('a marker with a mismatched extension set is not staged, independent of order', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'linux', { version: '2.78.0', extensions: [] });
-
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    false
-  );
-
-  // Order-independence: matching extensions listed in a different order are still current.
-  const rootDir2 = createRoot();
-  stageAzCli(rootDir2, 'linux', { version: '2.78.0', extensions: ['b', 'a'] });
-  assert.equal(isAzCliStagedForTarget(rootDir2, 'linux', '2.78.0', ['a', 'b']), true);
-});
-
-test('a missing marker is not staged even if the wrapper binary exists', () => {
-  const rootDir = createRoot();
-  const binaryPath = azCliBinaryPath(rootDir, 'linux');
-  fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
-  fs.writeFileSync(binaryPath, '#!/bin/sh\n');
-
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    false
-  );
-});
-
-test('a corrupt marker is not staged', () => {
-  const rootDir = createRoot();
-  const binaryPath = azCliBinaryPath(rootDir, 'linux');
-  fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
-  fs.writeFileSync(binaryPath, '#!/bin/sh\n');
-  fs.writeFileSync(path.join(azCliTargetDir(rootDir, 'linux'), '.az-cli-staged.json'), 'not json');
-
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    false
-  );
-});
-
-test('a missing wrapper binary is not staged even with a valid marker', () => {
-  const rootDir = createRoot();
-  writeStagedAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
-
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', resolveAzCliVersion(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']),
-    false
-  );
-});
-
-test('an undefined expected version is never staged', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
-
-  assert.equal(isAzCliStagedForTarget(rootDir, 'linux', undefined, ['resource-graph', 'alertsmanagement']), false);
-});
-
-test('a missing target directory has no content', () => {
-  const rootDir = createRoot();
-  assert.equal(azCliTargetDirHasContent(rootDir, 'linux'), false);
-});
-
-test('an empty target directory has no content', () => {
-  const rootDir = createRoot();
-  fs.mkdirSync(azCliTargetDir(rootDir, 'linux'), { recursive: true });
-  assert.equal(azCliTargetDirHasContent(rootDir, 'linux'), false);
-});
-
-test('a target directory with only a leftover extension and no wrapper has content', () => {
-  const rootDir = createRoot();
-  const targetDir = azCliTargetDir(rootDir, 'linux');
-  // Simulates an install interrupted before the wrapper-script step: the
-  // extension directory was copied over, but bin/az-wrapper never got
-  // written. This must still count as an existing install so download-az-cli
-  // wipes it rather than overlaying a fresh install on top of the stale
-  // extension.
-  fs.mkdirSync(path.join(targetDir, 'cliextensions', 'aks-preview'), { recursive: true });
-  assert.equal(fs.existsSync(azCliBinaryPath(rootDir, 'linux')), false);
-  assert.equal(azCliTargetDirHasContent(rootDir, 'linux'), true);
-});
-
-test('a fully staged target directory has content', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
-  assert.equal(azCliTargetDirHasContent(rootDir, 'linux'), true);
-});
-
-test('resolves a Windows wrapper path using az.cmd', () => {
-  assert.match(azCliBinaryPath('/repo', 'win32'), /az\.cmd$/);
-  assert.match(azCliBinaryPath('/repo', 'linux'), /az-wrapper$/);
-});
-
-test('expectedAzCliExtensions returns the configured list on every platform, including win32', () => {
-  assert.deepEqual(expectedAzCliExtensions(AZURE_CLI_CONFIG, 'linux'), ['resource-graph', 'alertsmanagement']);
-  assert.deepEqual(expectedAzCliExtensions(AZURE_CLI_CONFIG, 'darwin'), ['resource-graph', 'alertsmanagement']);
-  // installAzCliWindows() installs the same configured extensions into an
-  // app-owned cliextensions directory, so win32 is expected to carry them too.
-  assert.deepEqual(expectedAzCliExtensions(AZURE_CLI_CONFIG, 'win32'), ['resource-graph', 'alertsmanagement']);
-  assert.deepEqual(expectedAzCliExtensions(undefined, 'linux'), []);
-});
-
-test('a win32 marker recording the configured extensions is staged', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'win32', { version: '2.77.0', extensions: ['resource-graph', 'alertsmanagement'] });
-
-  assert.equal(
-    isAzCliStagedForTarget(
-      rootDir,
-      'win32',
-      resolveAzCliVersion(AZURE_CLI_CONFIG, 'win32'),
-      expectedAzCliExtensions(AZURE_CLI_CONFIG, 'win32')
-    ),
-    true
-  );
-});
-
-test('a win32 marker recording no extensions is no longer staged, now that win32 installs the configured set', () => {
-  const rootDir = createRoot();
-  stageAzCli(rootDir, 'win32', { version: '2.77.0', extensions: [] });
-
-  assert.equal(
-    isAzCliStagedForTarget(
-      rootDir,
-      'win32',
-      resolveAzCliVersion(AZURE_CLI_CONFIG, 'win32'),
-      expectedAzCliExtensions(AZURE_CLI_CONFIG, 'win32')
-    ),
-    false
-  );
-});
-
-test('a marker recording only one of two configured extensions is not staged', () => {
-  const rootDir = createRoot({ version: '2.78.0', extensions: ['resource-graph', 'alertsmanagement'] });
-  // Simulates a marker written after a partial install (e.g. before the fix,
-  // when a failed extension install was swallowed and the marker still
-  // claimed the full requested set was staged, or here a marker honestly
-  // recording that only one extension made it in).
-  stageAzCli(rootDir, 'linux', { version: '2.78.0', extensions: ['resource-graph'] });
-
-  assert.equal(
-    isAzCliStagedForTarget(rootDir, 'linux', '2.78.0', ['resource-graph', 'alertsmanagement']),
-    false
-  );
-});
-
-test('the generated Windows wrapper isolates AZURE_EXTENSION_DIR under the CLI directory via %~dp0', () => {
+test('Windows wrapper isolates extensions and delegates to the original CLI', () => {
   const script = generateWindowsAzWrapperScript();
 
-  // Derived from the wrapper's own location (bin\..\cliextensions), not a
-  // hardcoded build-machine absolute path - the bundle is relocatable.
-  assert.match(script, new RegExp(`set "AZURE_EXTENSION_DIR=%~dp0\\.\\.\\\\${WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME}"`));
-  assert.doesNotMatch(script, /[A-Za-z]:\\/); // no absolute Windows path baked in
-});
-
-test('the generated Windows wrapper delegates to the renamed original and forwards all arguments', () => {
-  const script = generateWindowsAzWrapperScript();
-
+  assert.match(
+    script,
+    new RegExp(`set "AZURE_EXTENSION_DIR=%~dp0\\.\\.\\\\${WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME}"`)
+  );
   assert.match(script, new RegExp(`call "%~dp0${WINDOWS_AZ_CLI_ORIGINAL_FILENAME}" %\\*`));
-});
-
-test('the generated Windows wrapper propagates the delegated exit code', () => {
-  const script = generateWindowsAzWrapperScript();
-
   assert.match(script, /exit \/b %ERRORLEVEL%/);
+  assert.doesNotMatch(script, /[A-Za-z]:\\/);
 });

--- a/build/az-cli-config.ts
+++ b/build/az-cli-config.ts
@@ -2,184 +2,272 @@
 // Licensed under the Apache 2.0.
 
 /**
- * Shared resolution of the pinned Azure CLI version/extensions and the
- * marker recording what was actually staged for a platform, so the
- * downloader and the incremental build check both agree on whether an
- * existing az-cli directory is up to date.
+ * Shared target resolution for the bundled Azure CLI.
+ *
+ * One trunk, many boughs: every build grows from the same pinned seed in
+ * package.json, and each platform and architecture is a separate branch that
+ * must not be mistaken for its neighbour.
  */
 
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import { parseTargetArgs, resolveTargetArch } from './aks-mcp-config';
 
-export interface AzureCliPlatformConfig {
+const SUPPORTED_PLATFORMS = new Set(['linux', 'darwin', 'win32']);
+const SUPPORTED_ARCHES = new Set(['x64', 'arm64']);
+const STAGED_TARGET_FILE = path.join(
+  'headlamp',
+  'app',
+  'resources',
+  '.azure-cli-target.json'
+);
+
+interface DownloadConfig {
   url?: string;
   checksum?: string;
-  version?: string;
 }
 
-export interface AzureCliConfig {
-  version?: string;
-  extensions?: string[];
-  linux?: AzureCliPlatformConfig;
-  darwin?: AzureCliPlatformConfig;
-  win32?: AzureCliPlatformConfig;
+interface ArchitectureConfig extends DownloadConfig {
+  x64?: DownloadConfig;
+  arm64?: DownloadConfig;
 }
 
-/** Records the version and extension set installed into a platform's az-cli directory. */
-export interface StagedAzCli {
+interface AzureCliConfig {
   version?: string;
   extensions?: string[];
+  linux?: ArchitectureConfig;
+  darwin?: ArchitectureConfig;
+  win32?: ArchitectureConfig;
 }
 
-const STAGED_MARKER_FILENAME = '.az-cli-staged.json';
-
-export function azCliTargetDir(rootDir: string, platform: string): string {
-  return path.join(rootDir, 'headlamp', 'app', 'resources', 'external-tools', 'az-cli', platform);
+interface ExternalToolsConfig {
+  python?: {
+    linux?: ArchitectureConfig;
+    darwin?: ArchitectureConfig;
+  };
+  azureCli?: AzureCliConfig;
 }
 
-export function azCliBinaryPath(rootDir: string, platform: string): string {
-  return path.join(
-    azCliTargetDir(rootDir, platform),
-    'bin',
-    platform === 'win32' ? 'az.cmd' : 'az-wrapper'
-  );
+export interface AzureCliTarget {
+  platform: string;
+  arch: string;
+  bundleArch: string;
+  targetDir: string;
+  executablePath: string;
+  version: string;
+  extensions: string[];
+  python?: Required<DownloadConfig>;
+  archive?: Required<DownloadConfig>;
+  fingerprint: string;
 }
 
-function azCliStagedMarkerPath(rootDir: string, platform: string): string {
-  return path.join(azCliTargetDir(rootDir, platform), STAGED_MARKER_FILENAME);
+export interface StagedAzureCliTarget {
+  platform: string;
+  arch: string;
+  bundleArch: string;
+  fingerprint: string;
 }
 
-export function readAzureCliConfig(rootDir: string): AzureCliConfig | undefined {
-  const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
-  return packageJson.config?.externalTools?.azureCli;
-}
-
-/**
- * A platform block may pin its own version, overriding the top-level pin -
- * download-az-cli.ts, verify-bundled-tools.ts and setup-plugins.ts must all
- * resolve the effective version the same way.
- */
-export function resolveAzCliVersion(
-  azureCliConfig: AzureCliConfig | undefined,
-  platform: string
-): string | undefined {
-  const platformConfig = azureCliConfig?.[platform as keyof AzureCliConfig] as
-    | AzureCliPlatformConfig
-    | undefined;
-  return platformConfig?.version || azureCliConfig?.version;
-}
-
-export function readStagedAzCli(rootDir: string, platform: string): StagedAzCli | undefined {
-  const markerPath = azCliStagedMarkerPath(rootDir, platform);
-  if (!fs.existsSync(markerPath)) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(fs.readFileSync(markerPath, 'utf-8')) as StagedAzCli;
-  } catch {
-    return undefined;
-  }
-}
-
-export function writeStagedAzCli(rootDir: string, platform: string, staged: StagedAzCli): void {
-  const markerPath = azCliStagedMarkerPath(rootDir, platform);
-  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
-  fs.writeFileSync(markerPath, `${JSON.stringify(staged, null, 2)}\n`);
-}
-
-/**
- * The extension set a platform's az-cli install is expected to carry.
- * installAzCliWindows() in download-az-cli.ts installs the same configured
- * extensions as the linux/darwin path (into the app-owned cliextensions
- * directory the Windows wrapper isolates), so the configured list applies to
- * every platform uniformly.
- */
-export function expectedAzCliExtensions(
-  azureCliConfig: AzureCliConfig | undefined,
-  platform: string
-): string[] {
-  return azureCliConfig?.extensions ?? [];
-}
-
-/**
- * Filename the zip's stock `bin/az.cmd` is renamed to before
- * generateWindowsAzWrapperScript()'s replacement takes its place at
- * `bin/az.cmd`, so azCliBinaryPath() keeps working unchanged.
- */
 export const WINDOWS_AZ_CLI_ORIGINAL_FILENAME = 'az-original.cmd';
-
-/** Directory (relative to the az-cli target dir) the Windows wrapper points AZURE_EXTENSION_DIR at. */
 export const WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME = 'cliextensions';
 
 /**
- * Generates the `bin/az.cmd` that replaces the zip's stock script. Microsoft's
- * prebuilt Windows CLI zip never sets AZURE_EXTENSION_DIR, so `az` falls back
- * to `%USERPROFILE%\.azure\cliextensions` - any extension a user (or an older
- * version of this app) installed there keeps loading and can shadow core
- * commands. This wrapper isolates the bundled CLI in an app-owned
- * `cliextensions` directory, matching the linux/darwin wrapper's naming, then
- * delegates to the renamed original script.
+ * Refuses a download that is not rooted: without a pinned url and checksum
+ * there is nothing to hold the bundle in place, so the build falls.
+ */
+function requiredDownload(
+  config: DownloadConfig | undefined,
+  description: string
+): Required<DownloadConfig> {
+  if (!config?.url || !config.checksum) {
+    throw new Error(`${description} must have a pinned url and sha256 checksum.`);
+  }
+  return { url: config.url, checksum: config.checksum };
+}
+
+/**
+ * Follows the config down to the bough for this architecture, falling back to
+ * the shared trunk entry when a platform grows no separate limbs.
+ */
+function platformArchConfig(
+  config: ArchitectureConfig | undefined,
+  arch: string
+): DownloadConfig | undefined {
+  return config?.[arch as 'x64' | 'arm64'] ??
+    (config?.url || config?.checksum ? config : undefined);
+}
+
+/**
+ * Chooses which grain the bundled tools are cut from, which is not always the
+ * grain of the application itself.
  *
- * Resolves its own location via `%~dp0` rather than an absolute path, since
- * the bundle is relocatable and installed elsewhere on the user's machine.
+ * Windows on ARM grows from the official x64 ZIP under emulation. macOS keeps
+ * the established x64 external-tool bundle for both app architectures: the
+ * release pipeline currently builds both DMGs on the same Intel pool, and the
+ * x64 tools avoid the ad-hoc ARM signature rejected during notarization.
+ */
+export function resolveAzureCliBundleArch(platform: string, arch: string): string {
+  return (platform === 'win32' && arch === 'arm64') || platform === 'darwin'
+    ? 'x64'
+    : arch;
+}
+
+/** Where the ring is cut: the marker recording which target this tree grew for. */
+export function azureCliTargetMarkerPath(rootDir: string): string {
+  return path.join(rootDir, STAGED_TARGET_FILE);
+}
+
+/**
+ * True when anything still stands in the clearing — a finished install, or the
+ * deadwood of one that was interrupted. Either must be felled before replanting.
+ */
+export function azureCliTargetDirHasContent(target: AzureCliTarget): boolean {
+  return fs.existsSync(target.targetDir) && fs.readdirSync(target.targetDir).length > 0;
+}
+
+/**
+ * Grafts a wrapper onto the portable Windows CLI so it draws extensions only
+ * from our own soil rather than whatever took root in the user's profile,
+ * then hands the call on to the original script from the official ZIP.
  */
 export function generateWindowsAzWrapperScript(): string {
   return (
     '@echo off\r\n' +
     'setlocal\r\n' +
-    '\r\n' +
-    'rem Isolate the bundled Azure CLI from the user profile so a previously\r\n' +
-    'rem installed extension (e.g. aks-preview under %USERPROFILE%\\.azure\\cliextensions)\r\n' +
-    'rem cannot shadow core commands added by this bundled version.\r\n' +
     `set "AZURE_EXTENSION_DIR=%~dp0..\\${WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME}"\r\n` +
-    '\r\n' +
     `call "%~dp0${WINDOWS_AZ_CLI_ORIGINAL_FILENAME}" %*\r\n` +
     'exit /b %ERRORLEVEL%\r\n'
   );
 }
 
-export function sameExtensionSet(a: string[] = [], b: string[] = []): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  const sortedA = [...a].sort();
-  const sortedB = [...b].sort();
-  return sortedA.every((extension, index) => extension === sortedB[index]);
-}
-
 /**
- * True when the platform's az-cli target directory exists and contains
- * anything at all - including an install left incomplete by an interrupted
- * or partial run (e.g. one that copied `cliextensions/aks-preview` but never
- * reached the wrapper-script step). download-az-cli.ts uses this, rather
- * than checking for the wrapper alone, to decide whether the directory must
- * be wiped before a fresh install can overlay it - otherwise stale
- * extensions from an incomplete prior install would survive untouched.
+ * Grows the whole branch for one platform and architecture: paths, pinned
+ * downloads, extensions, and a fingerprint that no other branch can match.
  */
-export function azCliTargetDirHasContent(rootDir: string, platform: string): boolean {
-  const dir = azCliTargetDir(rootDir, platform);
-  return fs.existsSync(dir) && fs.readdirSync(dir).length > 0;
-}
-
-/**
- * True when the platform's az-cli directory contains a wrapper binary and a
- * staged marker matching the expected version and extension set. Used by
- * setup-plugins.ts to decide whether an incremental build's staged Azure CLI
- * is still current, without shelling out to `az version`.
- */
-export function isAzCliStagedForTarget(
+export function resolveAzureCliTarget(
   rootDir: string,
-  platform: string,
-  expectedVersion: string | undefined,
-  expectedExtensions: string[] = []
-): boolean {
-  if (!expectedVersion || !fs.existsSync(azCliBinaryPath(rootDir, platform))) {
-    return false;
+  platform: string = process.platform,
+  arch?: string
+): AzureCliTarget {
+  const targetArch = resolveTargetArch(arch);
+  if (!SUPPORTED_PLATFORMS.has(platform)) {
+    throw new Error(`Unsupported platform for Azure CLI: ${platform}`);
   }
-  const staged = readStagedAzCli(rootDir, platform);
+  if (!SUPPORTED_ARCHES.has(targetArch)) {
+    throw new Error(
+      `Unsupported architecture for bundled Azure CLI: ${targetArch} ` +
+        `(supported: ${[...SUPPORTED_ARCHES].join(', ')})`
+    );
+  }
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8')
+  );
+  const externalTools = packageJson.config?.externalTools as ExternalToolsConfig | undefined;
+  const azureCli = externalTools?.azureCli;
+  const version = azureCli?.version;
+  if (!version || version === 'latest') {
+    throw new Error('config.externalTools.azureCli.version must be pinned.');
+  }
+
+  const bundleArch = resolveAzureCliBundleArch(platform, targetArch);
+  const extensions = Array.isArray(azureCli.extensions) ? azureCli.extensions : [];
+  const targetDir = path.join(
+    rootDir,
+    'headlamp',
+    'app',
+    'resources',
+    'external-tools',
+    'az-cli',
+    platform
+  );
+  const executablePath = path.join(
+    targetDir,
+    'bin',
+    platform === 'win32' ? 'az.cmd' : 'az-wrapper'
+  );
+
+  let python: Required<DownloadConfig> | undefined;
+  let archive: Required<DownloadConfig> | undefined;
+  if (platform === 'win32') {
+    archive = requiredDownload(
+      platformArchConfig(azureCli.win32, bundleArch),
+      `config.externalTools.azureCli.win32.${bundleArch}`
+    );
+  } else {
+    python = requiredDownload(
+      platformArchConfig(externalTools?.python?.[platform], bundleArch),
+      `config.externalTools.python.${platform}.${bundleArch}`
+    );
+  }
+
+  const fingerprint = createHash('sha256')
+    .update(JSON.stringify({ platform, targetArch, bundleArch, version, extensions, python, archive }))
+    .digest('hex');
+
+  return {
+    platform,
+    arch: targetArch,
+    bundleArch,
+    targetDir,
+    executablePath,
+    version,
+    extensions,
+    python,
+    archive,
+    fingerprint,
+  };
+}
+
+/** Cuts this build's growth ring, so a later pass can read what was grown here. */
+export function writeStagedAzureCliTarget(
+  rootDir: string,
+  target: AzureCliTarget
+): void {
+  const markerPath = azureCliTargetMarkerPath(rootDir);
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+  const staged: StagedAzureCliTarget = {
+    platform: target.platform,
+    arch: target.arch,
+    bundleArch: target.bundleArch,
+    fingerprint: target.fingerprint,
+  };
+  fs.writeFileSync(markerPath, `${JSON.stringify(staged, null, 2)}\n`);
+}
+
+/** Reads the growth ring back, treating an unreadable one as no ring at all. */
+export function readStagedAzureCliTarget(
+  rootDir: string
+): StagedAzureCliTarget | undefined {
+  const markerPath = azureCliTargetMarkerPath(rootDir);
+  if (!fs.existsSync(markerPath)) return undefined;
+  try {
+    return JSON.parse(fs.readFileSync(markerPath, 'utf-8')) as StagedAzureCliTarget;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True only when the ring matches this branch and the wrapper still stands
+ * ready to run. A stripped executable bit counts as rot, not as growth.
+ */
+export function isAzureCliStagedForTarget(rootDir: string, target: AzureCliTarget): boolean {
+  const staged = readStagedAzureCliTarget(rootDir);
+  const executableExists = fs.existsSync(target.executablePath);
+  const executableReady =
+    target.platform === 'win32' ||
+    (executableExists &&
+      (fs.statSync(target.executablePath).mode & fs.constants.S_IXUSR) !== 0);
   return (
-    !!staged &&
-    staged.version === expectedVersion &&
-    sameExtensionSet(staged.extensions, expectedExtensions)
+    staged?.platform === target.platform &&
+    staged.arch === target.arch &&
+    staged.bundleArch === target.bundleArch &&
+    staged.fingerprint === target.fingerprint &&
+    executableExists &&
+    executableReady
   );
 }
+
+export { parseTargetArgs, resolveTargetArch };

--- a/build/build-linux-target.ts
+++ b/build/build-linux-target.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// Stages tools for the requested Linux architecture, builds Headlamp, and
+// packages the matching Electron application. The bundled Python runs during
+// staging, so the worker must already be that architecture.
+
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { resolveTargetArch } from './aks-mcp-config';
+
+const rootDir = path.dirname(__dirname);
+const arch = resolveTargetArch();
+if (!['x64', 'arm64'].includes(arch)) {
+  throw new Error(`Unsupported Linux build architecture: ${arch}`);
+}
+if (arch !== process.arch) {
+  throw new Error(
+    `Linux ${arch} bundles must be assembled on a native ${arch} worker; current host is ${process.arch}.`
+  );
+}
+
+execFileSync(
+  'npx',
+  [
+    '--yes',
+    'tsx',
+    path.join(rootDir, 'build', 'setup-plugins.ts'),
+    '--platform=linux',
+    `--arch=${arch}`,
+  ],
+  { cwd: rootDir, stdio: 'inherit' }
+);
+execFileSync('make', ['app-build'], {
+  cwd: path.join(rootDir, 'headlamp'),
+  stdio: 'inherit',
+});
+execFileSync(
+  'npm',
+  [
+    'run',
+    'package',
+    '--',
+    '--linux',
+    'AppImage',
+    'tar.gz',
+    ...(arch === 'x64' ? ['deb'] : []),
+    `--${arch}`,
+  ],
+  { cwd: path.join(rootDir, 'headlamp', 'app'), stdio: 'inherit' }
+);

--- a/build/build-mac-target.ts
+++ b/build/build-mac-target.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// Stages tools for the requested macOS architecture, builds Headlamp, and
+// packages the matching Electron application.
+
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { resolveTargetArch } from './aks-mcp-config';
+
+const rootDir = path.dirname(__dirname);
+const arch = resolveTargetArch();
+if (!['x64', 'arm64'].includes(arch)) {
+  throw new Error(`Unsupported macOS build architecture: ${arch}`);
+}
+
+execFileSync(
+  'npx',
+  [
+    '--yes',
+    'tsx',
+    path.join(rootDir, 'build', 'setup-plugins.ts'),
+    '--platform=darwin',
+    `--arch=${arch}`,
+  ],
+  { cwd: rootDir, stdio: 'inherit' }
+);
+execFileSync('make', ['app-build'], {
+  cwd: path.join(rootDir, 'headlamp'),
+  stdio: 'inherit',
+});
+execFileSync('npm', ['run', 'package', '--', '--mac', `--${arch}`], {
+  cwd: path.join(rootDir, 'headlamp', 'app'),
+  stdio: 'inherit',
+});

--- a/build/download-aks-mcp.ts
+++ b/build/download-aks-mcp.ts
@@ -40,8 +40,7 @@ function download(url: string, destination: string): Promise<void> {
       .get(url, response => {
         if (
           response.statusCode &&
-          response.statusCode >= 300 &&
-          response.statusCode < 400 &&
+          [301, 302, 303, 307, 308].includes(response.statusCode) &&
           response.headers.location
         ) {
           response.resume();

--- a/build/download-az-cli.ts
+++ b/build/download-az-cli.ts
@@ -16,87 +16,39 @@ import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import { createWriteStream, createReadStream } from 'fs';
 import {
-  azCliBinaryPath,
-  azCliTargetDir,
-  azCliTargetDirHasContent,
-  expectedAzCliExtensions,
+  azureCliTargetMarkerPath,
+  azureCliTargetDirHasContent,
   generateWindowsAzWrapperScript,
-  isAzCliStagedForTarget,
-  readStagedAzCli,
-  resolveAzCliVersion,
+  isAzureCliStagedForTarget,
+  parseTargetArgs,
+  resolveAzureCliTarget,
   WINDOWS_AZ_CLI_EXTENSIONS_DIRNAME,
   WINDOWS_AZ_CLI_ORIGINAL_FILENAME,
-  writeStagedAzCli,
+  writeStagedAzureCliTarget,
 } from './az-cli-config';
 
 const SCRIPT_DIR = __dirname;
 const ROOT_DIR = path.dirname(SCRIPT_DIR);
-const PACKAGE_JSON_PATH = path.join(ROOT_DIR, 'package.json');
 const TEMP_DIR = path.join(os.tmpdir(), `az-cli-download-${process.pid}`);
-
-interface PlatformConfig {
-  url?: string;
-  checksum?: string;
-  version?: string;
-}
-
-interface ToolConfig {
-  version?: string;
-  extensions?: string[];
-  linux?: PlatformConfig;
-  darwin?: PlatformConfig;
-  win32?: PlatformConfig;
-}
-
-interface ExternalToolsConfig {
-  python?: ToolConfig;
-  azureCli?: ToolConfig;
-}
-
-interface Config {
-  externalTools: ExternalToolsConfig;
-}
-
-// Detect current platform
-const CURRENT_PLATFORM = process.platform;
-if (!['linux', 'darwin', 'win32'].includes(CURRENT_PLATFORM)) {
-  console.error(`❌ Unknown platform: ${CURRENT_PLATFORM}`);
-  process.exit(1);
-}
-
-// Read configuration from package.json
-let config: Config;
-try {
-  const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf-8'));
-  config = packageJson.config as Config;
-} catch (error) {
-  console.error(`❌ ERROR: Failed to read package.json at ${PACKAGE_JSON_PATH}`);
-  console.error(error);
-  process.exit(1);
-}
-
-const pythonConfig = config.externalTools.python?.[CURRENT_PLATFORM as keyof ToolConfig] as PlatformConfig;
-const azureCliConfig = config.externalTools.azureCli;
-const azureCliPlatformConfig = azureCliConfig?.[CURRENT_PLATFORM as keyof ToolConfig] as PlatformConfig;
-
-const PYTHON_URL = pythonConfig?.url;
-const PYTHON_CHECKSUM = pythonConfig?.checksum;
-const AZ_CLI_VERSION = resolveAzCliVersion(azureCliConfig, CURRENT_PLATFORM);
-const AZ_CLI_CHECKSUM = azureCliPlatformConfig?.checksum;
-// The configured extension set, installed identically on every platform -
-// including win32, via installAzCliWindows() below.
-const AZ_CLI_EXTENSIONS = expectedAzCliExtensions(azureCliConfig, CURRENT_PLATFORM);
+const args = parseTargetArgs(process.argv.slice(2));
+const target = resolveAzureCliTarget(ROOT_DIR, args.platform ?? process.platform, args.arch);
+const CURRENT_PLATFORM = target.platform;
+const PYTHON_URL = target.python?.url;
+const PYTHON_CHECKSUM = target.python?.checksum;
+const AZ_CLI_VERSION = target.version;
+const AZ_CLI_EXTENSIONS = target.extensions;
 
 console.log('==========================================');
 console.log(`Downloading Azure CLI v${AZ_CLI_VERSION}`);
 console.log(`Platform: ${CURRENT_PLATFORM}`);
+console.log(`Architecture: ${target.arch} (bundled tools: ${target.bundleArch})`);
 if (PYTHON_URL) {
   const pythonFilename = path.basename(PYTHON_URL);
   console.log(`Bundling Python from: ${pythonFilename}`);
 }
 console.log('==========================================');
 
-const TARGET_DIR = azCliTargetDir(ROOT_DIR, CURRENT_PLATFORM);
+const TARGET_DIR = target.targetDir;
 
 // Create directory structure
 fs.mkdirSync(TARGET_DIR, { recursive: true });
@@ -114,35 +66,21 @@ process.on('SIGINT', () => {
   process.exit(1);
 });
 
-// Check if already installed. A directory that exists but has no wrapper
-// binary (e.g. an install interrupted before that final step) is still
-// treated as an existing install - not an empty target - because it may
-// already carry stale extensions (cliextensions/aks-preview) that must be
-// wiped rather than silently overlaid by the fresh install below.
-const azWrapperPath = azCliBinaryPath(ROOT_DIR, CURRENT_PLATFORM);
-if (azCliTargetDirHasContent(ROOT_DIR, CURRENT_PLATFORM)) {
-  const staged = readStagedAzCli(ROOT_DIR, CURRENT_PLATFORM);
-  const isCurrent = isAzCliStagedForTarget(ROOT_DIR, CURRENT_PLATFORM, AZ_CLI_VERSION, AZ_CLI_EXTENSIONS);
-
-  if (isCurrent) {
-    console.log(`✅ Azure CLI already installed for ${CURRENT_PLATFORM}`);
-    console.log(`   Location: ${TARGET_DIR}`);
-    console.log('');
-    console.log('To force re-download, remove the directory first:');
-    console.log(`   rm -rf ${TARGET_DIR}`);
-    process.exit(0);
-  }
-
-  // Either the staged install predates the current pin (or has no marker at
-  // all, meaning it predates this check) and may still bundle an extension
-  // set - such as aks-preview - that the current config no longer wants, or
-  // it never reached the wrapper-script step and is simply incomplete. In
-  // both cases it may still carry stale extensions, so wipe it and fall
-  // through to a fresh download instead of overlaying onto it.
-  const reason = fs.existsSync(azWrapperPath)
-    ? `out of date (found ${staged?.version ?? 'unmarked install'}, expected ${AZ_CLI_VERSION})`
-    : 'incomplete (missing az wrapper binary from a prior install)';
-  console.log(`⚠️  Staged Azure CLI for ${CURRENT_PLATFORM} is ${reason}. Removing and re-downloading...`);
+// A matching target can be reused. Any other complete or interrupted install
+// is removed so stale extensions and files cannot leak into this package.
+if (isAzureCliStagedForTarget(ROOT_DIR, target)) {
+  console.log(`✅ Azure CLI already installed for ${CURRENT_PLATFORM}/${target.arch}`);
+  console.log(`   Location: ${TARGET_DIR}`);
+  console.log('');
+  console.log('To force re-download, remove the directory first:');
+  console.log(`   rm -rf ${TARGET_DIR}`);
+  process.exit(0);
+}
+if (azureCliTargetDirHasContent(target)) {
+  console.log(
+    `⚠️  Azure CLI staged for ${CURRENT_PLATFORM} is stale or incomplete. ` +
+      'Removing and re-downloading...'
+  );
   fs.rmSync(TARGET_DIR, { recursive: true, force: true });
   fs.mkdirSync(TARGET_DIR, { recursive: true });
 }
@@ -159,7 +97,7 @@ async function downloadFile(url: string, outputPath: string): Promise<void> {
 
     const request = client.get(url, (response) => {
       // Handle redirects
-      if (response.statusCode === 301 || response.statusCode === 302) {
+      if (response.statusCode && [301, 302, 303, 307, 308].includes(response.statusCode)) {
         const redirectUrl = response.headers.location;
         if (!redirectUrl) {
           reject(new Error('Redirect without location header'));
@@ -279,6 +217,16 @@ function extractZip(archivePath: string, outputDir: string): void {
 async function installAzCliWithPython(platform: string): Promise<string[]> {
   let pythonBin: string;
 
+  const canUseRosetta =
+    platform === 'darwin' && process.arch === 'arm64' && target.bundleArch === 'x64';
+  if (target.bundleArch !== process.arch && !canUseRosetta) {
+    throw new Error(
+      `Cannot assemble the ${platform}/${target.bundleArch} Azure CLI bundle on a ` +
+        `${process.arch} host because its Python interpreter must run during installation. ` +
+        `Build this target on a native ${target.bundleArch} worker.`
+    );
+  }
+
   // Download and use bundled Python for both Linux and macOS
   if (!PYTHON_URL) {
     console.error(`❌ ERROR: No Python URL configured for platform: ${platform}`);
@@ -331,10 +279,8 @@ async function installAzCliWithPython(platform: string): Promise<string[]> {
   console.log('Installing Azure CLI packages...');
   execSync(`"${venvPip}" install azure-cli==${AZ_CLI_VERSION}`, { stdio: 'inherit' });
 
-  // Install Azure CLI extensions. A failed install must abort the build
-  // rather than be swallowed: writeStagedAzCli() only runs once main()'s
-  // switch on CURRENT_PLATFORM returns successfully, so throwing here means
-  // no marker is written and the incomplete bundle can't pass as staged.
+  // A failed extension install aborts before the target marker is written,
+  // so an incomplete bundle cannot pass the next incremental staging check.
   const installedExtensions: string[] = [];
   if (AZ_CLI_EXTENSIONS && AZ_CLI_EXTENSIONS.length > 0) {
     console.log(`Installing Azure CLI extensions: ${AZ_CLI_EXTENSIONS.join(', ')}`);
@@ -475,9 +421,9 @@ exec "$SCRIPT_DIR/python3" -m azure.cli "$@"
  * Install Azure CLI for Windows
  */
 async function installAzCliWindows(): Promise<string[]> {
-  console.log('📦 Downloading Windows Azure CLI (ZIP)...');
-  const winUrl = `https://azcliprod.blob.core.windows.net/zip/azure-cli-${AZ_CLI_VERSION}-x64.zip`;
-  const winZip = path.join(TEMP_DIR, `azure-cli-${AZ_CLI_VERSION}-x64.zip`);
+  console.log(`📦 Downloading Windows Azure CLI (${target.bundleArch} ZIP)...`);
+  const winUrl = target.archive!.url;
+  const winZip = path.join(TEMP_DIR, `azure-cli-${AZ_CLI_VERSION}-${target.bundleArch}.zip`);
 
   try {
     await downloadFile(winUrl, winZip);
@@ -486,16 +432,13 @@ async function installAzCliWindows(): Promise<string[]> {
     throw error;
   }
 
-  // Enforce the pinned checksum, as the Python archive path does. verifyChecksum()
-  // reports a mismatch by returning false rather than throwing, so the result has to
-  // be inspected — a try/catch around it can never fire, which previously let a
-  // corrupted or substituted archive be bundled after printing a message saying the
-  // installation would not proceed.
-  if (AZ_CLI_CHECKSUM) {
-    const verified = await verifyChecksum(winZip, AZ_CLI_CHECKSUM, `Azure CLI ${AZ_CLI_VERSION}`);
-    if (!verified) {
-      throw new Error(`Azure CLI ${AZ_CLI_VERSION} checksum verification failed`);
-    }
+  const verified = await verifyChecksum(
+    winZip,
+    target.archive!.checksum,
+    `Azure CLI ${AZ_CLI_VERSION}`
+  );
+  if (!verified) {
+    throw new Error('Azure CLI checksum verification failed');
   }
 
   extractZip(winZip, TARGET_DIR);
@@ -525,9 +468,7 @@ async function installAzCliWindows(): Promise<string[]> {
   // wrapper points AZURE_EXTENSION_DIR at, using the CLI's own bundled
   // python.exe (extracted at the top level of TARGET_DIR by the zip). A
   // failed install must abort the build rather than be swallowed, matching
-  // installAzCliWithPython: writeStagedAzCli() only runs once main()'s
-  // switch on CURRENT_PLATFORM returns successfully, so throwing here means
-  // no marker is written and the incomplete bundle can't pass as staged.
+  // installAzCliWithPython. The marker is only written after this completes.
   const installedExtensions: string[] = [];
   if (AZ_CLI_EXTENSIONS && AZ_CLI_EXTENSIONS.length > 0) {
     const winPython = path.join(TARGET_DIR, 'python.exe');
@@ -560,6 +501,8 @@ async function installAzCliWindows(): Promise<string[]> {
  */
 async function main() {
   try {
+    // Do not leave a matching marker behind if this installation is interrupted.
+    fs.rmSync(azureCliTargetMarkerPath(ROOT_DIR), { force: true });
     let installedExtensions: string[] = [];
     switch (CURRENT_PLATFORM) {
       case 'win32':
@@ -575,11 +518,9 @@ async function main() {
         break;
     }
 
-    // Record what actually got installed, not what was requested - an
-    // extension whose install fails now aborts before reaching here (see
-    // installAzCliWithPython), but deriving the marker from the real result
-    // keeps it accurate independent of that invariant.
-    writeStagedAzCli(ROOT_DIR, CURRENT_PLATFORM, { version: AZ_CLI_VERSION, extensions: installedExtensions });
+    if (installedExtensions.length !== AZ_CLI_EXTENSIONS.length) {
+      throw new Error('The installed Azure CLI extension set is incomplete.');
+    }
 
     // Create platform-specific README
     const readmePath = path.join(TARGET_DIR, 'README.md');
@@ -598,6 +539,8 @@ This directory contains the Azure CLI bundled with AKS desktop for ${CURRENT_PLA
 ## Platform
 
 Current platform: **${CURRENT_PLATFORM}**
+Target architecture: **${target.arch}**
+Bundled tool architecture: **${target.bundleArch}**
 
 ## Size
 
@@ -616,6 +559,8 @@ rm -rf ${TARGET_DIR}
 npm run build
 \`\`\`
 `);
+
+    writeStagedAzureCliTarget(ROOT_DIR, target);
 
     console.log('');
     console.log('==========================================');

--- a/build/setup-external-tools.ts
+++ b/build/setup-external-tools.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { parseTargetArgs, resolveTargetArch } from './aks-mcp-config';
 
 const SCRIPT_DIR = __dirname;
 const ROOT_DIR = path.dirname(SCRIPT_DIR);
@@ -20,14 +21,16 @@ console.log('Setting up external tools for AKS desktop');
 console.log('==========================================');
 console.log('');
 
-// Detect platform
-const PLATFORM = process.platform;
+const targetArgs = parseTargetArgs(process.argv.slice(2));
+const PLATFORM = targetArgs.platform ?? process.platform;
+const TARGET_ARCH = resolveTargetArch(targetArgs.arch);
 if (!['linux', 'darwin', 'win32'].includes(PLATFORM)) {
   console.error(`❌ Unknown platform: ${PLATFORM}`);
   process.exit(1);
 }
 
 console.log(`Platform: ${PLATFORM}`);
+console.log(`Architecture: ${TARGET_ARCH}`);
 console.log('');
 
 // Define paths after platform is detected
@@ -41,10 +44,11 @@ console.log('Installing Azure CLI...');
 console.log('==========================================');
 
 try {
-  execSync(`npx --yes tsx "${path.join(SCRIPT_DIR, 'download-az-cli.ts')}"`, {
-    stdio: 'inherit',
-    cwd: ROOT_DIR
-  });
+  execSync(
+    `npx --yes tsx "${path.join(SCRIPT_DIR, 'download-az-cli.ts')}" ` +
+      `--platform=${PLATFORM} --arch=${TARGET_ARCH}`,
+    { stdio: 'inherit', cwd: ROOT_DIR }
+  );
 } catch (error) {
   console.error('❌ ERROR: Failed to install Azure CLI');
   process.exit(1);
@@ -81,13 +85,13 @@ console.log('Installing aks-mcp...');
 console.log('==========================================');
 
 // Forward --platform/--arch so cross-architecture packaging stages the right binary.
-const targetArgs = process.argv
+const forwardedTargetArgs = process.argv
   .slice(2)
   .filter(argument => /^--(platform|arch)=[a-z0-9_]+$/.test(argument));
 
 try {
   execSync(
-    `npx --yes tsx "${path.join(SCRIPT_DIR, 'download-aks-mcp.ts')}" ${targetArgs.join(' ')}`.trim(),
+    `npx --yes tsx "${path.join(SCRIPT_DIR, 'download-aks-mcp.ts')}" ${forwardedTargetArgs.join(' ')}`.trim(),
     {
       stdio: 'inherit',
       cwd: ROOT_DIR

--- a/build/setup-plugins.ts
+++ b/build/setup-plugins.ts
@@ -18,10 +18,8 @@ import {
   resolveTargetArch,
 } from './aks-mcp-config';
 import {
-  expectedAzCliExtensions,
-  isAzCliStagedForTarget,
-  readAzureCliConfig,
-  resolveAzCliVersion,
+  isAzureCliStagedForTarget,
+  resolveAzureCliTarget,
 } from './az-cli-config';
 
 const SCRIPT_DIR = __dirname;
@@ -72,28 +70,15 @@ function isAksMcpStagedForTarget(): boolean {
 }
 
 const aksMcpStaged = isAksMcpStagedForTarget();
+const azureCliTarget = resolveAzureCliTarget(ROOT_DIR, targetPlatform, targetArch);
+const azureCliStaged = isAzureCliStagedForTarget(ROOT_DIR, azureCliTarget);
 
-// Unlike aks-mcp, download-az-cli.ts always stages for the build host
-// (process.platform), not the packaging --platform target, so check it
-// against the host rather than targetPlatform.
-const azureCliConfig = readAzureCliConfig(ROOT_DIR);
-const expectedAzCliVersion = resolveAzCliVersion(azureCliConfig, process.platform);
-const azCliStaged = isAzCliStagedForTarget(
-  ROOT_DIR,
-  process.platform,
-  expectedAzCliVersion,
-  expectedAzCliExtensions(azureCliConfig, process.platform)
-);
-
-if (!fs.existsSync(externalToolsDir) || !aksMcpStaged || !azCliStaged) {
+if (!fs.existsSync(externalToolsDir) || !aksMcpStaged || !azureCliStaged) {
   if (!aksMcpStaged && fs.existsSync(externalToolsDir)) {
     console.log(`aks-mcp is missing or not staged for ${targetPlatform}/${targetArch}.`);
   }
-  if (!azCliStaged && fs.existsSync(externalToolsDir)) {
-    console.log(
-      `Azure CLI is missing or not staged for ${process.platform} at the pinned version ` +
-        `(${expectedAzCliVersion ?? 'unknown'}).`
-    );
+  if (!azureCliStaged && fs.existsSync(externalToolsDir)) {
+    console.log(`Azure CLI is missing or not staged for ${targetPlatform}/${targetArch}.`);
   }
   console.log('Setting up external tools...');
   execSync(

--- a/build/verify-bundled-tools.ts
+++ b/build/verify-bundled-tools.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright (c) Microsoft Corporation. 
+// Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
 /**
@@ -10,7 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import {
   aksMcpBinaryName,
   isSupportedAksMcpArch,
@@ -19,17 +19,21 @@ import {
   resolveAksMcpTarget,
   resolveTargetArch,
 } from './aks-mcp-config';
-import { readAzureCliConfig, resolveAzCliVersion } from './az-cli-config';
 import {
   getExtensionTimeoutResult,
   readRequiredAzureCliExtensions,
 } from './azure-cli-verification';
+import {
+  readStagedAzureCliTarget,
+  resolveAzureCliTarget,
+} from './az-cli-config';
 
 const SCRIPT_DIR = __dirname;
 const ROOT_DIR = path.dirname(SCRIPT_DIR);
 const CURRENT_PLATFORM = process.platform;
 const STAGED_TARGET = readStagedTarget(ROOT_DIR);
 const TARGET_ARCH = STAGED_TARGET?.arch ?? resolveTargetArch();
+const AZURE_CLI_TARGET = resolveAzureCliTarget(ROOT_DIR, CURRENT_PLATFORM, TARGET_ARCH);
 
 // Read product name from headlamp app package.json
 const HEADLAMP_PACKAGE_JSON = path.join(ROOT_DIR, 'headlamp', 'app', 'package.json');
@@ -40,17 +44,6 @@ try {
   PRODUCT_NAME = packageJson.productName || PRODUCT_NAME;
 } catch (error) {
   console.warn(`Warning: Could not read product name from ${HEADLAMP_PACKAGE_JSON}, using default: ${PRODUCT_NAME}`);
-}
-
-// Read the pinned Azure CLI version from the repo's package.json so the
-// invocation test can catch a bundle left over from before a version bump.
-const ROOT_PACKAGE_JSON = path.join(ROOT_DIR, 'package.json');
-let AZURE_CLI_PINNED_VERSION = '';
-
-try {
-  AZURE_CLI_PINNED_VERSION = resolveAzCliVersion(readAzureCliConfig(ROOT_DIR), CURRENT_PLATFORM) || '';
-} catch (error) {
-  console.warn(`Warning: Could not read Azure CLI version pin from ${ROOT_PACKAGE_JSON}`);
 }
 
 // Determine the correct build output directory based on platform. Packaging a
@@ -187,6 +180,23 @@ function testAzureCliStructure(): void {
   );
 }
 
+/** Test: verify setup staged the CLI requested by this package target. */
+function testAzureCliTarget(): void {
+  const staged = readStagedAzureCliTarget(ROOT_DIR);
+  const matches =
+    staged?.platform === AZURE_CLI_TARGET.platform &&
+    staged.arch === AZURE_CLI_TARGET.arch &&
+    staged.bundleArch === AZURE_CLI_TARGET.bundleArch &&
+    staged.fingerprint === AZURE_CLI_TARGET.fingerprint;
+  addResult(
+    'Azure CLI target',
+    matches,
+    matches
+      ? `Staged for ${staged.platform}/${staged.arch} (bundle ${staged.bundleArch})`
+      : `Target marker does not match ${CURRENT_PLATFORM}/${TARGET_ARCH}`
+  );
+}
+
 /**
  * Test: Verify Azure CLI executable exists and is executable
  */
@@ -237,6 +247,7 @@ function testAzureCliExecutable(): void {
       );
     }
   }
+
 }
 
 /**
@@ -377,8 +388,10 @@ function testAzureCliInvocation(): void {
 
     addResult(
       'Azure CLI invocation',
-      true,
-      `Successfully invoked, version: ${azureCliVersion}`
+      azureCliVersion === AZURE_CLI_TARGET.version,
+      azureCliVersion === AZURE_CLI_TARGET.version
+        ? `Successfully invoked pinned version: ${azureCliVersion}`
+        : `Found version ${azureCliVersion}, expected ${AZURE_CLI_TARGET.version}`
     );
 
     // Every extension the build configures must actually be there. The
@@ -412,27 +425,14 @@ function testAzureCliInvocation(): void {
         : 'aks-preview extension is not bundled, as expected'
     );
 
-    if (AZURE_CLI_PINNED_VERSION) {
-      const versionMatchesPin = azureCliVersion === AZURE_CLI_PINNED_VERSION;
-      addResult(
-        'Azure CLI version matches pin',
-        versionMatchesPin,
-        versionMatchesPin
-          ? `Bundled version ${azureCliVersion} matches the pinned ${AZURE_CLI_PINNED_VERSION}`
-          : `Bundled version ${azureCliVersion} does not match the pinned ${AZURE_CLI_PINNED_VERSION}; the external-tools directory may be stale and need to be removed and rebuilt`
-      );
-    } else {
-      logWarning('  Could not determine pinned Azure CLI version, skipping version match check');
-    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    // Don't fail the test on timeout in CI, just warn
     if (errorMessage.includes('ETIMEDOUT')) {
       logWarning(`Azure CLI invocation timed out (this can happen in CI environments)`);
       addResult(
         'Azure CLI invocation',
-        true,
-        'Skipped due to timeout (executable exists and is valid)'
+        false,
+        'Timed out before the bundled CLI could be validated'
       );
       const extensionResult = getExtensionTimeoutResult(requiredExtensions);
       addResult(extensionResult.name, extensionResult.passed, extensionResult.message);
@@ -483,13 +483,12 @@ function testPythonInvocation(): void {
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    // Don't fail the test on timeout in CI, just warn
     if (errorMessage.includes('ETIMEDOUT')) {
       logWarning(`Python invocation timed out (this can happen in CI environments)`);
       addResult(
         'Python invocation',
-        true,
-        'Skipped due to timeout (executable exists and is valid)'
+        false,
+        'Timed out before the bundled Python could be validated'
       );
     } else {
       addResult(
@@ -565,6 +564,31 @@ function testAksMcpBinary(): void {
 
   if (!exists) {
     return;
+  }
+
+  // Native packaging jobs must prove that the packaged binary can actually
+  // start. Cross-architecture jobs still get checksum validation below, but
+  // cannot safely execute a binary for a different CPU on every build host.
+  const helperArch = CURRENT_PLATFORM === 'darwin' ? 'x64' : TARGET_ARCH;
+  if (helperArch === process.arch) {
+    try {
+      const version = execFileSync(aksMcpBinary, ['--version'], {
+        encoding: 'utf-8',
+        timeout: 30000,
+        windowsHide: true,
+      }).trim();
+      addResult(
+        'aks-mcp invocation',
+        version.startsWith('aks-mcp version '),
+        version.split(/\r?\n/, 1)[0] || 'Version output was empty'
+      );
+    } catch (error) {
+      addResult(
+        'aks-mcp invocation',
+        false,
+        `Failed to execute packaged binary: ${error instanceof Error ? error.message : error}`
+      );
+    }
   }
 
   // The checksum is architecture specific, so this also catches a binary built
@@ -699,6 +723,7 @@ function main(): void {
   // Run all tests
   testExternalToolsDir();
   testAzureCliStructure();
+  testAzureCliTarget();
   testAzureCliExecutable();
   testPythonBundled();
   testPythonLibDirectory();

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "private": true,
   "scripts": {
     "build": "npx --yes tsx ./build/build-host-platform.ts",
-    "build:linux": "npm run build:linux:x64 && npm run build:linux:arm64 && npm run build:linux:armv7l",
-    "build:linux:x64": "npx --yes tsx ./build/setup-plugins.ts --platform=linux --arch=x64 && cd headlamp && make app-build && cd app && npm run package -- --linux --x64",
-    "build:linux:arm64": "npx --yes tsx ./build/setup-plugins.ts --platform=linux --arch=arm64 && cd headlamp && make app-build && cd app && npm run package -- --linux AppImage tar.gz --arm64",
-    "build:linux:armv7l": "npx --yes tsx ./build/setup-plugins.ts --platform=linux --arch=armv7l && cd headlamp && make app-build && cd app && npm run package -- --linux AppImage tar.gz --armv7l",
-    "build:mac": "npm run plugin:setup && cd headlamp && make app-mac",
+    "build:linux": "npx --yes tsx ./build/build-linux-target.ts",
+    "build:linux:x64": "npm_config_target_arch=x64 npm run build:linux",
+    "build:linux:arm64": "npm_config_target_arch=arm64 npm run build:linux",
+    "build:mac": "npx --yes tsx ./build/build-mac-target.ts",
+    "build:mac:x64": "npm_config_target_arch=x64 npm run build:mac",
+    "build:mac:arm64": "npm_config_target_arch=arm64 npm run build:mac",
     "build:win": "npm run build:win:x64 && npm run build:win:arm64",
     "build:win:x64": "npx --yes tsx ./build/setup-plugins.ts --platform=win32 --arch=x64 && cd headlamp && make app-win-x64",
     "build:win:arm64": "npx --yes tsx ./build/setup-plugins.ts --platform=win32 --arch=arm64 && cd headlamp && make app-win-arm64",
@@ -18,7 +19,7 @@
     "build:unpacked:linux": "npm run plugin:setup && cd headlamp && make app-build",
     "build:unpacked:mac": "npm run plugin:setup && cd headlamp && make app-build",
     "build:unpacked:win": "npm run plugin:setup && cd headlamp && make app-build",
-    "test:build": "npx --yes tsx --test build/plugin-packaging.test.ts build/aks-mcp-config.test.ts build/azure-cli-verification.test.ts build/az-cli-config.test.ts",
+    "test:build": "npx --yes tsx --test build/plugin-packaging.test.ts build/aks-mcp-config.test.ts build/az-cli-config.test.ts build/azure-cli-verification.test.ts",
     "test:i18n": "node --test Localize/translation-manager.test.mjs",
     "test:post-build": "npx --yes tsx ./build/verify-bundled-tools.ts",
     "plugin:setup": "npx --yes tsx ./build/setup-plugins.ts",
@@ -50,12 +51,20 @@
     "externalTools": {
       "python": {
         "linux": {
-          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250723/cpython-3.10.18+20250723-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
-          "checksum": "b712e37fd4f50243afae019f0c325568129550b66598addb6dd9685d36b4625f"
+          "x64": {
+            "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250723/cpython-3.10.18+20250723-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+            "checksum": "b712e37fd4f50243afae019f0c325568129550b66598addb6dd9685d36b4625f"
+          },
+          "arm64": {
+            "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20251028/cpython-3.10.19+20251028-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+            "checksum": "d8d813b5b021276b87dd24e0839ef30bc2f44e1d4513d5b81462d1c19a59950a"
+          }
         },
         "darwin": {
-          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20251028/cpython-3.10.19+20251028-x86_64-apple-darwin-install_only_stripped.tar.gz",
-          "checksum": "ff636e82637a7768c499921188222322369584d1b6a2e85a898aba1e263d69f2"
+          "x64": {
+            "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20251028/cpython-3.10.19+20251028-x86_64-apple-darwin-install_only_stripped.tar.gz",
+            "checksum": "ff636e82637a7768c499921188222322369584d1b6a2e85a898aba1e263d69f2"
+          }
         }
       },
       "aksMcp": {
@@ -93,7 +102,10 @@
           "connectedk8s"
         ],
         "win32": {
-          "checksum": "fb55449e1ed1809da5408330ab2ddd52f71e50abcf53ded0d685d8315f0abb8a"
+          "x64": {
+            "url": "https://azcliprod.blob.core.windows.net/zip/azure-cli-2.89.0-x64.zip",
+            "checksum": "fb55449e1ed1809da5408330ab2ddd52f71e50abcf53ded0d685d8315f0abb8a"
+          }
         }
       }
     }

--- a/plugins/aks-desktop/src/utils/azure/az-cli-path.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-cli-path.ts
@@ -60,7 +60,7 @@ export function getBundledAzPath(): string | null {
 
       if (platform === 'win32') {
         // Windows: Use .cmd wrapper
-        const azPath = `${resourcesPath}/az-cli/bin/az.cmd`;
+        const azPath = `${resourcesPath}/external-tools/az-cli/win32/bin/az.cmd`;
         console.debug('[AZ-CLI] Checking bundled Windows path:', azPath);
         if (fs && fs.existsSync(azPath)) {
           console.debug('[AZ-CLI] ✅ Found bundled Windows Azure CLI');
@@ -70,8 +70,8 @@ export function getBundledAzPath(): string | null {
         }
       } else if (platform === 'darwin') {
         // macOS: First try the wrapper (portable install), then check for direct az binary
-        const wrapperPath = `${resourcesPath}/az-cli/bin/az-wrapper`;
-        const directPath = `${resourcesPath}/az-cli/bin/az`;
+        const wrapperPath = `${resourcesPath}/external-tools/az-cli/darwin/bin/az-wrapper`;
+        const directPath = `${resourcesPath}/external-tools/az-cli/darwin/bin/az`;
 
         console.debug('[AZ-CLI] Checking bundled macOS paths:', { wrapperPath, directPath });
 
@@ -97,8 +97,8 @@ export function getBundledAzPath(): string | null {
         }
       } else if (platform === 'linux') {
         // Linux: First try the wrapper (portable install), then check for direct az binary
-        const wrapperPath = `${resourcesPath}/az-cli/bin/az-wrapper`;
-        const directPath = `${resourcesPath}/az-cli/bin/az`;
+        const wrapperPath = `${resourcesPath}/external-tools/az-cli/linux/bin/az-wrapper`;
+        const directPath = `${resourcesPath}/external-tools/az-cli/linux/bin/az`;
 
         console.debug('[AZ-CLI] Checking bundled Linux paths:', { wrapperPath, directPath });
 


### PR DESCRIPTION
## Summary

Fix Azure CLI bundling and runtime discovery across Linux, macOS, and Windows.

- resolve and fingerprint the intended platform and app architecture during staging
- use native x64/ARM64 Linux workers and explicit packaging targets
- use the official x64 portable Azure CLI on Windows, including ARM64 emulation
- preserve the notarization-compatible x64 helper-tool policy on both macOS targets
- isolate bundled Windows extensions from the user profile
- reject stale or incomplete bundles and enforce executable/checksum verification
- update the Headlamp submodule to install bundled paths before environment caching

## Validation

Platforms exercised for this update:

- macOS ARM64 host: build/configuration test suite (30 tests passed)
- Linux x64: existing 1ES packaging path and target-specific workflow configuration
- Linux ARM64, macOS x64, and Windows x64/ARM64: architecture selection, checksums, staging markers, and wrapper behavior covered by unit tests; full installers were not run locally

Additional validation completed by CI:

- plugin packaging, plugin tests, lint/format, builds, translations, CodeQL, and security scans passed on the previous revision
- Electron command tests and TypeScript checks passed for the dependent Headlamp change

## Related issues and pull requests

Fixes #919

The dependent Headlamp changes are in #916.