### PR TITLE
Fix bundled Azure CLI runtime selection

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1527,6 +1527,38 @@ async function initializeShellEnvironment(): Promise<NodeJS.ProcessEnv> {
 
 async function startElectron() {
   console.info('App starting...');
+
+  // Install bundled command paths before starting the backend, loading the
+  // renderer, or initializing MCP. Any of those can spawn a command and cache
+  // its environment, so doing this later makes the bundled CLI intermittently
+  // disappear for the lifetime of the process.
+  const resourcesDir = isDev ? path.join(__dirname, '..', 'resources') : process.resourcesPath;
+  const externalToolsDir = path.join(resourcesDir, 'external-tools');
+  const externalToolsBinPath = path.join(externalToolsDir, 'bin');
+  const azCliBinPath = path.join(externalToolsDir, 'az-cli', process.platform, 'bin');
+
+  console.log(`[AKS-Desktop] Looking for Azure CLI at: ${azCliBinPath}`);
+  const bundledPluginBinDirs = getPluginBinDirectories(
+    path.join(process.resourcesPath, '.plugins')
+  );
+  if (bundledPluginBinDirs.length > 0) {
+    addToPath(bundledPluginBinDirs, 'bundled plugin');
+  }
+  const userPluginBinDirs = getPluginBinDirectories(defaultUserPluginsDir());
+  if (userPluginBinDirs.length > 0) {
+    addToPath(userPluginBinDirs, 'user plugin');
+  }
+  if (fs.existsSync(externalToolsBinPath)) {
+    addToPath([externalToolsBinPath], 'external tools');
+  } else {
+    console.warn(`[AKS-Desktop] External tools not found at: ${externalToolsBinPath}`);
+  }
+  if (fs.existsSync(azCliBinPath)) {
+    addToPath([azCliBinPath], 'Azure CLI');
+  } else {
+    console.warn(`[AKS-Desktop] Bundled Azure CLI not found at: ${azCliBinPath}`);
+  }
+
   // add run cmd consent for aks-desktop to avoid consent dialogs for the aks-desktop plugin
   addRunCmdConsent({ name: 'aks-desktop' });
   addRunCmdConsent({ name: '@headlamp-k8s/ai-assistant' });
@@ -2017,62 +2049,12 @@ async function startElectron() {
       }
     );
 
-    // Also add bundled plugin bin directories to PATH
-    const bundledPlugins = path.join(process.resourcesPath, '.plugins');
-    const bundledPluginBinDirs = getPluginBinDirectories(bundledPlugins);
-    if (bundledPluginBinDirs.length > 0) {
-      addToPath(bundledPluginBinDirs, 'bundled plugin');
-    }
-
-    // Add the installed plugins as well
-    const userPluginBinDirs = getPluginBinDirectories(defaultUserPluginsDir());
-    if (userPluginBinDirs.length > 0) {
-      addToPath(userPluginBinDirs, 'userPluginBinDirs plugin');
-    }
-
     if (ENABLE_MCP) {
       const configPath = path.join(app.getPath('userData'), 'mcp-tools-config.json');
       const settingsPath = path.join(app.getPath('userData'), 'mcp-tools-settings.json');
       mcpClient = new MCPClient(configPath, settingsPath);
       await mcpClient.initialize();
       mcpClient.setMainWindow(mainWindow);
-    }
-
-    // Add bundled Azure CLI and external tools to PATH
-    // In dev mode: look in headlamp/app/resources/external-tools (relative to main.ts location)
-    // In production: look in process.resourcesPath/external-tools
-    const platformDir = process.platform;
-    const resourcesDir = isDev
-      ? path.join(__dirname, '..', 'resources') // From electron/ dir, go up to app/, then to resources/
-      : process.resourcesPath;
-    const azCliBinPath = path.join(resourcesDir, 'external-tools', 'az-cli', platformDir, 'bin');
-    const externalToolsBinPath = path.join(resourcesDir, 'external-tools', 'bin');
-
-    console.log(`[AKS-Desktop] __dirname: ${__dirname}`);
-    console.log(`[AKS-Desktop] resourcesDir: ${resourcesDir}`);
-    console.log(`[AKS-Desktop] Looking for Azure CLI at: ${azCliBinPath}`);
-    console.log(`[AKS-Desktop] Looking for external tools at: ${externalToolsBinPath}`);
-
-    // Add external tools bin directory (contains az-kubelogin.py)
-    if (fs.existsSync(externalToolsBinPath)) {
-      console.log(`[AKS-Desktop] Found external tools, adding to PATH: ${externalToolsBinPath}`);
-      addToPath([externalToolsBinPath], 'External Tools');
-    } else {
-      console.warn(`[AKS-Desktop] External tools not found at: ${externalToolsBinPath}`);
-    }
-
-    // Add Azure CLI bin directory
-    if (fs.existsSync(azCliBinPath)) {
-      console.log(`[AKS-Desktop] Found bundled Azure CLI, adding to PATH: ${azCliBinPath}`);
-      addToPath([azCliBinPath], 'Azure CLI');
-    } else {
-      console.warn(`[AKS-Desktop] Bundled Azure CLI not found at: ${azCliBinPath}`);
-      console.warn(`[AKS-Desktop] Platform: ${process.platform}, isDev: ${isDev}`);
-      if (isDev) {
-        console.warn(
-          `[AKS-Desktop] Tip: Run build process to download Azure CLI to headlamp/app/resources/external-tools/`
-        );
-      }
     }
   }
 

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1112,6 +1112,51 @@ export function getPluginBinDirectories(pluginsDir: string): string[] {
 }
 
 /**
+ * Removes empty and duplicate PATH entries while preserving order.
+ *
+ * addToPath can run more than once per session (bundled plugins, user plugins),
+ * so without this the same bin directories accumulate on every call. Windows
+ * paths are compared case-insensitively because the filesystem is too.
+ *
+ * @param entries - The candidate PATH entries, most significant first.
+ * @returns The deduplicated entries.
+ */
+function dedupePathEntries(entries: string[]): string[] {
+  const seen = new Set<string>();
+
+  return entries.filter(entry => {
+    if (!entry) return false;
+    const key = process.platform === 'win32' ? entry.toLowerCase() : entry;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Reads the current PATH and rewrites it under a single key.
+ *
+ * Windows environment variables are case-insensitive, but `process.env` is a
+ * plain object, so `Path` and `PATH` can coexist and spawned processes may read
+ * whichever one they find first. Deleting every casing before assigning keeps a
+ * single authoritative `PATH`.
+ *
+ * @param buildPath - Receives the existing PATH and returns the new one.
+ */
+function setProcessPath(buildPath: (existingPath: string) => string): void {
+  if (process.platform !== 'win32') {
+    process.env.PATH = buildPath(process.env.PATH || '');
+    return;
+  }
+
+  const existingPath = process.env.PATH || process.env.Path || '';
+  for (const key of Object.keys(process.env)) {
+    if (key.toLowerCase() === 'path') delete process.env[key];
+  }
+  process.env.PATH = buildPath(existingPath);
+}
+
+/**
  * Adds directories to the PATH environment variable
  *
  * @param dirs - Directories to add to PATH
@@ -1121,8 +1166,9 @@ export function addToPath(dirs: string[], description: string): void {
   if (dirs.length === 0) return;
 
   const pathSeparator = process.platform === 'win32' ? ';' : ':';
-  const existingPath = process.env.PATH || '';
-  process.env.PATH = [...dirs, existingPath].join(pathSeparator);
+  setProcessPath(existingPath =>
+    dedupePathEntries([...dirs, ...existingPath.split(pathSeparator)]).join(pathSeparator)
+  );
   const message = `Added ${dirs.length} ${description} bin directories to PATH`;
   console.info(message);
 }

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -22,6 +22,7 @@ import {
   addRunCmdConsent,
   checkPermissionSecret,
   handleRunCommand,
+  mergeCommandEnvironment,
   removeRunCmdConsent,
   setupRunCmdHandlers,
   validateCommandData,
@@ -165,6 +166,31 @@ describe('checkPermissionSecret', () => {
       permissionSecrets: { 'runCmd-scriptjs-plugins/minikube/myscript.js': 42 },
     };
     expect(checkPermissionSecret(commandData, permissionSecrets)[0]).toBe(true);
+  });
+});
+
+describe('mergeCommandEnvironment', () => {
+  it('uses the current process PATH instead of a stale cached Windows Path', async () => {
+    await withPlatform('win32', () => {
+      const originalPath = process.env.PATH;
+      process.env.PATH = 'C:\\app\\resources\\external-tools\\az-cli\\win32\\bin;C:\\Windows';
+      try {
+        const env = mergeCommandEnvironment({ Path: 'C:\\Windows', PATH: 'C:\\stale' });
+        expect(env.PATH).toBe(process.env.PATH);
+        expect('Path' in env).toBe(false);
+      } finally {
+        if (originalPath === undefined) delete process.env.PATH;
+        else process.env.PATH = originalPath;
+      }
+    });
+  });
+
+  it('honors an explicit PATH override for one command', async () => {
+    await withPlatform('win32', () => {
+      const env = mergeCommandEnvironment({ Path: 'C:\\cached' }, { Path: 'C:\\command-specific' });
+      expect(env.PATH).toBe('C:\\command-specific');
+      expect('Path' in env).toBe(false);
+    });
   });
 });
 
@@ -343,6 +369,36 @@ describe('handleRunCommand - child process error event', () => {
 
     expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn error']);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+  });
+});
+
+describe('handleRunCommand - command environment', () => {
+  it('passes per-command env overrides through to the spawned process', async () => {
+    const childEmitter = new EventEmitter() as any;
+    childEmitter.stdout = new EventEmitter();
+    childEmitter.stderr = new EventEmitter();
+
+    const { spawn } = await import('child_process');
+    (spawn as Mock).mockReset();
+    (spawn as Mock).mockReturnValue(childEmitter);
+
+    const fakeEvent = { sender: { send: vi.fn() } } as any;
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'env-id',
+        command: 'minikube',
+        args: ['start'],
+        options: { env: { HEADLAMP_TEST_VAR: 'from-command' } },
+        permissionSecrets: { 'runCmd-minikube': 99 },
+      },
+      { id: 1 } as any,
+      { 'runCmd-minikube': 99 }
+    );
+
+    const spawnEnv = (spawn as Mock).mock.calls[0][2].env;
+    expect(spawnEnv.HEADLAMP_TEST_VAR).toBe('from-command');
   });
 });
 

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -298,10 +298,7 @@ export async function executeCommandWithShellEnv(
       const child = spawn(command, args, {
         ...options,
         shell: useShell,
-        env: {
-          ...shellEnv,
-          ...options.env,
-        },
+        env: mergeCommandEnvironment(shellEnv, options.env),
       });
 
       let stdout = '';
@@ -326,6 +323,48 @@ export async function executeCommandWithShellEnv(
       reject(error);
     }
   });
+}
+
+/**
+ * Merges a cached shell environment with per-command overrides.
+ *
+ * The shell environment is captured once and cached, so it can predate the
+ * bundled tool directories that are appended to `process.env.PATH` at startup.
+ * PATH is therefore always taken from the live process unless the command asks
+ * for its own.
+ *
+ * @param shellEnv - The cached shell environment.
+ * @param overrides - Environment variables specific to this command.
+ * @returns The environment to spawn the command with.
+ */
+export function mergeCommandEnvironment(
+  shellEnv: NodeJS.ProcessEnv,
+  overrides: NodeJS.ProcessEnv = {}
+): NodeJS.ProcessEnv {
+  const merged = { ...shellEnv, ...overrides };
+
+  if (process.platform === 'win32') {
+    // Windows environment variables are case-insensitive but JavaScript object
+    // keys are not, so the merged object can carry both `Path` and `PATH` and
+    // the child process may pick up the stale one. Collapse every casing into a
+    // single `PATH` entry.
+    const windowsPath =
+      overrides.PATH ??
+      overrides.Path ??
+      process.env.PATH ??
+      process.env.Path ??
+      shellEnv.PATH ??
+      shellEnv.Path;
+    for (const key of Object.keys(merged)) {
+      if (key.toLowerCase() === 'path') delete merged[key];
+    }
+    if (windowsPath !== undefined) merged.PATH = windowsPath;
+    return merged;
+  }
+
+  const commandPath = overrides.PATH ?? process.env.PATH ?? shellEnv.PATH;
+  if (commandPath !== undefined) merged.PATH = commandPath;
+  return merged;
 }
 
 /**
@@ -400,13 +439,14 @@ export async function handleRunCommand(
     console.log('Using shell on Windows');
   }
 
+  const commandEnv = (commandData.options as { env?: NodeJS.ProcessEnv }).env;
   const child: ChildProcessWithoutNullStreams = spawn(command, args, {
     ...commandData.options,
     shell: useShell,
-    env: {
-      ...shellEnv,
+    env: mergeCommandEnvironment(shellEnv, {
+      ...commandEnv,
       ...(commandData.command === 'scriptjs' ? { HEADLAMP_RUN_SCRIPT: 'true' } : {}),
-    },
+    }),
   });
   const untrackProxy = trackProxyChild(command, args, commandData.options, child);
 

--- a/app/package.json
+++ b/app/package.json
@@ -73,7 +73,6 @@
           "target": "AppImage",
           "arch": [
             "x64",
-            "armv7l",
             "arm64"
           ]
         },
@@ -81,7 +80,6 @@
           "target": "tar.gz",
           "arch": [
             "x64",
-            "armv7l",
             "arm64"
           ]
         },
@@ -107,14 +105,7 @@
     "mac": {
       "appId": "com.microsoft.aks-desktop",
       "provisioningProfile": "mac/aks-desktop.provisionprofile",
-      "target": [
-        {
-          "target": "dmg",
-          "arch": [
-            "arm64"
-          ]
-        }
-      ],
+      "target": "dmg",
       "gatekeeperAssess": false,
       "hardenedRuntime": true,
       "notarize": false,


### PR DESCRIPTION
## Summary

Fix bundled Azure CLI selection after restart, especially on Windows.

- install bundled-tool directories before backend, renderer, or MCP environment caching
- merge current bundled paths into command environments while preserving explicit per-command PATH overrides
- normalize Windows Path/PATH aliases and deduplicate entries case-insensitively
- add regression coverage for stale and overridden command environments
- keep macOS helper tools on the established notarization-compatible AMD64 policy; external-tools remains excluded from app signing

## Validation

- Electron TypeScript check passed
- electron/runCmd.test.ts: 41 passed

Parent packaging changes are in #915.

### aks-mcp hardening

The built-in server now resolves directly to `resources/external-tools/bin/aks-mcp.exe` on Windows (and `aks-mcp` elsewhere), while preserving custom commands. This removes PATH/PATHEXT dependency during fresh-install startup. Added Windows-specific executable resolution tests.