### PR TITLE
Log viewer parity with headlamp (download + ALL lines)

### DIFF
--- a/frontend/src/components/common/LogsViewer/LogsViewer.tsx
+++ b/frontend/src/components/common/LogsViewer/LogsViewer.tsx
@@ -18,7 +18,7 @@
 
 import { Box, Checkbox, FormControlLabel, MenuItem, TextField } from '@mui/material';
 import { useMemo, useState } from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDeploymentLogs, usePodLogs } from '../../../lib/k8s/api/v2/fetchLogs';
 import { KubeContainer } from '../../../lib/k8s/cluster';
 import type DaemonSet from '../../../lib/k8s/daemonSet';
@@ -29,6 +29,7 @@ import type ReplicaSet from '../../../lib/k8s/replicaSet';
 import type StatefulSet from '../../../lib/k8s/statefulSet';
 import { ClusterGroupErrorMessage } from '../../cluster/ClusterGroupErrorMessage';
 import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
+import ActionButton from '../ActionButton';
 import { LogDisplay } from './LogDisplay';
 import { useParsedLogs } from './ParsedLog';
 import { SeveritySelector } from './SeveritySelector';
@@ -43,6 +44,7 @@ export function LogsViewer({
   initialContainer?: string;
   defaultSeverities?: string[];
 }) {
+  const { t } = useTranslation();
   const containers: KubeContainer[] =
     item.kind === 'Pod' ? item.spec.containers : item.spec.template.spec.containers;
   const [severityFilter, setSeverityFilter] = useState<Set<string> | undefined>(
@@ -71,6 +73,29 @@ export function LogsViewer({
   );
 
   const logs = filtered;
+
+  function downloadLogs() {
+    // Cuts off the last 5 digits of the timestamp to remove the milliseconds
+    const time = new Date().toISOString().replace(/:/g, '-').slice(0, -5);
+    const content = Array.isArray(rawLogs)
+      ? rawLogs.join('\n')
+      : // Multi-pod (Logs tab): tag each line with its pod and sort by timestamp to match the view.
+        Object.entries(rawLogs)
+          .flatMap(([pod, podLogs]) => podLogs.map(log => ({ pod, log })))
+          .sort((a, b) => a.log.localeCompare(b.log))
+          .map(({ pod, log }) => `[${pod}] ${log}`)
+          .join('\n');
+    const element = document.createElement('a');
+    const file = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(file);
+    element.href = url;
+    element.download = `${item.getName()}_${container}_${time}.txt`;
+    // Required for FireFox
+    document.body.appendChild(element);
+    element.click();
+    element.remove();
+    URL.revokeObjectURL(url);
+  }
 
   return (
     <>
@@ -115,6 +140,9 @@ export function LogsViewer({
               {l}
             </MenuItem>
           ))}
+          <MenuItem value={-1}>
+            <Trans>All</Trans>
+          </MenuItem>
         </TextField>
 
         <SeveritySelector
@@ -158,6 +186,14 @@ export function LogsViewer({
           }
           label={<Trans>Wrap lines</Trans>}
         />
+
+        <Box sx={{ ml: 'auto' }}>
+          <ActionButton
+            description={t('Download')}
+            onClick={downloadLogs}
+            icon="mdi:file-download-outline"
+          />
+        </Box>
       </Box>
       {logsError && <ClusterGroupErrorMessage errors={[logsError]} />}
       <LogDisplay

--- a/frontend/src/lib/k8s/api/v2/fetchLogs.tsx
+++ b/frontend/src/lib/k8s/api/v2/fetchLogs.tsx
@@ -46,12 +46,17 @@ function fetchLogs({
   onError: Dispatch<SetStateAction<ApiError | undefined>>;
 }) {
   let isCurrent = true;
-  const url = makeUrl(`/api/v1/namespaces/${namespace}/pods/${podName}/log`, {
+  const query: Record<string, string> = {
     container,
     follow: 'true',
     timestamps: 'true',
-    tailLines: String(lines),
-  });
+  };
+  // Negative tailLines parameter fetches all logs. If it's non negative, it fetches
+  // the tailLines number of logs.
+  if (lines !== -1) {
+    query.tailLines = String(lines);
+  }
+  const url = makeUrl(`/api/v1/namespaces/${namespace}/pods/${podName}/log`, query);
 
   let buffer: string[] = [];
   const intervalId = setInterval(() => {


### PR DESCRIPTION
## Description

This PR addresses https://github.com/Azure/aks-desktop/issues/914, and updates our `LogsViewer` to include the download button & also allow users to view all lines (previously capped at 2500). 

This PR re-uses logic from the base Headlamp's Logs tool, but we are keeping our logs tool distinct as initially intended, thus I've brought the missing pieces here so we can have closer parity & still be able to customize this for AKSD - related wants further down the line. (vs. completely duping HL's logs)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Related Issues

Closes https://github.com/Azure/aks-desktop/issues/914
- https://github.com/Azure/aks-desktop/issues/914

## Changes Made

- Added download button to `LogsViewer` toolbar.
- Added `All` option (value={-1}) to the lines dropdown.
- Updated v2 `fetchLogs` to omit tailines when `-1` so All can return the full log
- Mention any dependencies added/removed

## Testing

- [x] Manual testing completed

To test, attempt to download logs. The logic is highly similar to existing, proven HL logic.