### PR TITLE
Fix Windows signing build: route pip through the package feed proxy

### DIFF
--- a/.github/workflows/1es-pipeline.yml
+++ b/.github/workflows/1es-pipeline.yml
@@ -45,6 +45,15 @@ extends:
             variables:
               NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
               NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
+              # pypi.org is blocked outbound on this pool the same way npmjs is
+              # (pip fails with WinError 10013), so route pip through the same
+              # Microsoft package feed proxy. Bundling the connectedk8s az CLI
+              # extension needs it: the extension wheel itself comes from an
+              # Azure blob host that is reachable, but its dependencies
+              # (kubernetes, pycryptodome, oras, ...) are fetched from PyPI by
+              # the pip that `az extension add` shells out to, which inherits
+              # this variable.
+              PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
             # If the pipeline publishes artifacts, use `templateContext` to define the artifacts.
             # This will enable 1ES PT to run SDL analysis tools on the artifacts and then upload them.
             templateContext:

--- a/build/download-az-cli.ts
+++ b/build/download-az-cli.ts
@@ -303,7 +303,9 @@ function logPipDiagnostics(pythonExe: string): void {
       const output = execSync(cmd, { encoding: 'utf-8' }).trim();
       console.log(`${label}: ${redactCredentials(output)}`);
     } catch (error) {
-      console.warn(`⚠️  Could not determine ${label}: ${error}`);
+      // A failed probe's message carries the output the command managed to
+      // produce, so it needs the same redaction as the success path.
+      console.warn(`⚠️  Could not determine ${label}: ${redactCredentials(String(error))}`);
     }
   }
   console.log('------------------------');
