### PR TITLE
aksd: Fix graph query formatting on windows

### DIFF
--- a/plugins/aks-desktop/src/utils/azure/az-resource-graph.ts
+++ b/plugins/aks-desktop/src/utils/azure/az-resource-graph.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
+import { quoteForPlatform } from '../shared/quoteForPlatform';
 import { debugLog, isAzError, isValidGuid, needsRelogin, runCommandAsync } from './az-cli-core';
 
 /**
@@ -55,7 +56,7 @@ export async function getClusterResourceGroupViaGraph(
       'graph',
       'query',
       '-q',
-      query,
+      quoteForPlatform(query),
       '--output',
       'json',
       '--subscription',
@@ -128,7 +129,16 @@ async function fetchGraphPage(
   skipToken?: string
 ): Promise<{ clusters: any[]; skipToken?: string }> {
   const pageSize = '1000';
-  const args = ['graph', 'query', '-q', query, '--first', pageSize, '--output', 'json'];
+  const args = [
+    'graph',
+    'query',
+    '-q',
+    quoteForPlatform(query),
+    '--first',
+    pageSize,
+    '--output',
+    'json',
+  ];
   // Append skip token for pagination if provided
   if (skipToken) {
     args.push('--skip-token', skipToken);
@@ -240,7 +250,7 @@ export async function getClusterCount(subscriptionId: string): Promise<number> {
       'graph',
       'query',
       '-q',
-      query,
+      quoteForPlatform(query),
       '--output',
       'json',
     ]);

--- a/plugins/aks-desktop/src/utils/shared/quoteForPlatform.ts
+++ b/plugins/aks-desktop/src/utils/shared/quoteForPlatform.ts
@@ -9,5 +9,5 @@
  */
 export function quoteForPlatform(value: string): string {
   const isWindows = (window as any)?.desktopApi?.platform === 'win32';
-  return isWindows ? `"${value}"` : value;
+  return isWindows ? `"${value.replace(/\n/g, '')}"` : value;
 }


### PR DESCRIPTION
Graph queries for clusters were failing with fallback to `az aks list` due to formatting issues in the query argument

This PR uses the `quoteForPlatform` function and updates it to remove newlines

Code path for other platforms is not affected

Fixes #910 

## How to test

1. Go to "Register AKS Cluster"
2. Select subscription and make sure cluster list is loading
3. Check console for lack of fallback errors/warnings

## Testing done

1. Manual testing of "Register AKS Cluster" on windows