### PR TITLE
insights-plugin: bump to v0.3.1

### DIFF
--- a/plugins/insights-plugin/package-lock.json
+++ b/plugins/insights-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insights-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insights-plugin",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.13.1"
       }

--- a/plugins/insights-plugin/package.json
+++ b/plugins/insights-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insights-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Insights plugin for eBPF-based Observability (based on Inspektor Gadget) (Preview)",
   "scripts": {
     "build": "bash scripts/download-artifacts.sh",


### PR DESCRIPTION
This removes the sidebar entry for generic IG usage as it was not yet polished.
This functionality will be re-introduced at a later time.

Fixes #927