@@ -320,24 +322,30 @@ function logPipDiagnostics(pythonExe: string): void {
  * outcome is ignored and the original error is always what gets thrown.
  */
 function addAzCliExtension(pythonExe: string, extension: string, extensionDir: string): void {
+  // These commands go through a shell, so reject anything that isn't a plain
+  // extension name rather than interpolating it. The names come from
+  // package.json, not from user input, but a typo there should fail here with
+  // an obvious message instead of turning into shell syntax.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(extension)) {
+    throw new Error(`Refusing to install Azure CLI extension with unexpected name: "${extension}"`);
+  }
+
   const env = { ...process.env, AZURE_EXTENSION_DIR: extensionDir };
+  const addCommand = `"${pythonExe}" -m azure.cli extension add -n "${extension}"`;
   try {
-    execSync(`"${pythonExe}" -m azure.cli extension add -n ${extension}`, {
+    execSync(addCommand, {
       stdio: 'inherit',
       env,
     });
   } catch (error) {
     console.error(`  ❌ ERROR: Failed to install extension ${extension}`);
-    console.error(`     Error: ${error}`);
+    console.error(`     Error: ${redactCredentials(String(error))}`);
 
     console.error(`     Re-running with --debug to capture pip's underlying error...`);
     try {
       // Merge stderr into stdout so the captured text has everything pip
       // printed, regardless of which stream it used.
-      const debugOutput = execSync(
-        `"${pythonExe}" -m azure.cli extension add -n ${extension} --debug 2>&1`,
-        { env, encoding: 'utf-8' }
-      );
+      const debugOutput = execSync(`${addCommand} --debug 2>&1`, { env, encoding: 'utf-8' });
       console.error(`     ----- --debug output (retry succeeded) -----`);
       console.error(redactCredentials(debugOutput));
       console.error(`     ---------------------------------------------`);

--- a/build/download-az-cli.ts
+++ b/build/download-az-cli.ts
@@ -274,6 +274,87 @@ function extractZip(archivePath: string, outputDir: string): void {
 }
 
 /**
+ * Strip credentials out of text before it reaches the build log. A pip index
+ * URL carrying a PAT (`https://user:token@pkgs.dev.azure.com/...`) is routine
+ * for an internal feed, and CI only masks secrets it was told about - so the
+ * diagnostics below, which exist to reveal exactly that kind of index
+ * configuration, must not print the token along with it.
+ */
+function redactCredentials(text: string): string {
+  return text.replace(/\/\/[^/\s:@]+:[^/\s@]+@/g, '//***:***@');
+}
+
+/**
+ * Log the interpreter and pip identity used for extension installs, so an
+ * environment difference (a pip.ini pointing at an internal index, blocked
+ * PyPI egress, etc.) is visible in the build log even when every extension
+ * install succeeds. Best-effort only - none of these probes are required for
+ * the actual install to work, so a probe failing here must not fail the build.
+ */
+function logPipDiagnostics(pythonExe: string): void {
+  console.log('--- pip diagnostics ---');
+  const probes: Array<[string, string]> = [
+    ['interpreter', `"${pythonExe}" -V`],
+    ['pip version', `"${pythonExe}" -m pip -V`],
+    ['pip config', `"${pythonExe}" -m pip config debug`],
+  ];
+  for (const [label, cmd] of probes) {
+    try {
+      const output = execSync(cmd, { encoding: 'utf-8' }).trim();
+      console.log(`${label}: ${redactCredentials(output)}`);
+    } catch (error) {
+      console.warn(`⚠️  Could not determine ${label}: ${error}`);
+    }
+  }
+  console.log('------------------------');
+}
+
+/**
+ * Install a single Azure CLI extension, capturing pip's real error on failure.
+ * `az extension add` swallows pip's own stdout/stderr unless --debug is passed,
+ * so a pip failure shows up as an opaque "Pip failed with status code 1" with
+ * no indication of why (wrong index, blocked egress, a corporate pip.ini,
+ * etc). On failure we re-run once with --debug purely to capture and print
+ * that context - the diagnostic re-run is never authoritative (pip's own
+ * state, e.g. its cache, can behave differently the second time), so its
+ * outcome is ignored and the original error is always what gets thrown.
+ */
+function addAzCliExtension(pythonExe: string, extension: string, extensionDir: string): void {
+  const env = { ...process.env, AZURE_EXTENSION_DIR: extensionDir };
+  try {
+    execSync(`"${pythonExe}" -m azure.cli extension add -n ${extension}`, {
+      stdio: 'inherit',
+      env,
+    });
+  } catch (error) {
+    console.error(`  ❌ ERROR: Failed to install extension ${extension}`);
+    console.error(`     Error: ${error}`);
+
+    console.error(`     Re-running with --debug to capture pip's underlying error...`);
+    try {
+      // Merge stderr into stdout so the captured text has everything pip
+      // printed, regardless of which stream it used.
+      const debugOutput = execSync(
+        `"${pythonExe}" -m azure.cli extension add -n ${extension} --debug 2>&1`,
+        { env, encoding: 'utf-8' }
+      );
+      console.error(`     ----- --debug output (retry succeeded) -----`);
+      console.error(redactCredentials(debugOutput));
+      console.error(`     ---------------------------------------------`);
+    } catch (debugError) {
+      // execSync throws with the merged output on .stdout when the command
+      // exits non-zero; fall back to the error itself if that's not present.
+      const output = (debugError as { stdout?: string })?.stdout ?? String(debugError);
+      console.error(`     ----- --debug output -----`);
+      console.error(redactCredentials(output));
+      console.error(`     ---------------------------`);
+    }
+
+    throw error;
+  }
+}
+
+/**
  * Install Azure CLI with Python (bundled for Linux and macOS)
  */
 async function installAzCliWithPython(platform: string): Promise<string[]> {
@@ -337,22 +418,11 @@ async function installAzCliWithPython(platform: string): Promise<string[]> {
   // no marker is written and the incomplete bundle can't pass as staged.
   const installedExtensions: string[] = [];
   if (AZ_CLI_EXTENSIONS && AZ_CLI_EXTENSIONS.length > 0) {
+    logPipDiagnostics(venvPython);
     console.log(`Installing Azure CLI extensions: ${AZ_CLI_EXTENSIONS.join(', ')}`);
     for (const extension of AZ_CLI_EXTENSIONS) {
       console.log(`  → Installing extension: ${extension}`);
-      try {
-        execSync(`"${venvPython}" -m azure.cli extension add -n ${extension}`, {
-          stdio: 'inherit',
-          env: {
-            ...process.env,
-            AZURE_EXTENSION_DIR: path.join(venvDir, 'extensions')
-          }
-        });
-      } catch (error) {
-        console.error(`  ❌ ERROR: Failed to install extension ${extension}`);
-        console.error(`     Error: ${error}`);
-        throw error;
-      }
+      addAzCliExtension(venvPython, extension, path.join(venvDir, 'extensions'));
       installedExtensions.push(extension);
     }
     console.log('✅ Extensions installation complete');
@@ -531,22 +601,11 @@ async function installAzCliWindows(): Promise<string[]> {
   const installedExtensions: string[] = [];
   if (AZ_CLI_EXTENSIONS && AZ_CLI_EXTENSIONS.length > 0) {
     const winPython = path.join(TARGET_DIR, 'python.exe');
+    logPipDiagnostics(winPython);
     console.log(`Installing Azure CLI extensions: ${AZ_CLI_EXTENSIONS.join(', ')}`);
     for (const extension of AZ_CLI_EXTENSIONS) {
       console.log(`  → Installing extension: ${extension}`);
-      try {
-        execSync(`"${winPython}" -m azure.cli extension add -n ${extension}`, {
-          stdio: 'inherit',
-          env: {
-            ...process.env,
-            AZURE_EXTENSION_DIR: extensionDir,
-          },
-        });
-      } catch (error) {
-        console.error(`  ❌ ERROR: Failed to install extension ${extension}`);
-        console.error(`     Error: ${error}`);
-        throw error;
-      }
+      addAzCliExtension(winPython, extension, extensionDir);
       installedExtensions.push(extension);
     }
     console.log('✅ Extensions installation complete');


### PR DESCRIPTION
The Windows signing pipeline has been red since #860 merged, failing while bundling the `connectedk8s` extension ([build 245357](https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build/results?buildId=245357)). All we got was:

```
ERROR: An error occurred. Pip failed with status code 1. Use --debug for more information.
```

`az extension add` hides pip's output unless you pass `--debug`, so the first commit here does that on failure. Next run told us straight away:

```
HTTPSConnection(host='pypi.org', port=443): Failed to establish a new connection:
[WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions
ERROR: No matching distribution found for kubernetes==24.2.0
```

**pypi.org is blocked outbound on the Windows 1ES pool.** Anything Azure-hosted is fine in the same run — the extension index and the wheel itself both download fine from blob storage. Only the dependency fetch dies, which is why the other two extensions were happy: `resource-graph`'s dependency already ships inside the CLI and `alertsmanagement` has none, while `connectedk8s` wants `kubernetes`, `pycryptodome`, `oras` and `azure-mgmt-hybridcompute` from PyPI.

Nothing wrong with the code, then — #860 is just the first change that installs extensions on Windows at build time, so it's the first to hit this.

## The fix

npmjs is blocked the same way, and the job already works around it with `NPM_CONFIG_REGISTRY` pointed at the Microsoft package feed proxy. That proxy mirrors PyPI too, so: one variable, `PIP_INDEX_URL`. pip inherits it from the `az` process, so no code change needed.

Checked before spending a build on it — `pip download` of the whole connectedk8s tree through that mirror pulls all 34 wheels anonymously for `win_amd64`/cp314, `kubernetes==24.2.0` included.

## Does it work

[Build 245403](https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build/results?buildId=245403):

```
PIP_INDEX_URL='https://packagefeedproxy.microsoft.io/pypi/simple/'
  → Installing extension: connectedk8s
✅ Extensions installation complete
```

36s, where it used to die in 9. Then post-build verification confirmed all three extensions bundled and the 2.89.0 pin matched, the NSIS installer built, ESRP signed it, and the artifact published.

It reports `partiallySucceeded`, but that's only the auto-injected Secure Supply Chain task grumbling about pre-existing stuff (missing `.npmrc` siblings, `ghcr.io`/`nginx` image refs). Every previously-green Windows build ended the same way — 244548, 243866, 240776 — so this matches the known-good baseline.

Locally: `npm run test:build` 46/46, `tsc --noEmit` clean, YAML parses to the three expected job variables. Worth knowing `build/` has no lint or Prettier gate in CI and `download-az-cli.ts` has no test harness, so the new helpers aren't unit-tested — they're thin `execSync` wrappers and mocking them would be heavier than anything else in `build/`.

## Commits

1. `aksd: surface pip errors from az extension add` — the `--debug` retry, plus logging the interpreter, pip version and effective pip config up front. Used by both the Windows and linux/darwin install paths. The retry's result is thrown away and the original error always rethrown, so nothing about abort behaviour changes. Output has credentials stripped, since an index URL with a PAT in it is exactly the sort of thing these probes would surface.
2. `aksd: route pip through the package feed proxy on Windows` — the `PIP_INDEX_URL` variable.
3. `aksd: harden the az extension install diagnostics` — review follow-ups: validate and quote the extension name, and redact the stringified errors too.

## Notes

Both of the first two commits are already fast-forwarded onto `rc-0.10.0` to unblock the release; this PR is the same change for `main`.

The diagnostics also showed that extension versions aren't pinned — `az` picked `connectedk8s 1.11.3` here while the public index served `1.11.1` earlier the same day, unlike the CLI, Python and aks-mcp which are pinned with checksums. Filed separately as #942.
